### PR TITLE
fix(claude): disable continuation tools when goals are off

### DIFF
--- a/docs/features/goals.md
+++ b/docs/features/goals.md
@@ -67,9 +67,12 @@ agent = CodexAgent(CodexAgentConfig(model="gpt-5.6-sol", effort="high", goals=Fa
 `agent.disable_goals()` remains the imperative equivalent before the first turn.
 
 Ordinary turns continue to work, but later calls to `pursue` raise `RuntimeError`, even with
-`suppress=True`. Codex starts that agent's app server with its goal tools disabled; Claude Code
-has no separate runtime feature, so HMZ refuses its goal before invoking the CLI. Neither path
-changes the user's global backend configuration.
+`suppress=True`. Codex starts that agent's app server with its goal tools disabled. For an
+ordinary Claude Code print turn, HMZ disables the noninteractive continuation tools `Agent`,
+`ScheduleWakeup`, `CronCreate`, `CronDelete`, and `CronList`; ordinary tools remain governed by
+the agent's permission and skill configuration. These denials are combined with excluded-skill
+denials in one deterministic backend argument. Neither path changes the user's global backend
+configuration, and a Claude agent whose goals remain enabled keeps its existing command.
 
 ## Asking for an agent that has one
 

--- a/src/hmz/agents/claude.py
+++ b/src/hmz/agents/claude.py
@@ -23,6 +23,17 @@ if TYPE_CHECKING:
 #: what the permission prompt of an interactive Claude fills in.
 _ASKS = "AskUserQuestion"
 
+#: Noninteractive orchestration tools that can move work beyond the ordinary turn HMZ owns.
+#: An agent whose goals are disabled remains able to use its ordinary permission-bound tools,
+#: but cannot escape into a hidden goal, subagent, wakeup, or cron lifecycle.
+_CONTINUATION_TOOLS = (
+    "Agent",
+    "ScheduleWakeup",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+)
+
 #: Reasons that leave an answer unfinished even when a broken intermediary labels the result
 #: `success`. Claude normally keeps its own agent loop going for these rather than returning
 #: them as the result of the whole turn.
@@ -189,6 +200,9 @@ class ClaudeCodeSession(StreamSessionBase):
             # Claude validates the answer against this itself, so a turn that lands has
             # answered in the shape: what comes back is the object, and nothing else.
             argv += ["--json-schema", json.dumps(self._shaping.model_json_schema())]
+        denied: list[str] = (
+            list(_CONTINUATION_TOOLS) if not self._agent.goals_enabled else []
+        )
         if off := leaving(
             self._agent.backend, self._agent.config.skills, self._workspace()
         ):
@@ -196,7 +210,11 @@ class ClaudeCodeSession(StreamSessionBase):
             # agent is refused every skill it was not given. It is still told they exist --
             # Claude lists what is installed, and no flag takes one off that list -- so this
             # is a skill it cannot use rather than one it never hears of.
-            argv += ["--disallowedTools", ",".join(f"Skill({one})" for one in off)]
+            denied.extend(f"Skill({one})" for one in off)
+        if denied:
+            # One backend argument is the authority boundary. Keeping continuation tools first
+            # and skills in their established load order makes the resolved command stable.
+            argv += ["--disallowedTools", ",".join(denied)]
         return argv
 
     def _write(self, text: str, ticket: str = "") -> str:

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -125,10 +125,12 @@ def clis(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _FakeCLIs:
         "for line in sys.stdin:\n"
         "    said = json.loads(line)['message']['content'][0]['text']\n"
         "    note([], said)\n"
+        "    answer = (pathlib.Path('PROJECT_FACT').read_text() "
+        "if said == 'read project fact' else said)\n"
         "    print(json.dumps({'type': 'assistant', 'message': {'content': "
         "[{'type': 'text', 'text': 'working'}]}}), flush=True)\n"
         # One answer per thing said, which is what the real one does.
-        "    print(json.dumps({'type': 'result', 'result': said}), flush=True)\n"
+        "    print(json.dumps({'type': 'result', 'result': answer}), flush=True)\n"
     )
     fake = binaries / "claude"
     fake.write_text(f"#!{sys.executable}\n{claude}")
@@ -436,19 +438,25 @@ def test_claude_pursues_through_its_own_goal_command(clis: _FakeCLIs) -> None:
     ]
 
 
-def test_disabled_goals_never_reach_claude(clis: _FakeCLIs) -> None:
-    """Claude has no feature flag for goals, so HMZ refuses them before invoking its CLI."""
+def test_disabled_goals_never_reach_claude(clis: _FakeCLIs, tmp_path: Path) -> None:
+    """A goals-off ordinary turn cannot leave HMZ through continuation tools."""
     agent = ClaudeCodeAgent(
         ClaudeCodeAgentConfig(model="claude-opus-4-8", effort="high")
     )
-    session = agent.new()
+    (tmp_path / "PROJECT_FACT").write_text("the frozen source fact")
+    session = agent.new(tmp_path)
     agent.disable_goals()
 
     assert not agent.goals_enabled
     with pytest.raises(RuntimeError, match="goals are disabled"):
         session.pursue("the suite passes", suppress=True)
     assert not clis.log.exists()
-    assert session("an ordinary turn") == "an ordinary turn"
+    assert session("read project fact") == "the frozen source fact"
+    launched = clis.calls()[0].argv
+    assert launched.count("--disallowedTools") == 1
+    assert launched[launched.index("--disallowedTools") + 1] == (
+        "Agent,ScheduleWakeup,CronCreate,CronDelete,CronList"
+    )
 
 
 def test_an_anchored_agent_hands_its_whole_turn_to_the_anchor(clis: _FakeCLIs) -> None:

--- a/tests/agents/test_shapes.py
+++ b/tests/agents/test_shapes.py
@@ -183,11 +183,22 @@ def test_claude_is_refused_every_skill_this_agent_was_not_given(
     )
 
     # An agent given none is refused all of them, which is not the same as never being asked.
-    none = ClaudeCodeAgent(
+    none_agent = ClaudeCodeAgent(
         ClaudeCodeAgentConfig(model="m", effort="high", skills=())
-    ).new()
+    )
+    none = none_agent.new()
     argv = none._command()
     assert (
         argv[argv.index("--disallowedTools") + 1]
         == "Skill(hf-cli),Skill(writing),Skill(housekeeping)"
+    )
+
+    # Goal and skill denials share one deterministic backend argument rather than competing
+    # flags whose precedence would belong to the CLI.
+    none_agent.disable_goals()
+    argv = none._command()
+    assert argv.count("--disallowedTools") == 1
+    assert argv[argv.index("--disallowedTools") + 1] == (
+        "Agent,ScheduleWakeup,CronCreate,CronDelete,CronList,"
+        "Skill(hf-cli),Skill(writing),Skill(housekeeping)"
     )


### PR DESCRIPTION
## Summary

- disable Claude continuation/orchestration tools when goals are explicitly off
- combine continuation and excluded-skill denials into one deterministic backend argument
- document the behavior and test both goals-off and skills-denial command construction

## Why this boundary

Hmz treats goals as authority for work that can continue beyond one ordinary agent invocation. With `goals=False`, a backend must not retain alternate continuation or persistent-scheduling paths:

- `Agent` can start another agent lifecycle.
- `ScheduleWakeup` can resume work after the current invocation returns.
- `CronCreate` can create persistent future work.
- `CronDelete` can mutate persistent scheduler state.
- `CronList` reads scheduler state outside the current invocation; denying the complete cron surface keeps the disabled capability closed and consistent.

Ordinary tools remain governed by the existing permission and skill configuration, and agents with goals enabled keep their existing command unchanged. If nested agents or scheduler inspection should become independently configurable, Hmz can expose separate explicit capabilities instead of inferring them from `goals`.

## Verification

- `uv run pre-commit run --all-files`
- `uv run pytest tests/agents/test_agents.py tests/agents/test_shapes.py` (47 passed)