### PR TITLE
fix(kimi): expose skills and reclaim app servers

### DIFF
--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -24,6 +24,7 @@ Where each CLI keeps them is written down in `hmz.backends`:
 | --- | --- | --- |
 | `claude` | `~/.claude/skills/*/SKILL.md` | `.claude/skills/*/SKILL.md` |
 | `codex` | `~/.codex/skills/*/SKILL.md`, `~/.agents/skills/*/SKILL.md` | `.agents/skills/*/SKILL.md`, `.codex/skills/*/SKILL.md` |
+| `kimi` | `~/.kimi-code/skills/*/SKILL.md`, `~/.agents/skills/*/SKILL.md` | `.kimi-code/skills/*/SKILL.md`, `.agents/skills/*/SKILL.md` |
 
 Nothing is asked of the CLI to find out, which would mean starting it, and nothing is written:
 what a person has installed is not something a flow is entitled to rewrite, and a list that
@@ -64,8 +65,8 @@ the next time a run asks for it, so a skill somebody else maintains is one that 
 | Backend | Where |
 | --- | --- |
 | `claude` | `.claude/skills/` in the workspace |
-| `codex`, `grok`, `qwen` | `.agents/skills/`, the directory more than one of these agreed to read |
-| `agy`, `dsh`, `kimi`, `mimo`, `opencode`, `pi` | — none: they carry what their CLI installs |
+| `codex`, `grok`, `kimi`, `qwen` | `.agents/skills/`, the directory more than one of these agreed to read |
+| `agy`, `dsh`, `mimo`, `opencode`, `pi` | — none: they carry what their CLI installs |
 
 A project's own skill of that name wins — a flow does not write over what the project keeps —
 and two sessions of one flow working in one directory share the mount until the last of them

--- a/src/hmz/agents/kimi.py
+++ b/src/hmz/agents/kimi.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import collections
 import contextlib
 import json
+import os
 import re
+import signal
 import subprocess
 import sys
 import threading
@@ -33,7 +35,6 @@ from .config import AgentConfig
 from .event import Event, Failed, Question, Usage, say
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import Iterator, Mapping
 
     from pydantic import BaseModel
@@ -112,6 +113,8 @@ class _AppServer:
             is the turn that starts it that has nowhere to run.
         """
         self._argv = argv
+        self._stopping = threading.Lock()
+        self._stopped = False
         self._proc = subprocess.Popen(
             argv,
             # Its log is nobody's to read; what is wanted from it is the one line below.
@@ -121,6 +124,7 @@ class _AppServer:
             encoding="utf-8",
             errors="replace",
             env=dict(env) if env else None,
+            start_new_session=os.name != "nt",
         )
         assert self._proc.stdout is not None  # noqa: S101
         for line in self._proc.stdout:
@@ -184,12 +188,30 @@ class _AppServer:
         return said.get("data")
 
     def stop(self) -> None:
-        """Takes the daemon down, leaving the sessions it held on disk."""
-        self._proc.terminate()
-        # Reaped rather than left: a flow that cycles through agents would otherwise gather a
-        # zombie for each one it let go of.
-        with contextlib.suppress(subprocess.TimeoutExpired):
-            self._proc.wait(timeout=_STOP_SECONDS)
+        """Takes the daemon and its children down, leaving its sessions on disk."""
+        with self._stopping:
+            if self._stopped:
+                return
+            self._stopped = True
+            if os.name == "nt":
+                if self._proc.poll() is None:
+                    self._proc.terminate()
+                    try:
+                        self._proc.wait(timeout=_STOP_SECONDS)
+                    except subprocess.TimeoutExpired:
+                        self._proc.kill()
+                self._proc.wait()
+                return
+
+            # Provider wrappers and Kimi share this dedicated group. Taking down the group
+            # prevents a stopped flow from leaving either wrapper or daemon behind.
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(self._proc.pid, signal.SIGTERM)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                self._proc.wait(timeout=_STOP_SECONDS)
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(self._proc.pid, signal.SIGKILL)
+            self._proc.wait()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/hmz/backends.py
+++ b/src/hmz/backends.py
@@ -647,9 +647,14 @@ PROFILES = (
         # Every model Kimi runs takes a turn as a fleet as well as as one agent: `swarmmax`
         # and `max` are the same thinking at two widths.
         swarms=True,
-        # None named: `--skills-dir` is a flag of the command line, and a session here is a
-        # thread on `kimi web`, which takes none. A skill Kimi finds is a skill it loads, so
-        # there is nothing here to be offered a choice about.
+        # Kimi Code discovers both its own and the shared skill directories without a command
+        # line flag, including for sessions served by `kimi web`. The shared project directory
+        # is also where a flow can mount one skill for Claude, Codex or Kimi without installing
+        # it into any of their homes.
+        skills=("skills/*/SKILL.md",),
+        shared=(".agents/skills/*/SKILL.md",),
+        works=(".kimi-code/skills/*/SKILL.md", ".agents/skills/*/SKILL.md"),
+        mounts=".agents/skills",
         #
         # A directory apiece: kimi keeps one file per endpoint it has signed into, named
         # after that endpoint, and a lock beside it that two of its processes rotate a

--- a/tests/agents/test_kimi_cleanup.py
+++ b/tests/agents/test_kimi_cleanup.py
@@ -1,0 +1,64 @@
+"""Process-lifecycle checks for the Kimi Code app-server harness."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import sys
+import textwrap
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.agents import kimi as kimi_backend
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are unavailable")
+def test_kimi_server_stop_terminates_its_entire_process_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider wrapper cannot leave its Kimi child behind after a flow stops."""
+    program = tmp_path / "server.py"
+    child_pid = tmp_path / "child.pid"
+    program.write_text(
+        textwrap.dedent(
+            f"""
+            import pathlib
+            import signal
+            import subprocess
+            import sys
+            import time
+
+            child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+            pathlib.Path({str(child_pid)!r}).write_text(str(child.pid))
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            print("Kimi server: http://127.0.0.1:1/#token=test", flush=True)
+            time.sleep(60)
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kimi_backend, "_STOP_SECONDS", 0.05)
+    server = kimi_backend._AppServer([sys.executable, str(program)])
+    process_group = server._proc.pid
+    try:
+        server.stop()
+        server.stop()
+        assert server._proc.poll() is not None
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                os.killpg(process_group, 0)
+            except ProcessLookupError:
+                break
+            if time.monotonic() >= deadline:
+                pytest.fail("Kimi process group was not reaped")
+            time.sleep(0.01)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process_group, signal.SIGKILL)

--- a/tests/test_flow_skills.py
+++ b/tests/test_flow_skills.py
@@ -37,6 +37,14 @@ class ClaudeAgent(ShellAgent):
     """
 
 
+class CodexAgent(ShellAgent):
+    """A stand-in named for Codex, which reads the shared project skill directory."""
+
+
+class KimiAgent(ShellAgent):
+    """A stand-in named for Kimi, which reads the shared project skill directory."""
+
+
 #: A flow that does what it is told, in a session of its own: what the turn is is the shell
 #: line the test hands it, so a test can have it look at what was mounted beside it.
 DOES = '''"""Does the one thing it is told."""
@@ -222,6 +230,32 @@ def test_a_session_is_given_them_where_its_backend_reads_a_projects_own(
     assert "does a thing" in (tmp_path / "read.txt").read_text()
     # Mounted rather than installed: what the flow brought is not left on the machine.
     assert not (tmp_path / ".claude").exists()
+
+
+@pytest.mark.parametrize("agent_type", [CodexAgent, KimiAgent])
+def test_a_shared_skill_backend_is_given_flow_skills_in_the_project_directory(
+    agent_type: type[ShellAgent],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex and Kimi discover flow skills from the shared project directory."""
+    monkeypatch.chdir(tmp_path)
+    written(
+        tmp_path / ".humanize/flows",
+        "mine",
+        DOES,
+        {"note-taking": skill("note-taking")},
+    )
+
+    Runner("mine", [agent_type(CONFIG)]).run(
+        "ls .agents/skills > listed.txt; "
+        "cat .agents/skills/note-taking/SKILL.md > read.txt"
+    )
+    gc.collect()
+
+    assert (tmp_path / "listed.txt").read_text().split() == ["note-taking"]
+    assert "does a thing" in (tmp_path / "read.txt").read_text()
+    assert not (tmp_path / ".agents").exists()
 
 
 def test_a_projects_own_skill_of_that_name_is_left_alone(

--- a/tests/tui/test_skills.py
+++ b/tests/tui/test_skills.py
@@ -86,9 +86,28 @@ def test_codex_is_read_from_all_four_places_it_looks(
     ]
 
 
-def test_a_backend_that_keeps_none_here_finds_none(homes: Path) -> None:
-    """Kimi's daemon reads no directory of them, so there is nothing here to show."""
-    assert skills("kimi") == []
+def test_kimi_is_read_from_its_own_and_shared_skill_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Kimi web discovers the same skill roots as an interactive Kimi session."""
+    _write(tmp_path / "kimi-home" / "skills", "its-own")
+    _write(tmp_path / "home" / ".agents" / "skills", "shared")
+    _write(tmp_path / "project" / ".kimi-code" / "skills", "project-kimi")
+    _write(tmp_path / "project" / ".agents" / "skills", "project-agents")
+    monkeypatch.setenv("KIMI_CODE_HOME", str(tmp_path / "kimi-home"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.chdir(tmp_path / "project")
+
+    assert [one.name for one in skills("kimi")] == [
+        "its-own",
+        "shared",
+        "project-kimi",
+        "project-agents",
+    ]
+
+
+def test_an_unknown_backend_finds_no_skills(homes: Path) -> None:
+    """A backend Humanize does not know has nowhere to discover a skill from."""
     assert skills("not-a-cli") == []
 
 
@@ -106,11 +125,14 @@ def test_a_skill_with_no_front_matter_is_the_directory_it_is_in(homes: Path) -> 
     "hmz.tui.app.installed",
     return_value={"kimi": (Model("kimi-code/k3", ("max",)),)},
 )
-async def test_a_cli_that_keeps_none_says_that_rather_than_none_installed(
+async def test_a_cli_with_no_installed_skills_says_so(
     _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
     homes: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Blaming the machine for what the backend does not do would be the wrong sentence."""
+    """A supported skill directory with no entries is empty rather than unsupported."""
+    monkeypatch.setenv("KIMI_CODE_HOME", str(homes / "kimi-home"))
+    monkeypatch.setattr(Path, "home", lambda: homes / "home")
     app = Humanize()
     async with app.run_test() as driver:
         await into_flows(app, driver)
@@ -119,7 +141,7 @@ async def test_a_cli_that_keeps_none_says_that_rather_than_none_installed(
         await until(lambda: isinstance(app.screen, Skills), driver)
         said = str(app.screen.query_one("#tuning", Label).content)
 
-        assert "kimi keeps no skills of its own here" in said
+        assert "kimi has none installed here" in said
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION

### Summary

- Describe the skill roots Kimi Code already discovers, including the shared
  `.agents/skills` project directory, so Humanize can list and mount flow-carried skills for
  Kimi sessions.
- Start `kimi web` in a dedicated POSIX process group and stop that group idempotently, using
  a bounded TERM-to-KILL escalation so provider wrappers and daemon children do not survive a
  stopped run.
- Document Kimi's user/project skill locations and cover discovery, mounting, cleanup, and TUI
  reporting.

### Motivation

The Kimi backend currently declares no skill roots even though Kimi Code reads its own skill
directory and the shared `.agents/skills` directory. A flow can therefore carry a skill for
Claude and Codex but cannot expose the same capability to a Kimi actor or reviewer.

Also, terminating only the direct `kimi web` process can leave a provider or machine wrapper's
children alive after Ctrl-C or flow teardown. Each app server belongs to one agent, so a private
process group gives Humanize a bounded unit to reclaim without affecting unrelated processes.

### Implementation

- Add Kimi `skills`, `shared`, `works`, and `mounts` profile metadata.
- Use `start_new_session` on POSIX when launching the app server.
- Serialize shutdown with a lock and make repeated `stop()` calls no-ops.
- Terminate the POSIX process group, wait, escalate to SIGKILL, and reap the direct child.
- Keep Windows on direct-process termination with a bounded kill fallback.
- Wait for asynchronous orphan/zombie reaping in the lifecycle test without relaxing the
  requirement that the process group disappear.

### Modified files

- `src/hmz/backends.py`: declare Kimi skill discovery and mount locations.
- `src/hmz/agents/kimi.py`: own and reclaim the app-server process group.
- `docs/features/skills.md`: add Kimi to the documented skill/mount matrix.
- `tests/agents/test_kimi_cleanup.py`: verify idempotent whole-group cleanup.
- `tests/test_flow_skills.py`: verify a Kimi session receives and releases a flow skill from
  `.agents/skills`.
- `tests/tui/test_skills.py`: verify Kimi skill discovery and empty-state wording.

Scope: 6 files, 166 insertions, 18 deletions.

### Compatibility and risk

- No Kimi request, response, model, effort, or session protocol changes.
- Existing user/project skills remain read-only; flow skills are mounted only for session
  lifetime and project-owned same-name skills still win.
- POSIX group signaling is limited to the new session created for this app server.
- Shutdown can wait up to the existing stop timeout before escalation.

### Validation

- `uv run pre-commit run --all-files`: passed on this branch.
- Kimi/backend/skill focused suite: 73 passed, 10 skipped.
- Process-group lifecycle test run under five concurrent pytest processes: all passed.
- With PR 2 applied as well, the Kaggle composition flowverse suite passes all 55 tests.

