### PR TITLE
fix(tui): preserve IME input in iTerm2

### DIFF
--- a/src/hmz/cli/__init__.py
+++ b/src/hmz/cli/__init__.py
@@ -24,8 +24,32 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser
+    from collections.abc import MutableMapping
 
 __all__ = ["COMMANDS", "main"]
+
+
+def _prepare_textual_terminal(
+    environ: MutableMapping[str, str] | None = None,
+) -> None:
+    """Keeps Textual's extended keys off a direct iTerm2 session.
+
+    iTerm2 loses IME-composed text when Textual asks it to report every key with associated
+    text. A tmux between them handles that protocol correctly, so only the direct path needs
+    Textual's own opt-out. An explicit setting belongs to whoever launched the process.
+
+    Args:
+      environ: The process environment, or another mapping for a caller testing the choice.
+    """
+    import os
+
+    target = os.environ if environ is None else environ
+    direct_iterm = not target.get("TMUX") and (
+        target.get("TERM_PROGRAM") == "iTerm.app"
+        or target.get("LC_TERMINAL") == "iTerm2"
+    )
+    if direct_iterm:
+        target.setdefault("TEXTUAL_DISABLE_KITTY_KEY", "1")
 
 
 def _exec(argv: list[str]) -> int:
@@ -169,6 +193,10 @@ def _tui(argv: list[str]) -> int:
     Returns:
       Zero, once the interface has been closed, or two for a line to correct.
     """
+    # Textual reads this once, while it is imported, so the terminal must be prepared before
+    # reaching the lazily imported interface below.
+    _prepare_textual_terminal()
+
     from hmz.runner import configures, read_agent, set_up_from, wanted
     from hmz.tui import Humanize
     from hmz.tui.pick import Runs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,44 @@ def test_a_line_naming_no_command_opens_the_interface() -> None:
     assert "tui" not in cli.COMMANDS
 
 
+@pytest.mark.parametrize(
+    "terminal",
+    [
+        {"TERM_PROGRAM": "iTerm.app"},
+        {"LC_TERMINAL": "iTerm2"},
+    ],
+)
+def test_a_direct_iterm_session_uses_plain_terminal_input(
+    terminal: dict[str, str],
+) -> None:
+    cli._prepare_textual_terminal(terminal)
+
+    assert terminal["TEXTUAL_DISABLE_KITTY_KEY"] == "1"
+
+
+def test_iterm_through_tmux_keeps_extended_terminal_input() -> None:
+    terminal = {
+        "TERM_PROGRAM": "tmux",
+        "LC_TERMINAL": "iTerm2",
+        "TMUX": "/tmp/tmux/default,1,0",
+    }
+
+    cli._prepare_textual_terminal(terminal)
+
+    assert "TEXTUAL_DISABLE_KITTY_KEY" not in terminal
+
+
+def test_an_explicit_textual_keyboard_choice_is_kept() -> None:
+    terminal = {
+        "TERM_PROGRAM": "iTerm.app",
+        "TEXTUAL_DISABLE_KITTY_KEY": "0",
+    }
+
+    cli._prepare_textual_terminal(terminal)
+
+    assert terminal["TEXTUAL_DISABLE_KITTY_KEY"] == "0"
+
+
 def test_a_line_of_flags_and_no_command_opens_the_interface_set_up() -> None:
     """`hmz -f <flow>`: a run that is always the same run is one line rather than three walks."""
     with unittest.mock.patch("hmz.tui.Humanize.run") as opened:


### PR DESCRIPTION
## Summary

- disable Textual's Kitty keyboard protocol when `hmz` runs directly in iTerm2, restoring Chinese and other IME-composed input
- keep the protocol enabled when iTerm2 is behind tmux, where input already works and extended keys remain useful
- respect an explicit `TEXTUAL_DISABLE_KITTY_KEY` choice and configure Textual before its first import

## Root cause

Textual enables Kitty's report-all-keys and associated-text modes. iTerm2's direct handling of that combination loses IME-composed text before it reaches the `TextArea`. tmux changes the terminal protocol boundary and does not reproduce the failure.

This uses Textual's supported compatibility switch rather than modifying its input driver or handling composed text inside the editor.

## Test plan

- `uv run pre-commit run --all-files`
- `uv run pytest` (`1096 passed, 58 skipped`)
- manually confirmed Chinese IME input in direct iTerm2
