### PR TITLE
feat(cli): accept per-agent permissions

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -645,6 +645,14 @@ CLIs name them rather than in a vocabulary of humanize's own:
 ClaudeCodeAgentConfig(model="claude-opus-5", effort="high", permission="read-only")
 ```
 
+The command line names the same setting in an agent's written-out form:
+
+```sh
+hmz exec -f ralph_loop \
+    -a cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only \
+    "review the current change"
+```
+
 `bypass` is the default, because that is what a flow driving an agent unattended has always
 run it at: a flow watches its agent rather than gating it, and a turn waiting on an approval
 nobody is there to give is a flow that has stopped. Anything tighter is a choice, and in the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,10 +83,12 @@ claude/claude-opus-4-8:high
 cli=claude,model=claude-opus-4-8,effort=high
 claude@deepseek/claude-opus-4-8:high
 cli=claude,model=claude-opus-4-8,effort=high,provider=deepseek
+cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only
 ```
 
-Both spellings mean the same thing. The written-out form exists because a model or an effort may
-hold the punctuation the short form separates on.
+The first two spellings mean the same thing. The written-out form exists because a model or an
+effort may hold the punctuation the short form separates on, and is also where settings with no
+unambiguous short spelling go.
 
 - `<cli>` is `claude`, `codex`, `kimi`, `pi`, `opencode` or `mimo`. Each also answers to the
   longer name it is installed under: `claude-code`, `kimi-code`, `mimocode` and `mimo-code`.
@@ -99,6 +101,9 @@ hold the punctuation the short form separates on.
   account, not the model: `claude@deepseek`. Written out, it is `provider=`. A CLI is never
   spelled with an `@` in it, so the two are told apart wherever an agent is written. An agent
   that names none runs its CLI as you already run it.
+- `permission=` names [what that agent may do](agents.md#what-an-agent-may-do): `read-only`,
+  `workspace-write`, `auto` or `bypass`. It is available in the written-out form only and
+  defaults to `bypass`. A misspelling is refused before any agent runs.
 
 **One `-a` is one agent.** A list inside a single `-a` is not split into several. Two agents of
 one spelling are two agents, which is what makes a flow of an actor and a reviewer at one
@@ -123,6 +128,7 @@ Whatever else a flow does as it is imported is the flow's own, and fails as it w
 hmz exec -f ralph_loop -a claude/claude-opus-4-8:high "$(cat TASK.md)"
 hmz exec -f flame_chase -a claude/claude-opus-4-8:max -a codex/gpt-5.6-sol:max "fix the build"
 hmz exec -f rlar -a claude/claude-opus-4-8:high -a claude/claude-opus-4-8:high "$(cat TASK.md)"
+hmz exec -f rlar -a claude/claude-opus-4-8:high -a cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only "$(cat TASK.md)"
 hmz exec -f flame_chase -a claude@anthropic/claude-opus-5:max -a claude@deepseek/deepseek-chat:high "fix the build"
 hmz exec -f ./flows/mine.py -a kimi/kimi-code/k3:swarmmax "port this to asyncio"
 hmz exec -f ralph_loop -a pi/openai-codex/gpt-5.5:high "$(cat TASK.md)"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,6 +138,15 @@ hmz exec -f ralph_loop -a claude/claude-opus-4-8:high "fix the failing tests"
   in the order the flow takes them — `rlar` drives two, so it takes two `-a`.
 - The last argument is the task.
 
+To narrow what one of those agents may do, use the written-out form and name one of the four
+[permission rungs](agents.md#what-an-agent-may-do):
+
+```sh
+hmz exec -f ralph_loop \
+    -a cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only \
+    "review this repository"
+```
+
 Nobody is at a prompt here, so an agent that stops to ask a question is told nobody answered
 and carries on rather than waiting forever.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,7 +63,7 @@ if TYPE_CHECKING:                     # ← this is the problem
 Import it at runtime instead. The count has to be readable where the flow runs, not only where
 pyright looks.
 
-### `bad agent 'claude:high': expected CLI/MODEL:EFFORT or cli=CLI,model=MODEL,effort=EFFORT`
+### `bad agent 'claude:high': expected CLI[@PROVIDER]/MODEL:EFFORT or cli=CLI,…`
 
 An `-a` that is missing a part. All three are required:
 
@@ -75,10 +75,19 @@ An `-a` that is missing a part. All three are required:
 The CLI is read from the front and the effort from after the **last** colon, so a model with
 slashes in it — `kimi/kimi-code/k3:high` — is fine.
 
-### `bad agent '…': foo is not cli, model or effort`
+### `bad agent '…': foo is not cli, model, effort, provider or permission`
 
-A key in the written-out form that is none of the three. Only `cli`, `model` and `effort` are
-taken.
+A key in the written-out form that is not one of the five it takes: `cli`, `model`, `effort`,
+`provider` and `permission`.
+
+### `permission must be one of read-only, workspace-write, auto, bypass`
+
+The `permission=` value is misspelled or empty. It is matched exactly and is refused rather than
+silently replaced with the default:
+
+```sh
+-a cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only
+```
 
 ### The agent starts and immediately fails
 

--- a/src/humanize/backends.py
+++ b/src/humanize/backends.py
@@ -664,7 +664,7 @@ def named(backend: str) -> Profile | None:
     return next((one for one in PROFILES if backend in one.aliases), None)
 
 
-def read(spec: str) -> tuple[Profile, str, str, str]:
+def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
     """Reads one `-a` into the backend to drive, what to drive it at, and as whom.
 
     Args:
@@ -672,30 +672,34 @@ def read(spec: str) -> tuple[Profile, str, str, str]:
         where a model or an effort holding the punctuation the short form separates on goes.
         The CLI may name a provider after an `@`, as `claude@deepseek/MODEL:EFFORT`, which is
         the account that agent's turns run as; `provider=` says the same thing written out.
+        The written-out form may also name the agent's permission rung as `permission=`.
 
     Returns:
-      The backend, the model, the effort, and the provider -- which is "" for an agent that
-      runs as whoever is at this machine already runs its CLI, and is most of them.
+      The backend, the model, the effort, the provider -- which is "" for an agent that runs
+      as whoever is at this machine already runs its CLI -- and the permission, which is None
+      for an agent that runs at the default rung.
 
     Raises:
       ValueError: If it is neither spelling, or names no backend there is. What it says is
         what a command line reports after the agent it could not read.
     """
     provider = ""
+    permission: str | None = None
     if "=" in spec:
         given = {
             key.strip(): value.strip()
             for key, _, value in (part.partition("=") for part in spec.split(","))
         }
-        backend, model, effort, provider = (
+        backend, model, effort, provider, permission = (
             given.pop("cli", ""),
             given.pop("model", ""),
             given.pop("effort", ""),
             given.pop("provider", ""),
+            given.pop("permission", None),
         )
         if given:
             raise ValueError(
-                f"{', '.join(sorted(given))} is not cli, model, effort or provider"
+                f"{', '.join(sorted(given))} is not cli, model, effort, provider or permission"
             )
     else:
         # Read from both ends: a model may hold slashes of its own -- Kimi's are
@@ -717,5 +721,6 @@ def read(spec: str) -> tuple[Profile, str, str, str]:
         raise ValueError(
             "expected CLI[@PROVIDER]/MODEL:EFFORT or "
             "cli=CLI,model=MODEL,effort=EFFORT[,provider=PROVIDER]"
+            "[,permission=PERMISSION]"
         )
-    return profile, model.strip(), effort.strip(), provider.strip()
+    return profile, model.strip(), effort.strip(), provider.strip(), permission

--- a/src/humanize/cli/__init__.py
+++ b/src/humanize/cli/__init__.py
@@ -142,7 +142,7 @@ def _line() -> ArgumentParser:
         dest="agents",
         metavar="CLI/MODEL:EFFORT",
         help="what one of that flow's agents runs, repeated once for each it drives, in the "
-        "order it takes them; needs -f",
+        "order it takes them; the written-out form may include permission=PERMISSION; needs -f",
     )
     parser.add_argument(
         "-c",
@@ -169,7 +169,7 @@ def _tui(argv: list[str]) -> int:
       Zero, once the interface has been closed, or two for a line to correct.
     """
     from humanize.flows import find
-    from humanize.runner import configures, set_up_from, wanted
+    from humanize.runner import configures, read_agent, set_up_from, wanted
     from humanize.tui import Humanize
     from humanize.tui.pick import Runs
 
@@ -181,6 +181,11 @@ def _tui(argv: list[str]) -> int:
         parser.error("-a says what runs the flow, so it needs -f")
     if args.config is not None and not flow:
         parser.error("-c says how the flow runs, so it needs -f")
+    for spec in args.agents:
+        try:
+            read_agent(spec)
+        except ValueError as bad:
+            parser.error(f"bad agent {spec!r}: {bad}")
     setting = None
     if args.config is not None:
         try:

--- a/src/humanize/runner.py
+++ b/src/humanize/runner.py
@@ -507,6 +507,31 @@ class Runner:
                 _finished(running)
 
 
+def read_agent(
+    spec: str,
+) -> tuple[backends.Profile, str, str, str, str | None]:
+    """Reads and validates one command-line agent specification.
+
+    Args:
+      spec: The short or written-out form accepted by ``-a``.
+
+    Returns:
+      The backend, model, effort, provider and optional permission rung.
+
+    Raises:
+      ValueError: If the specification is malformed or names no permission rung there is.
+    """
+    from .agents import PERMISSIONS
+
+    parsed = backends.read(spec)
+    permission = parsed[-1]
+    if permission is not None and permission not in PERMISSIONS:
+        raise ValueError(
+            f"permission must be one of {', '.join(PERMISSIONS)}, not {permission!r}"
+        )
+    return parsed
+
+
 def flow_and_agents(
     argv: list[str],
 ) -> tuple[str, list[AgentBase], str, dict[str, Any] | None]:
@@ -551,7 +576,8 @@ def flow_and_agents(
         dest="agents",
         metavar="CLI/MODEL:EFFORT",
         help="one agent, repeated once for each the flow drives, in the order it takes "
-        "them; also written cli=CLI,model=MODEL,effort=EFFORT. CLI is one of "
+        "them; also written cli=CLI,model=MODEL,effort=EFFORT with optional "
+        "permission=PERMISSION. CLI is one of "
         f"{', '.join(sorted(one.name for one in backends.PROFILES))}",
     )
     parser.add_argument(
@@ -580,13 +606,23 @@ def flow_and_agents(
     agents: list[AgentBase] = []
     for spec in args.agents:
         try:
-            profile, model, effort, provider = backends.read(spec)
+            profile, model, effort, provider, permission = read_agent(spec)
         except ValueError as bad:
             parser.error(f"bad agent {spec!r}: {bad}")
         agent, config = DRIVEN[profile.name]
         # Named rather than looked up: an account that is not there is caught by the agent
         # the first time it needs one, which says whose it was and what it was called.
-        agents.append(agent(config(model=model, effort=effort, provider=provider)))
+        configured = (
+            config(model=model, effort=effort, provider=provider)
+            if permission is None
+            else config(
+                model=model,
+                effort=effort,
+                provider=provider,
+                permission=permission,
+            )
+        )
+        agents.append(agent(configured))
     return args.flow, agents, args.task, held
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -38,12 +38,15 @@ def test_a_home_shared_with_every_program_keeps_its_own_directory_under_it(
 
 
 def test_an_agent_is_read_off_a_command_line_however_it_is_spelled() -> None:
-    profile, model, effort, provider = backends.read("pi/openai-codex/gpt-5.5:high")
+    profile, model, effort, provider, permission = backends.read(
+        "pi/openai-codex/gpt-5.5:high"
+    )
     assert (profile.name, model, effort) == ("pi", "openai-codex/gpt-5.5", "high")
     assert provider == ""  # as whoever is at this machine already runs it
-    profile, model, effort, _ = backends.read("mimocode/xiaomi/mimo-v2.5:low")
+    assert permission is None  # at the default rung
+    profile, model, effort, _, _ = backends.read("mimocode/xiaomi/mimo-v2.5:low")
     assert (profile.name, model, effort) == ("mimo", "xiaomi/mimo-v2.5", "low")
-    profile, model, effort, _ = backends.read(
+    profile, model, effort, _, _ = backends.read(
         "cli=opencode,model=opencode/big-pickle,effort=xhigh"
     )
     assert (profile.name, model, effort) == ("opencode", "opencode/big-pickle", "xhigh")
@@ -51,7 +54,7 @@ def test_an_agent_is_read_off_a_command_line_however_it_is_spelled() -> None:
 
 def test_an_agent_may_name_the_account_it_runs_as() -> None:
     """Two agents of one CLI are two accounts when the line says so, either way it is written."""
-    profile, model, effort, provider = backends.read(
+    profile, model, effort, provider, _ = backends.read(
         "claude@deepseek/claude-opus-5:high"
     )
     assert (profile.name, model, effort, provider) == (
@@ -60,18 +63,35 @@ def test_an_agent_may_name_the_account_it_runs_as() -> None:
         "high",
         "deepseek",
     )
-    _, _, _, provider = backends.read(
+    _, _, _, provider, _ = backends.read(
         "cli=claude,model=claude-opus-5,effort=high,provider=work"
     )
     assert provider == "work"
     # A CLI is never spelled with an `@` in it, so the model keeps whatever it holds.
-    profile, model, _, provider = backends.read("kimi@mine/kimi-code/k3:max")
+    profile, model, _, provider, _ = backends.read("kimi@mine/kimi-code/k3:max")
     assert (profile.name, model, provider) == ("kimi", "kimi-code/k3", "mine")
+
+
+def test_an_agent_may_name_its_permission_rung() -> None:
+    """Only the written-out form has somewhere unambiguous to put the fourth setting."""
+    profile, model, effort, provider, permission = backends.read(
+        "cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only"
+    )
+
+    assert (profile.name, model, effort, provider, permission) == (
+        "codex",
+        "gpt-5.6-sol",
+        "high",
+        "",
+        "read-only",
+    )
 
 
 def test_a_backend_nobody_has_heard_of_is_a_line_to_correct() -> None:
     assert backends.named("nope") is None
     with pytest.raises(ValueError, match="expected CLI"):
         backends.read("nope/model:high")
-    with pytest.raises(ValueError, match="not cli, model, effort or provider"):
+    with pytest.raises(
+        ValueError, match="not cli, model, effort, provider or permission"
+    ):
         backends.read("cli=claude,model=m,effort=high,machine=elsewhere")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,23 @@ def test_a_line_of_flags_and_no_command_opens_the_interface_set_up() -> None:
     assert opened.called
 
 
+def test_a_bad_permission_does_not_open_the_interface(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    spec = "cli=codex,model=m,effort=high,permission=readonly"
+    with (
+        unittest.mock.patch("humanize.tui.Humanize.run") as opened,
+        pytest.raises(SystemExit) as stopped,
+    ):
+        cli.main(["-f", "chat", "-a", spec])
+
+    assert stopped.value.code == 2
+    assert not opened.called
+    error = capsys.readouterr().err
+    assert f"bad agent {spec!r}" in error
+    assert "permission must be one of read-only, workspace-write, auto, bypass" in error
+
+
 @pytest.mark.parametrize("argv", [["--help"], ["-h"]])
 def test_the_help_lists_every_command(
     argv: list[str], capsys: pytest.CaptureFixture[str]

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 
 import pytest
 
-from humanize.agents import AgentConfig, SessionBase
+from humanize.agents import PERMISSIONS, AgentConfig, SessionBase
 from humanize.cli import main
 from humanize.runner import NotAFlow, Runner
 from tests.stubs import ShellAgent
@@ -59,6 +59,20 @@ from humanize.agents import AgentBase
 def run(agents: tuple[AgentBase, AgentBase], task: str) -> None:
     Path(__file__).with_suffix(".json").write_text(
         json.dumps([agent.config.provider for agent in agents])
+    )
+"""
+
+#: A flow that writes down the permission rung each agent was configured to run at.
+ACCESS = """
+import json
+from pathlib import Path
+
+from humanize.agents import AgentBase
+
+
+def run(agents: tuple[AgentBase, AgentBase], task: str) -> None:
+    Path(__file__).with_suffix(".json").write_text(
+        json.dumps([agent.config.permission for agent in agents])
     )
 """
 
@@ -204,6 +218,28 @@ def test_an_agent_that_names_no_account_runs_as_this_machine_does(
     flow = _flow(tmp_path, ACCOUNTS)
     main(["exec", "-f", flow, "-a", "claude/m:high", "-a", "codex/m:high", "task"])
     assert json.loads((tmp_path / "flow.json").read_text()) == ["", ""]
+
+
+@pytest.mark.parametrize("permission", PERMISSIONS)
+def test_an_agent_may_be_given_a_permission_rung(
+    tmp_path: Path, permission: str
+) -> None:
+    """Each `-a` carries its own rung, and omitting it keeps the existing default."""
+    flow = _flow(tmp_path, ACCESS)
+    main(
+        [
+            "exec",
+            "-f",
+            flow,
+            "-a",
+            f"cli=codex,model=m,effort=high,permission={permission}",
+            "-a",
+            "claude/m:high",
+            "task",
+        ]
+    )
+
+    assert json.loads((tmp_path / "flow.json").read_text()) == [permission, "bypass"]
 
 
 def test_a_named_tuple_says_what_each_agent_is_for_as_well_as_how_many(
@@ -474,6 +510,25 @@ def test_an_agent_that_is_not_cli_model_and_effort_is_a_usage_error(
         main(["exec", "-f", flow, "-a", spec, "task"])
     assert stopped.value.code == 2
     assert f"bad agent {spec!r}" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("permission", ["readonly", "read_only", ""])
+def test_an_unknown_permission_is_a_usage_error_before_any_agent_runs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    permission: str,
+) -> None:
+    flow = _flow(tmp_path, RECORD.replace("AGENTS", "AgentBase"))
+    spec = f"cli=codex,model=m,effort=high,permission={permission}"
+
+    with pytest.raises(SystemExit) as stopped:
+        main(["exec", "-f", flow, "-a", spec, "task"])
+
+    assert stopped.value.code == 2
+    error = capsys.readouterr().err
+    assert f"bad agent {spec!r}" in error
+    assert "permission must be one of read-only, workspace-write, auto, bypass" in error
+    assert not (tmp_path / "flow.json").exists()
 
 
 def test_a_flow_fails_as_it_would_anywhere_when_it_is_the_flow_that_failed(


### PR DESCRIPTION
## Summary

- accept `permission=` in written-out `-a` agent specifications
- pass each selected permission rung into its agent config while preserving the existing `bypass` default
- reject empty or unknown permission values before opening the TUI or starting a flow
- document the command-line form and troubleshooting guidance

```sh
hmz exec -f ralph_loop \
  -a cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only \
  "review the current change"
```

## Test plan

- `uv run pre-commit run --all-files`
- `uv run pytest` (`1029 passed, 57 skipped`)