### PR TITLE
fix(agents): reject unfinished Claude results

### DIFF
--- a/src/humanize/agents/claude.py
+++ b/src/humanize/agents/claude.py
@@ -23,6 +23,19 @@ if TYPE_CHECKING:
 #: what the permission prompt of an interactive Claude fills in.
 _ASKS = "AskUserQuestion"
 
+#: Reasons that leave an answer unfinished even when a broken intermediary labels the result
+#: `success`. Claude normally keeps its own agent loop going for these rather than returning
+#: them as the result of the whole turn.
+_UNFINISHED = frozenset(
+    {
+        "max_tokens",
+        "model_context_window_exceeded",
+        "pause_turn",
+        "tool_deferred",
+        "tool_use",
+    }
+)
+
 #: What Claude calls each rung of the ladder. Its own four modes line up with them, and one of
 #: them is even called the same thing: `plan` is an agent that works everything out and changes
 #: nothing, `acceptEdits` is one that may change what it is working on without asking, Claude's
@@ -69,6 +82,28 @@ def _about(called: dict[str, Any]) -> str:
         ),
         "",
     )
+
+
+def _result_failure(said: dict[str, Any]) -> str | None:
+    """Explains why a Claude result did not finish its turn, or says that it did."""
+    reason: str | None = None
+    if said.get("is_error"):
+        reason = "the turn failed"
+    elif (subtype := said.get("subtype")) not in (None, "success"):
+        reason = f"Claude ended the turn with {subtype}"
+    elif (terminal := said.get("terminal_reason")) not in (None, "completed"):
+        reason = f"Claude ended the turn with {terminal}"
+    elif (stopped := said.get("stop_reason")) in _UNFINISHED:
+        reason = f"Claude stopped with {stopped} before completing the turn"
+    if reason is None:
+        return None
+
+    if result := said.get("result"):
+        return str(result)
+    errors = said.get("errors") or []
+    if isinstance(errors, list) and errors:
+        return "; ".join(str(error) for error in errors)
+    return reason
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -334,14 +369,15 @@ class ClaudeCodeSession(StreamSessionBase):
             # wrong, and a session is only opened by a turn that lands in it.
             self._named = str(said["session_id"])
         elif said.get("type") == "result":
-            if said.get("is_error"):
-                # `subtype` reads "success" even here, so this flag is the whole of it. The
-                # text is Claude explaining itself, which is a diagnostic and not an answer.
+            if failure := _result_failure(said):
+                # Claude has emitted `subtype: success` with `is_error: true`, so neither
+                # field is sufficient alone. The remaining reasons also guard a malformed
+                # success result that arrives while Claude is still asking to use a tool.
                 tokens, risen = self._spent(said)
                 self._settle(risen)
                 yield Event(
                     kind="failed",
-                    text=str(said.get("result") or "the turn failed"),
+                    text=failure,
                     tokens=tokens,
                     spent=risen,
                 )

--- a/src/humanize/agents/claude.py
+++ b/src/humanize/agents/claude.py
@@ -100,8 +100,8 @@ def _result_failure(said: dict[str, Any]) -> str | None:
 
     if result := said.get("result"):
         return str(result)
-    errors = said.get("errors") or []
-    if isinstance(errors, list) and errors:
+    errors = cast("list[Any]", said.get("errors") or [])
+    if errors:
         return "; ".join(str(error) for error in errors)
     return reason
 

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -512,6 +512,78 @@ def test_a_turn_the_backend_refuses_fails_rather_than_answering(
         _ = session.id
 
 
+@pytest.mark.parametrize(
+    ("result", "because"),
+    [
+        (
+            {
+                "subtype": "error_max_turns",
+                "is_error": False,
+                "terminal_reason": "max_turns",
+                "stop_reason": "tool_use",
+                "errors": ["turn limit reached"],
+            },
+            "turn limit reached",
+        ),
+        (
+            {
+                "subtype": "success",
+                "is_error": False,
+                "terminal_reason": "aborted_streaming",
+                "stop_reason": "end_turn",
+            },
+            "aborted_streaming",
+        ),
+        (
+            {
+                "subtype": "success",
+                "is_error": False,
+                "terminal_reason": "completed",
+                "stop_reason": "tool_use",
+            },
+            "tool_use",
+        ),
+    ],
+)
+def test_claude_does_not_accept_an_unfinished_result(
+    result: dict[str, object], because: str
+) -> None:
+    session = ClaudeCodeAgent(
+        ClaudeCodeAgentConfig(model="claude-opus-4-8", effort="high")
+    ).new()
+
+    events = list(session._read(json.dumps({"type": "result", **result})))
+
+    assert len(events) == 1
+    assert events[0].kind == "failed"
+    assert because in events[0].text
+
+
+def test_claude_accepts_a_completed_result() -> None:
+    session = ClaudeCodeAgent(
+        ClaudeCodeAgentConfig(model="claude-opus-4-8", effort="high")
+    ).new()
+
+    events = list(
+        session._read(
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "terminal_reason": "completed",
+                    "stop_reason": "end_turn",
+                    "result": "done",
+                }
+            )
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].kind == "result"
+    assert events[0].text == "done"
+
+
 def test_a_loop_that_swallows_a_failed_turn_does_not_swallow_being_stopped() -> None:
     """What `/stop` rests on: being stopped must not arrive as a failed turn.
 


### PR DESCRIPTION
## Problem

HMZ currently treats every Claude Code `result` event whose `is_error` field is false or absent as a completed turn.

That is too permissive for Claude Code's result protocol:

- `subtype` is the primary completion discriminator and can report outcomes such as `error_max_turns` or `error_during_execution`.
- `terminal_reason` can show that the agent loop ended through `aborted_streaming`, `max_turns`, or another non-completion path.
- `stop_reason` can still be `tool_use`, `pause_turn`, or another reason that means the response is unfinished.

Before this change, an inconsistent result such as:

```json
{
  "type": "result",
  "subtype": "success",
  "is_error": false,
  "terminal_reason": "completed",
  "stop_reason": "tool_use",
  "result": ""
}
```

was accepted as success. HMZ then adopted the Claude session and emitted an empty successful result. A looping flow such as Flame Chase could consequently move on as though Claude had completed its turn, even though the last model response was still requesting a tool.

This was observed in long-running HMZ workflows where Claude sessions appeared to finish at a tool call and control passed to the next agent without a final answer.

## Fix

This PR validates all available completion metadata instead of relying on `is_error` alone:

- reject a result when `is_error` is true;
- reject a present `subtype` other than `success`;
- reject a present `terminal_reason` other than `completed`;
- reject explicitly unfinished stop reasons:
  - `tool_use`
  - `tool_deferred`
  - `pause_turn`
  - `max_tokens`
  - `model_context_window_exceeded`

When rejecting a result, HMZ preserves Claude's diagnostic text from `result` or `errors` where available.

The checks remain backward compatible with older Claude Code result events that omit `subtype`, `terminal_reason`, or `stop_reason`. Missing optional metadata alone does not turn an otherwise successful result into a failure.

Claude Code documents `subtype` as the primary result status and describes `stop_reason` and `terminal_reason` as additional termination metadata:
https://code.claude.com/docs/en/agent-sdk/agent-loop

## Behavior after this change

A normal result such as `success / completed / end_turn` behaves exactly as before: HMZ adopts the session and returns the final result.

An older result without the newer optional metadata also continues to work.

An error or unfinished result now emits a failed event instead of a successful result. Consequently:

- the failed opening turn does not cause HMZ to adopt or record the Claude session as successfully opened;
- an empty or partial response is not propagated as the completed work of the turn;
- the session layer raises `CalledProcessError`, allowing the caller or flow policy to handle the failed turn.

For flows using `suppress=True`, including Flame Chase, the flow may still continue to the next scheduled agent. The important behavioral change is that the Claude turn is classified as failed rather than falsely classified as completed.

This PR does not change flow scheduling and does not add retries for API gateway errors. Those are separate concerns.

## Tests

Regression coverage includes:

- a non-success subtype even when `is_error` is false;
- an abnormal `terminal_reason`;
- `stop_reason=tool_use` inside an otherwise successful-looking result;
- a normal completed result;
- the existing legacy result shape without the newer fields.

Validated locally with:

- `uv run pre-commit run --all-files`
- `uv run pytest`
