### PR TITLE
feat(flows): support reusable composition layers

### DIFF
--- a/docs/guide/tutorial-calling-flows.md
+++ b/docs/guide/tutorial-calling-flows.md
@@ -83,7 +83,20 @@ async def run(agents: tuple[AgentBase], task: str) -> None:
     await calls("official/rlar")(agents, task)
 ```
 
-## Step 5 — a flow that talks to you
+## Step 5 — optionally pass wrapper skills through
+
+A called flow carries its own skills by default. A wrapper whose purpose is to add a reusable
+capability can explicitly keep its skills available inside the called flow:
+
+```python
+calls("official/rlar", inherit_skills=True)(agents, task)
+```
+
+The child wins a same-name skill, parent-only skills follow it, and the agents return carrying
+exactly what they had before the call. Keep the default isolation for reviewers and other flows
+that should not receive the caller's capabilities.
+
+## Step 6 — a flow that talks to you
 
 A flow that drives [the person](/features/human-agent) may be handed one fewer agent, since nobody
 chooses what the person runs. Hand over your own if you have one, so that what it asks reaches
@@ -100,7 +113,7 @@ def run(agents: Agents, task: str) -> None:
     calls("chat")((agents.assistant, agents.human), task)
 ```
 
-## Step 6 — see that both are running
+## Step 7 — see that both are running
 
 ```python
 from hmz.runner import running
@@ -155,6 +168,7 @@ where flows are listed, which is otherwise the first line of its docstring.
 
 - `calls(name)` takes what `-f` takes and is refused immediately for a name nothing answers to.
 - Hand a called flow the agents it declares; nothing is renamed.
+- Use `inherit_skills=True` only when a wrapper intentionally extends its child flow.
 - Settings pass as a third argument, checked against that flow's model.
 - `@flow(name="…")` puts three flows in one file.
 

--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -515,6 +515,17 @@ The name is what you write in the mark and nothing else — a name written down 
 run should not change under whoever renames the function. `@flow(about="…")` says what it does
 where flows are listed, which is otherwise the first line of its docstring.
 
+An implementation flow used only through `calls()` can stay out of those lists and the `/flow`
+picker without losing its name:
+
+```python
+@flow(name="engine", selectable=False)
+def engine(agents: Agents, task: str) -> None:
+    ...
+```
+
+It remains directly callable by `<flow>:engine`; `selectable=False` changes discovery only.
+
 Each of them declares its own agents and its own settings, so the agents page asks two questions
 rather than five and setting one up shows one phase's flags rather than three phases' at once. What
 passes between them is whatever they write — a file, usually.
@@ -567,6 +578,17 @@ the agents are handed back carrying the calling flow's own when it returns, howe
 A call refused — for settings the flow does not take, for an agent that cannot run a moment it
 declares, for a place run under a goal filled by an agent that has none — is a call that never
 happened, and leaves the agents exactly as it found them.
+
+A wrapper flow may deliberately keep its own skills available inside the called flow:
+
+```python
+calls("official/rlar", inherit_skills=True)(agents, task)
+```
+
+The called flow's skills come first and win any same-name collision. Parent-only skills are
+then appended, and the agents are restored to exactly what the wrapper carried when the call
+returns or raises. Without the flag, calls remain isolated; a reviewer or other child flow is
+not implicitly given its caller's capabilities.
 
 **A flow that takes [settings of its own](#settings-of-the-flow-s-own) takes them here too**,
 as a third argument — an instance of that flow's model, or the fields to build one from:

--- a/src/hmz/flows/__init__.py
+++ b/src/hmz/flows/__init__.py
@@ -101,12 +101,15 @@ class Flow:
         so is handed a dict as its last argument -- what it wrote there last time -- which is
         kept in the run's own cycle and read back into the run after it. A flow that says
         nothing is run from the top every time, which is what every flow was before this.
+      selectable: Whether people are offered this flow in lists and the flow picker. An
+        internal composition may set this false while remaining callable by name.
     """
 
     name: str = ""
     about: str = ""
     skills: tuple[str, ...] = ()
     resumable: bool = False
+    selectable: bool = True
 
 
 #: Where a decorated function keeps what it said about itself. On the function rather than in
@@ -126,6 +129,7 @@ def flow[**P, T](
     about: str = "",
     skills: Iterable[str] = (),
     resumable: bool = False,
+    selectable: bool = True,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
@@ -137,6 +141,7 @@ def flow[**P, T](
     about: str = "",
     skills: Iterable[str] = (),
     resumable: bool = False,
+    selectable: bool = True,
 ) -> Callable[P, T] | Callable[[Callable[P, T]], Callable[P, T]]:
     """Marks a function as a flow. Nothing else is one.
 
@@ -174,6 +179,12 @@ def flow[**P, T](
     and saved as the flow writes it, so a run that was stopped or killed is one the next run
     picks up from rather than one whose week is gone.
 
+    A helper used only by another flow remains callable without cluttering the flow picker::
+
+        @flow(name="engine", selectable=False)
+        def engine(agents: tuple[AgentBase], task: str) -> None:
+            ...
+
     Args:
       call: The function, when the decorator is written with no arguments at all.
       name: What to call this one among the flows its directory holds, or "" for the one it
@@ -183,6 +194,8 @@ def flow[**P, T](
         optional `#<skill>`. What it keeps in its own `skills/` needs no declaring.
       resumable: Whether it takes the state of the last run of it, and is handed a dict to
         write the next run's into.
+      selectable: Whether to offer it in flow lists and the flow picker. False keeps an
+        internal composition callable by name without presenting it as a flow to start.
 
     Returns:
       The function, unchanged but for what it now says about itself: a flow is called the way
@@ -199,6 +212,7 @@ def flow[**P, T](
                 about=about or _first(said.__doc__),
                 skills=tuple(skills),
                 resumable=resumable,
+                selectable=selectable,
             ),
         )
         return said
@@ -310,7 +324,11 @@ def _flows_of(inside: dict[str, Any]) -> list[Flow]:
         # flow is documented as that flow, and its first line is what it does.
         if not marked.name and not marked.about:
             marked = Flow(
-                name="", about=_first(inside.get("__doc__")), skills=marked.skills
+                name="",
+                about=_first(inside.get("__doc__")),
+                skills=marked.skills,
+                resumable=marked.resumable,
+                selectable=marked.selectable,
             )
         said.append(marked)
     return [one for one in said if not one.name] + [one for one in said if one.name]
@@ -463,6 +481,7 @@ def _named(at: Path, called: str) -> list[tuple[str, str]]:
     return [
         (called if not one.name else f"{called}{_INSIDE}{one.name}", one.about)
         for one in _flows_of(inside)
+        if one.selectable
     ]
 
 

--- a/src/hmz/runner.py
+++ b/src/hmz/runner.py
@@ -442,7 +442,41 @@ def _called(flow: str | os.PathLike[str]) -> str:
     return said.parent.name if said.name == ENTRY else said.stem
 
 
-def calls(flow: str | os.PathLike[str]) -> Flow:
+class _CalledSkills:
+    """Template for handing agents into a called flow and restoring them afterwards."""
+
+    def carry(self, flow: str, agents: Sequence[AgentBase]) -> list[tuple[Loaded, ...]]:
+        """Loads the called flow's skills under this policy, returning the prior state."""
+        before = [agent.loaded for agent in agents]
+        carries(flow, agents)
+        for agent, parent in zip(agents, before, strict=True):
+            agent.loads(self.combine(parent, agent.loaded))
+        return before
+
+    def combine(
+        self, parent: tuple[Loaded, ...], child: tuple[Loaded, ...]
+    ) -> tuple[Loaded, ...]:
+        """Chooses what the called flow carries; isolation is the default policy."""
+        del parent
+        return child
+
+
+class _InheritedCalledSkills(_CalledSkills):
+    """Carries a child's skills plus parent skills whose names the child did not replace."""
+
+    def combine(
+        self, parent: tuple[Loaded, ...], child: tuple[Loaded, ...]
+    ) -> tuple[Loaded, ...]:
+        """Merges child first so its version wins every same-name skill."""
+        child_names = {one.name for one in child}
+        return child + tuple(one for one in parent if one.name not in child_names)
+
+
+_ISOLATED_SKILLS = _CalledSkills()
+_INHERITED_SKILLS = _InheritedCalledSkills()
+
+
+def calls(flow: str | os.PathLike[str], *, inherit_skills: bool = False) -> Flow:
     """One flow, ready for another flow to run: what it marked, found by name.
 
     A flow is a loop over agents, and a loop worth having is one another loop can reach for::
@@ -474,8 +508,15 @@ def calls(flow: str | os.PathLike[str]) -> Flow:
     somebody first asked for it. That is what makes a loop that improves its own flow, or its
     own skills, a loop that then runs the improved one.
 
+    A called flow carries only its own skills by default. A wrapper flow may explicitly pass
+    its skills through with ``inherit_skills=True``. The called flow still owns the result:
+    its skill wins when parent and child use the same name, and the agents are restored to
+    exactly what the caller carried when the call returns or raises.
+
     Args:
       flow: The flow to call, by the name `-f` takes.
+      inherit_skills: Whether skills carried by the calling flow remain available inside the
+        called flow, after the called flow's own and only where their names do not collide.
 
     Returns:
       Something to call with the agents and the task.
@@ -488,6 +529,7 @@ def calls(flow: str | os.PathLike[str]) -> Flow:
     """
     _read(flow)  # said now, so a name that is wrong is wrong where it was written
     named = str(flow)
+    skill_policy = _INHERITED_SKILLS if inherit_skills else _ISOLATED_SKILLS
 
     def calling(
         agents: Sequence[AgentBase],
@@ -513,8 +555,7 @@ def calls(flow: str | os.PathLike[str]) -> Flow:
         # And the skills it works by, which are the flow's rather than the agents': a called
         # flow brings its own, mounted onto whatever sessions it opens, and hands the agents
         # back as it found them so that the flow which called it goes on carrying its own.
-        before = [agent.loaded for agent in driven]
-        carries(named, driven)
+        before = skill_policy.carry(named, driven)
         started = _entered(named, driven)
         _wrote(driven, "called", flow=named, task=task)
         try:

--- a/tests/test_calling_flows.py
+++ b/tests/test_calling_flows.py
@@ -364,3 +364,111 @@ def test_a_called_flow_brings_its_own_skills_and_hands_the_agents_back(
     assert (flows / "carried.txt").read_text() == "over-notes|over-notes"
     assert [one.name for one in agent.loaded] == ["over-notes"]
     assert isinstance(agent.loaded[0], Loaded)
+
+
+def test_a_called_flow_can_explicitly_inherit_its_callers_skills(flows: Path) -> None:
+    """A wrapper can add a skill without copying the called flow's own bundle."""
+    card = "---\nname: {name}\ndescription: does a thing\n---\n\n{says}\n"
+    inner = '''"""Records everything it carries."""
+
+from pathlib import Path
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    (agent,) = agents
+    names = ",".join(one.name for one in agent.loaded)
+    shared = next(one for one in agent.loaded if one.name == "shared")
+    Path("inherited.txt").write_text(names + "|" + (shared.at / "SKILL.md").read_text())
+'''
+    written(
+        flows / ".humanize/flows",
+        "deep",
+        inner,
+        {
+            "deep-notes": card.format(name="deep-notes", says="Deep."),
+            "shared": card.format(name="shared", says="Child wins."),
+        },
+    )
+    written(
+        flows / ".humanize/flows",
+        "over",
+        '''"""Passes its skills into a called flow."""
+
+from pathlib import Path
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+from hmz.runner import calls
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    calls("deep", inherit_skills=True)(agents, task)
+    Path("restored.txt").write_text(",".join(one.name for one in agents[0].loaded))
+''',
+        {
+            "over-notes": card.format(name="over-notes", says="Over."),
+            "shared": card.format(name="shared", says="Parent loses."),
+        },
+    )
+    agent = ShellAgent(CONFIG)
+
+    Runner("over", [agent]).run("go")
+
+    inherited = (flows / "inherited.txt").read_text()
+    assert inherited.startswith("deep-notes,shared,over-notes|")
+    assert "Child wins." in inherited
+    assert "Parent loses." not in inherited
+    assert (flows / "restored.txt").read_text() == "over-notes,shared"
+    assert [one.name for one in agent.loaded] == ["over-notes", "shared"]
+
+
+def test_inherited_skills_are_restored_when_the_called_flow_raises(flows: Path) -> None:
+    """The template's cleanup applies to unsuccessful calls as well as returns."""
+    card = "---\nname: {name}\ndescription: does a thing\n---\n\nDo it.\n"
+    written(
+        flows / ".humanize/flows",
+        "bad",
+        '''"""Fails after receiving inherited skills."""
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    assert [one.name for one in agents[0].loaded] == ["child", "parent"]
+    raise RuntimeError("no")
+''',
+        {"child": card.format(name="child")},
+    )
+    written(
+        flows / ".humanize/flows",
+        "over",
+        '''"""Catches a failed inherited call and records its restored skills."""
+
+from pathlib import Path
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+from hmz.runner import calls
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    try:
+        calls("bad", inherit_skills=True)(agents, task)
+    except RuntimeError:
+        pass
+    Path("restored-after-error.txt").write_text(",".join(one.name for one in agents[0].loaded))
+''',
+        {"parent": card.format(name="parent")},
+    )
+
+    Runner("over", [ShellAgent(CONFIG)]).run("go")
+
+    assert (flows / "restored-after-error.txt").read_text() == "parent"

--- a/tests/test_flow_naming.py
+++ b/tests/test_flow_naming.py
@@ -104,6 +104,26 @@ def twice(agents: tuple[AgentBase], task: str) -> None:
     agent.new()(task)
 '''
 
+#: A public composition and the internal engine it calls by name.
+AUXILIARY = '''"""One flow to choose and one implementation detail."""
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    (agent,) = agents
+    agent.new()(task)
+
+
+@flow(name="engine", selectable=False)
+def engine(agents: tuple[AgentBase], task: str) -> None:
+    (agent,) = agents
+    agent.new()(task)
+    agent.new()(task)
+'''
+
 #: A file with a `run` in it and nothing marked, which is what a flow used to be and is not.
 UNMARKED = '''"""A file that says nothing about which of its functions is a flow."""
 
@@ -185,6 +205,28 @@ def test_each_flow_in_a_file_is_offered_under_its_own_name(
         (".humanize/flows/three:gen-idea", "Opens a loose idea into a draft."),
         (".humanize/flows/three:build", "builds it, under review"),
     ]
+
+
+def test_an_auxiliary_flow_is_callable_but_not_offered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A composition engine is an API for another flow, not a choice for a person."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project = tmp_path / "project"
+    at = written(project / ".humanize/flows", "composed", AUXILIARY)
+    monkeypatch.chdir(project)
+
+    assert [(one.name, one.selectable) for one in held(at)] == [
+        ("", True),
+        ("engine", False),
+    ]
+    assert [one.name for one in found() if one.whose == "local"] == [
+        ".humanize/flows/composed"
+    ]
+    assert drives("composed:engine") == ("",)
+    agent = ShellAgent(CONFIG)
+    Runner("composed:engine", [agent]).run("echo internal")
+    assert len(agent.opened) == 2
 
 
 def test_which_one_was_asked_for_is_the_half_after_the_colon(tmp_path: Path) -> None:


### PR DESCRIPTION

### Summary

- Add `selectable=False` flow metadata for internal composition entry points. Hidden helpers
  remain callable by name but are omitted from discovery and the flow picker.
- Add opt-in `calls(flow, inherit_skills=True)` behavior for wrappers whose purpose is to extend
  a child flow with reusable capabilities.
- Preserve upstream native resume, validation, cycle-state, and running-flow telemetry behavior
  while composing these two features with it.

### Motivation

A flowverse can factor shared engines and capability wrappers into named flows, but every named
flow currently appears as something a person should start. That exposes implementation details
such as review brokers and parallel engines in the picker.

Called flows also intentionally replace their caller's skills. Isolation is the correct default,
but a capability wrapper needs an explicit way to keep its own skills available while delegating
execution to a child. Repeating the same skill bundle in every child defeats reusable flow
composition.

### Behavior

- `@flow(selectable=False)` changes discovery only. `held()`, `find()`, `drives()`, and
  `calls()` can still resolve the helper.
- `calls(flow)` remains isolated by default.
- With `inherit_skills=True`, child skills come first and win same-name collisions; parent-only
  skills follow them.
- The exact parent skill set is restored after synchronous return, asynchronous return, invalid
  configuration, or an exception.
- Called-flow configuration and goal validation still happen before mounting, preserving the
  upstream rule that a refused call is a call that never happened.
- Called resumable flows still receive their own state through the upstream `_holding()` path,
  and running telemetry still receives the actual driven agents.

### Modified files

- `src/hmz/flows/__init__.py`: add and preserve `Flow.selectable`, then filter only discovery.
- `src/hmz/runner.py`: add explicit isolated/inherited called-skill policies.
- `tests/test_flow_naming.py`: prove hidden helpers are callable but not offered.
- `tests/test_calling_flows.py`: cover inheritance, collisions, restoration, async calls, and
  refused calls.
- `docs/guide/tutorial-calling-flows.md`: document opt-in wrapper inheritance.
- `docs/reference/flows.md`: document hidden helpers and inheritance semantics.

Scope: 6 files, 252 insertions, 6 deletions.

### Compatibility and risk

- Both new options preserve existing behavior by default.
- `resumable` and `selectable` are independent metadata and are both preserved when a module
  docstring supplies a default flow description.
- Skill inheritance is explicit at each call site; reviewer and other isolated child flows do
  not gain caller capabilities accidentally.
- No Kimi-specific code or backend profile changes are included in this PR.

### Validation

- `uv run pre-commit run --all-files`: passed on this branch.
- Flow/calling/resume/TUI focused suite: 72 passed.
- With PR 1 applied as well, the Kaggle composition flowverse suite passes all 55 tests, exposes
  exactly five public workflows, and resolves eight internal flows through `calls()`.

