### PR TITLE
feat(codex): opt a GPT-5.6 Sol agent into the 1M context window

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -92,10 +92,10 @@ An `-a` is missing a part. All three are required:
 The CLI is read from the front and the effort from after the **last** colon. A model with
 slashes in it, such as `kimi/kimi-code/k3:high`, is fine.
 
-### `bad agent '…': foo is not cli, model, effort, provider or permission`
+### `bad agent '…': foo is not cli, model, effort, provider, permission or config.KEY`
 
-The written-out form has a key that is not one of the five it takes: `cli`, `model`, `effort`,
-`provider` and `permission`.
+The written-out form has a key that is not one of the five every backend takes — `cli`,
+`model`, `effort`, `provider` and `permission` — or a `config.KEY` Codex override.
 
 ### `bad agent '…': permission must be one of read-only, workspace-write, auto, bypass, not '…'`
 

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -144,9 +144,29 @@ A config takes `model`, `effort`, an optional [`machine`](#where-the-turns-land)
 [what it may do](#what-an-agent-may-do), [which account it runs as](#which-account-it-runs-as),
 whether [goals](/guide/goals) are available to it, and nothing else — the
 [skills it carries](#the-skills-an-agent-carries) are not among them, being its CLI's own and
-its flow's. It is frozen,
+its flow's. Codex also takes `overrides`, the app-server `-c` keys that are not already one
+of those fields. It is frozen,
 because a session resumes under the settings it opened with — a config that changed mid-flow
 would silently split one conversation across two models.
+
+```python
+from hmz.agents import CodexAgent, CodexAgentConfig
+
+agent = CodexAgent(
+    CodexAgentConfig(
+        model="gpt-5.6-sol",
+        effort="max",
+        overrides=(
+            ("model_context_window", "1000000"),
+            ("model_auto_compact_token_limit", "900000"),
+        ),
+    )
+)
+```
+
+On a command line the same settings are that agent's `config.KEY=VALUE`, not a flag of
+`hmz exec`. Only `model_context_window` and `model_auto_compact_token_limit` are taken. The
+user's `~/.codex/config.toml` is left as it was.
 
 An agent takes an optional `name=`:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,6 +70,7 @@ cli=claude,model=claude-opus-4-8,effort=high
 claude@deepseek/claude-opus-4-8:high
 cli=claude,model=claude-opus-4-8,effort=high,provider=deepseek
 cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only
+cli=codex,model=gpt-5.6-sol,effort=max,config.model_context_window=1000000,config.model_auto_compact_token_limit=900000
 ```
 
 The first two spellings mean the same thing. The written-out form exists because a model or an
@@ -93,6 +94,9 @@ unambiguous short spelling go.
 - `permission=` names [what that agent may do](/reference/agents#what-an-agent-may-do): `read-only`,
   `workspace-write`, `auto` or `bypass`. It is available in the written-out form only and
   defaults to `bypass`. A misspelling is refused before any agent runs.
+- `config.KEY=VALUE` names a Codex app-server `-c` override for **that agent**. Only
+  `model_context_window` and `model_auto_compact_token_limit` are taken, both as a positive
+  integer, and only on `cli=codex`. This is not `hmz exec -c`, which is the flow's YAML.
 
 **One `-a` is one agent.** A list inside a single `-a` is not split into several. Two agents of
 one spelling are two agents, which is what makes a flow of an actor and a reviewer at one

--- a/src/hmz/agents/codex.py
+++ b/src/hmz/agents/codex.py
@@ -33,9 +33,14 @@ from .event import Event, Failed, Question, Usage, say
 from .hooks import EVERYWHERE, Moment, Occasion
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from pydantic import BaseModel
+
+#: `-c` keys this driver may take. They are process configuration of the app server, and
+#: none of them is already a field of AgentConfig -- model, effort and permission are asked
+#: elsewhere, and a second place for them would be two answers.
+_OVERRIDE_KEYS = frozenset({"model_context_window", "model_auto_compact_token_limit"})
 
 #: What the server calls a turn stopping to ask its user something. Every other request it
 #: makes of a client is an approval, which an unattended flow does not stop for.
@@ -735,9 +740,61 @@ class _AppServer:
         return message.get("result")
 
 
+def _overrides(given: Sequence[tuple[str, str]]) -> tuple[tuple[str, str], ...]:
+    """The app-server `-c` pairs, or a reason they cannot be taken.
+
+    Args:
+      given: What was asked for, as ``(key, value)`` in the order it was written.
+
+    Returns:
+      The same pairs, stripped, in that order.
+
+    Raises:
+      ValueError: If a key is not one of :data:`_OVERRIDE_KEYS`, is repeated, is not a
+        positive integer, or the compact limit is not below the context window.
+    """
+    held: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for key, value in given:
+        name, said = key.strip(), value.strip()
+        if name not in _OVERRIDE_KEYS:
+            raise ValueError(
+                f"{name} is not a Codex override; expected "
+                f"{', '.join(sorted(_OVERRIDE_KEYS))}"
+            )
+        if name in seen:
+            raise ValueError(f"{name} was given twice")
+        if not said.isdigit() or int(said) < 1:
+            raise ValueError(f"{name} must be a positive integer, not {value!r}")
+        seen.add(name)
+        held.append((name, said))
+    window = next(
+        (int(said) for name, said in held if name == "model_context_window"), None
+    )
+    compact = next(
+        (int(said) for name, said in held if name == "model_auto_compact_token_limit"),
+        None,
+    )
+    if window is not None and compact is not None and compact >= window:
+        raise ValueError(
+            "model_auto_compact_token_limit must be below model_context_window"
+        )
+    return tuple(held)
+
+
 @dataclass(frozen=True, kw_only=True)
 class CodexAgentConfig(AgentConfig):
-    """What Codex is configured with: the common model and effort, and nothing else."""
+    """What Codex is configured with: the common model and effort, and its app-server `-c`.
+
+    `overrides` is only the keys Codex treats as process configuration and that
+    :class:`AgentConfig` does not already name. They are this agent's, so two Codex agents
+    of one flow may take different windows, and neither writes the user's `config.toml`.
+    """
+
+    overrides: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "overrides", _overrides(self.overrides))
 
 
 class CodexSession(SessionBase):
@@ -974,6 +1031,11 @@ class CodexAgent(AgentBase):
                     # session belonging to the user.
                     argv += ["--disable", "goals"]
                 argv += ["--stdio"]
+                for key, value in getattr(self.config, "overrides", ()):
+                    # The same `-c` Codex's own client takes, scoped to this server: a
+                    # window asked for here is this agent's, and the user's config.toml is
+                    # left exactly as it was.
+                    argv += ["-c", f"{key}={value}"]
                 # Read before the environment is built out of it: a fallback landing
                 # between the two reads would name the account this server is *not* signed
                 # into, and a server that believes it is already elsewhere is one nothing ever

--- a/src/hmz/backends.py
+++ b/src/hmz/backends.py
@@ -1192,7 +1192,9 @@ def named(backend: str) -> Profile | None:
     return next((one for one in profiles() if backend in one.aliases), None)
 
 
-def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
+def read(
+    spec: str,
+) -> tuple[Profile, str, str, str, str | None, tuple[tuple[str, str], ...]]:
     """Reads one `-a` into the backend to drive, what to drive it at, and as whom.
 
     Args:
@@ -1200,12 +1202,14 @@ def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
         where a model or an effort holding the punctuation the short form separates on goes.
         The CLI may name a provider after an `@`, as `claude@deepseek/MODEL:EFFORT`, which is
         the account that agent's turns run as; `provider=` says the same thing written out.
-        The written-out form may also name the agent's permission rung as `permission=`.
+        The written-out form may also name the agent's permission rung as `permission=`, and
+        for Codex only, app-server `-c` overrides as `config.KEY=VALUE`.
 
     Returns:
       The backend, the model, the effort, the provider -- which is "" for an agent that runs
-      as whoever is at this machine already runs its CLI -- and the permission, which is None
-      for an agent that runs at the default rung.
+      as whoever is at this machine already runs its CLI -- the permission, which is None
+      for an agent that runs at the default rung, and the `config.KEY` pairs, which is ()
+      where none were named.
 
     Raises:
       ValueError: If it is neither spelling, or names no backend there is. What it says is
@@ -1213,6 +1217,7 @@ def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
     """
     provider = ""
     permission: str | None = None
+    overrides: list[tuple[str, str]] = []
     if "=" in spec:
         given = {
             key.strip(): value.strip()
@@ -1225,9 +1230,17 @@ def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
             given.pop("provider", ""),
             given.pop("permission", None),
         )
+        for key, value in list(given.items()):
+            if key.startswith("config."):
+                name = key.removeprefix("config.")
+                if not name:
+                    raise ValueError("expected config.KEY=VALUE")
+                overrides.append((name, value))
+                del given[key]
         if given:
             raise ValueError(
-                f"{', '.join(sorted(given))} is not cli, model, effort, provider or permission"
+                f"{', '.join(sorted(given))} is not cli, model, effort, provider, "
+                "permission or config.KEY"
             )
     else:
         # Read from both ends: a model may hold slashes of its own -- Kimi Code's and
@@ -1249,6 +1262,15 @@ def read(spec: str) -> tuple[Profile, str, str, str, str | None]:
         raise ValueError(
             "expected CLI[@PROVIDER]/MODEL:EFFORT or "
             "cli=CLI,model=MODEL,effort=EFFORT[,provider=PROVIDER]"
-            "[,permission=PERMISSION]"
+            "[,permission=PERMISSION][,config.KEY=VALUE]"
         )
-    return profile, model.strip(), effort.strip(), provider.strip(), permission
+    if overrides and profile.name != "codex":
+        raise ValueError("config.KEY is only for Codex")
+    return (
+        profile,
+        model.strip(),
+        effort.strip(),
+        provider.strip(),
+        permission,
+        tuple(overrides),
+    )

--- a/src/hmz/cli/agents.py
+++ b/src/hmz/cli/agents.py
@@ -151,7 +151,14 @@ def _add(
         print("hmz: an agent is written down under a name", file=sys.stderr)
         return 1
     try:
-        profile, model, effort, provider, permission = read(spec)
+        profile, model, effort, provider, permission, overrides = read(spec)
+        if overrides:
+            print(
+                "hmz: config.KEY is a setting of the agent on the line that runs it, "
+                "not of one written down under a name",
+                file=sys.stderr,
+            )
+            return 1
     except ValueError as why:
         print(f"hmz: {spec}: {why}", file=sys.stderr)
         return 1

--- a/src/hmz/runner.py
+++ b/src/hmz/runner.py
@@ -1318,27 +1318,27 @@ telemetry.about("flow", _about)
 
 def read_agent(
     spec: str,
-) -> tuple[backends.Profile, str, str, str, str | None]:
+) -> tuple[backends.Profile, str, str, str, str | None, tuple[tuple[str, str], ...]]:
     """Reads and validates one command-line agent specification.
 
     Args:
       spec: The short or written-out form accepted by ``-a``.
 
     Returns:
-      The backend, model, effort, provider and optional permission rung.
+      The backend, model, effort, provider, optional permission rung, and Codex
+      ``config.KEY`` pairs.
 
     Raises:
       ValueError: If the specification is malformed or names no permission rung there is.
     """
     from .agents import PERMISSIONS
 
-    parsed = backends.read(spec)
-    permission = parsed[-1]
+    profile, model, effort, provider, permission, overrides = backends.read(spec)
     if permission is not None and permission not in PERMISSIONS:
         raise ValueError(
             f"permission must be one of {', '.join(PERMISSIONS)}, not {permission!r}"
         )
-    return parsed
+    return profile, model, effort, provider, permission, overrides
 
 
 def flow_and_agents(
@@ -1387,7 +1387,7 @@ def flow_and_agents(
         metavar="CLI/MODEL:EFFORT",
         help="one agent, repeated once for each the flow drives, in the order it takes "
         "them; also written cli=CLI,model=MODEL,effort=EFFORT with optional "
-        "permission=PERMISSION. CLI is one of "
+        "permission=PERMISSION and, for Codex, config.KEY=VALUE. CLI is one of "
         f"{', '.join(sorted(one.name for one in backends.profiles()))}",
     )
     parser.add_argument(
@@ -1427,24 +1427,24 @@ def flow_and_agents(
     agents: list[AgentBase] = []
     for at, spec in enumerate(args.agents):
         try:
-            profile, model, effort, provider, permission = read_agent(spec)
+            profile, model, effort, provider, permission, overrides = read_agent(spec)
         except ValueError as bad:
             parser.error(f"bad agent {spec!r}: {bad}")
         agent, config = driver(profile.name)
         # Named rather than looked up: an account that is not there is caught by the agent
         # the first time it needs one, which says whose it was and what it was called.
         goals = places[at].goals_default if at < len(places) else True
-        configured = (
-            config(model=model, effort=effort, provider=provider, goals=goals)
-            if permission is None
-            else config(
-                model=model,
-                effort=effort,
-                provider=provider,
-                permission=permission,
-                goals=goals,
+        extra: dict[str, Any] = {}
+        if permission is not None:
+            extra["permission"] = permission
+        if overrides:
+            extra["overrides"] = overrides
+        try:
+            configured = config(
+                model=model, effort=effort, provider=provider, goals=goals, **extra
             )
-        )
+        except ValueError as bad:
+            parser.error(f"bad agent {spec!r}: {bad}")
         agents.append(agent(configured))
     return args.flow, agents, args.task, held
 

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -866,6 +866,74 @@ def test_codex_can_disable_goals_before_its_server_starts(
         agent.new().pursue("the suite passes", suppress=True)
 
 
+def test_codex_passes_allowlisted_overrides_to_its_app_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A window asked for on this agent is this server's `-c`, not the user's config.toml."""
+    started: list[list[str]] = []
+
+    class _Recording:
+        def __init__(
+            self, argv: list[str], env: Mapping[str, str] | None = None
+        ) -> None:
+            del env
+            started.append(argv)
+            self._held: list[Any] = []
+
+        def stop(self) -> None:
+            """Nothing was started, so there is nothing to take down."""
+
+    monkeypatch.setattr(appservers, "_AppServer", _Recording)
+    agent = CodexAgent(
+        CodexAgentConfig(
+            model="gpt-5.6-sol",
+            effort="high",
+            overrides=(
+                ("model_context_window", "1000000"),
+                ("model_auto_compact_token_limit", "900000"),
+            ),
+        )
+    )
+
+    assert agent.server is not None
+    assert started == [
+        [
+            "codex",
+            "app-server",
+            "--stdio",
+            "-c",
+            "model_context_window=1000000",
+            "-c",
+            "model_auto_compact_token_limit=900000",
+        ]
+    ]
+
+
+def test_codex_refuses_an_override_that_is_already_a_setting_of_the_agent() -> None:
+    """model, effort and permission have one place; a second would be two answers."""
+    with pytest.raises(ValueError, match="not a Codex override"):
+        CodexAgentConfig(
+            model="gpt-5.6-sol",
+            effort="high",
+            overrides=(("model", "gpt-5.6-sol"),),
+        )
+    with pytest.raises(ValueError, match="positive integer"):
+        CodexAgentConfig(
+            model="gpt-5.6-sol",
+            effort="high",
+            overrides=(("model_context_window", "1m"),),
+        )
+    with pytest.raises(ValueError, match="below model_context_window"):
+        CodexAgentConfig(
+            model="gpt-5.6-sol",
+            effort="high",
+            overrides=(
+                ("model_context_window", "1000000"),
+                ("model_auto_compact_token_limit", "1000000"),
+            ),
+        )
+
+
 def test_codex_refuses_to_disable_goals_after_its_server_starts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_codex_overrides.py
+++ b/tests/agents/test_codex_overrides.py
@@ -1,0 +1,137 @@
+"""Whether this agent's app-server `-c` is the window Codex itself reports.
+
+The rest of the suite checks that humanize put `-c` on the argv. Only a real
+`codex app-server` can say whether it took the keys: it writes the effective
+window on `task_started`. A value well below the catalog default is used so
+that honouring the override cannot be mistaken for the catalog clamp.
+
+Costs tokens and needs network access, so it only runs with ``pytest --run-agents``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from hmz.agents import CodexAgent, CodexAgentConfig
+
+pytestmark = pytest.mark.agent
+
+#: Below every catalog default this machine has been seen to report (258400), so a
+#: server that ignored `-c` cannot land in this band by accident.
+_ASKED_WINDOW = 50_000
+_ASKED_COMPACT = 40_000
+
+_SESSIONS = Path.home() / ".codex" / "sessions"
+
+
+def _window_in(path: Path) -> int | None:
+    """The window Codex wrote on the first `task_started` in this rollout, if any."""
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            row = cast("dict[str, Any]", json.loads(line))
+        except ValueError:
+            continue
+        raw = row.get("payload")
+        payload = cast("dict[str, Any]", raw) if isinstance(raw, dict) else {}
+        if payload.get("type") != "task_started":
+            continue
+        held = payload.get("model_context_window")
+        if isinstance(held, int):
+            return held
+        if isinstance(held, str) and held.isdigit():
+            return int(held)
+    return None
+
+
+def _window_codex_reported(session_id: str, started: float) -> int:
+    """The effective window Codex recorded for this thread.
+
+    Args:
+      session_id: The thread the turn landed in, as the app server named it.
+      started: Unix time just before the agent was constructed, so an older
+        rollout is not read as this one.
+
+    Returns:
+      The `model_context_window` Codex wrote on `task_started`.
+
+    Raises:
+      AssertionError: If Codex never wrote one for this thread.
+    """
+    found: list[Path] = []
+    if _SESSIONS.is_dir():
+        for path in _SESSIONS.rglob("*.jsonl"):
+            try:
+                if path.stat().st_mtime < started - 2:
+                    continue
+            except OSError:
+                continue
+            found.append(path)
+    for path in found:
+        if (
+            session_id
+            and session_id in path.name
+            and (window := _window_in(path)) is not None
+        ):
+            return window
+    for path in sorted(found, key=lambda item: item.stat().st_mtime, reverse=True):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if session_id and session_id not in text:
+            continue
+        if (window := _window_in(path)) is not None:
+            return window
+    raise AssertionError(
+        f"Codex never reported a context window for thread {session_id!r}"
+    )
+
+
+def _turn(overrides: tuple[tuple[str, str], ...]) -> tuple[str, int]:
+    """One cheap turn on a Codex agent, and the window Codex reported for it."""
+    started = time.time()
+    agent = CodexAgent(
+        CodexAgentConfig(
+            model="gpt-5.6-sol",
+            effort="low",
+            goals=False,
+            overrides=overrides,
+        )
+    )
+    session = agent.new()
+    said = list(session.stream("Reply with exactly: OK. Use no tools."))
+    assert said[-1].kind == "result", said[-1]
+    assert session.id
+    return session.id, _window_codex_reported(session.id, started)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A directory of its own for the turn to work in."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.timeout(600)
+def test_codex_reports_the_window_this_agent_asked_for(workspace: Path) -> None:
+    """`-c` is this server's, and Codex's own `task_started` is what says it took it."""
+    if shutil.which("codex") is None:
+        pytest.skip("codex is not installed here")
+
+    _, window = _turn(
+        (
+            ("model_context_window", str(_ASKED_WINDOW)),
+            ("model_auto_compact_token_limit", str(_ASKED_COMPACT)),
+        )
+    )
+
+    assert _ASKED_COMPACT <= window <= _ASKED_WINDOW, (
+        f"Codex reported {window} after -c model_context_window={_ASKED_WINDOW}; "
+        "the catalog default on this machine has been 258400"
+    )

--- a/tests/test_agents_command.py
+++ b/tests/test_agents_command.py
@@ -116,6 +116,23 @@ def test_a_permission_no_rung_answers_to_is_refused(
     assert "permission must be one of" in capsys.readouterr().err
 
 
+def test_a_codex_override_is_not_written_down_under_a_name(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`config.KEY` is of the line that runs the agent; a saved name has nowhere to keep it."""
+    assert (
+        run(
+            "add",
+            "wide",
+            "cli=codex,model=gpt-5.6-sol,effort=high,config.model_context_window=1000000",
+        )
+        == 1
+    )
+
+    assert "not of one written down under a name" in capsys.readouterr().err
+    assert Templates().all() == []
+
+
 def test_one_is_taken_away_and_the_rest_are_left(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -38,15 +38,16 @@ def test_a_home_shared_with_every_program_keeps_its_own_directory_under_it(
 
 
 def test_an_agent_is_read_off_a_command_line_however_it_is_spelled() -> None:
-    profile, model, effort, provider, permission = backends.read(
+    profile, model, effort, provider, permission, overrides = backends.read(
         "pi/openai-codex/gpt-5.5:high"
     )
     assert (profile.name, model, effort) == ("pi", "openai-codex/gpt-5.5", "high")
     assert provider == ""  # as whoever is at this machine already runs it
     assert permission is None  # at the default rung
-    profile, model, effort, _, _ = backends.read("mimocode/xiaomi/mimo-v2.5:low")
+    assert overrides == ()
+    profile, model, effort, _, _, _ = backends.read("mimocode/xiaomi/mimo-v2.5:low")
     assert (profile.name, model, effort) == ("mimo", "xiaomi/mimo-v2.5", "low")
-    profile, model, effort, _, _ = backends.read(
+    profile, model, effort, _, _, _ = backends.read(
         "cli=opencode,model=opencode/big-pickle,effort=xhigh"
     )
     assert (profile.name, model, effort) == ("opencode", "opencode/big-pickle", "xhigh")
@@ -54,7 +55,7 @@ def test_an_agent_is_read_off_a_command_line_however_it_is_spelled() -> None:
 
 def test_an_agent_may_name_the_account_it_runs_as() -> None:
     """Two agents of one CLI are two accounts when the line says so, either way it is written."""
-    profile, model, effort, provider, _ = backends.read(
+    profile, model, effort, provider, _, _ = backends.read(
         "claude@deepseek/claude-opus-5:high"
     )
     assert (profile.name, model, effort, provider) == (
@@ -63,27 +64,28 @@ def test_an_agent_may_name_the_account_it_runs_as() -> None:
         "high",
         "deepseek",
     )
-    _, _, _, provider, _ = backends.read(
+    _, _, _, provider, _, _ = backends.read(
         "cli=claude,model=claude-opus-5,effort=high,provider=work"
     )
     assert provider == "work"
     # A CLI is never spelled with an `@` in it, so the model keeps whatever it holds.
-    profile, model, _, provider, _ = backends.read("kimi@mine/kimi-code/k3:max")
+    profile, model, _, provider, _, _ = backends.read("kimi@mine/kimi-code/k3:max")
     assert (profile.name, model, provider) == ("kimi", "kimi-code/k3", "mine")
 
 
 def test_an_agent_may_name_its_permission_rung() -> None:
     """Only the written-out form has somewhere unambiguous to put the fourth setting."""
-    profile, model, effort, provider, permission = backends.read(
+    profile, model, effort, provider, permission, overrides = backends.read(
         "cli=codex,model=gpt-5.6-sol,effort=high,permission=read-only"
     )
 
-    assert (profile.name, model, effort, provider, permission) == (
+    assert (profile.name, model, effort, provider, permission, overrides) == (
         "codex",
         "gpt-5.6-sol",
         "high",
         "",
         "read-only",
+        (),
     )
 
 
@@ -92,6 +94,25 @@ def test_a_backend_nobody_has_heard_of_is_a_line_to_correct() -> None:
     with pytest.raises(ValueError, match="expected CLI"):
         backends.read("nope/model:high")
     with pytest.raises(
-        ValueError, match="not cli, model, effort, provider or permission"
+        ValueError,
+        match=r"not cli, model, effort, provider, permission or config\.KEY",
     ):
         backends.read("cli=claude,model=m,effort=high,machine=elsewhere")
+
+
+def test_a_codex_agent_may_name_app_server_overrides() -> None:
+    """`config.KEY` is that agent's, and only Codex has an app server that takes `-c`."""
+    profile, _, _, _, _, overrides = backends.read(
+        "cli=codex,model=gpt-5.6-sol,effort=high,"
+        "config.model_context_window=1000000,"
+        "config.model_auto_compact_token_limit=900000"
+    )
+    assert profile.name == "codex"
+    assert overrides == (
+        ("model_context_window", "1000000"),
+        ("model_auto_compact_token_limit", "900000"),
+    )
+    with pytest.raises(ValueError, match="only for Codex"):
+        backends.read(
+            "cli=claude,model=m,effort=high,config.model_context_window=1000000"
+        )

--- a/tests/test_flow_config.py
+++ b/tests/test_flow_config.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import pytest
 from pydantic import BaseModel, Field
 
-from hmz.agents import AgentConfig
+from hmz.agents import AgentConfig, CodexAgentConfig
 from hmz.runner import (
     NotAFlow,
     Runner,
@@ -210,6 +210,30 @@ def test_the_exec_line_reads_the_config_it_names(tmp_path: Path) -> None:
     assert held == {"rounds": 7}
     assert len(agents) == 1
     assert task == "go"
+
+
+def test_the_exec_line_gives_a_codex_agent_its_own_overrides() -> None:
+    """`config.KEY` is that `-a`, not a flag of the process starting every agent."""
+    _, agents, _, _ = flow_and_agents(
+        [
+            "-f",
+            "flow",
+            "-a",
+            (
+                "cli=codex,model=gpt-5.6-sol,effort=high,"
+                "config.model_context_window=1000000,"
+                "config.model_auto_compact_token_limit=900000"
+            ),
+            "go",
+        ]
+    )
+
+    held = agents[0].config
+    assert isinstance(held, CodexAgentConfig)
+    assert held.overrides == (
+        ("model_context_window", "1000000"),
+        ("model_auto_compact_token_limit", "900000"),
+    )
 
 
 def test_the_exec_line_without_a_config_says_nothing_about_one(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- GPT-5.6 Sol's 1M context is opt-in, not the Codex default. Tibo documented the two keys: https://x.com/thsottiaux/status/2089082893804896524
- A Codex `-a` can now name `config.model_context_window` and `config.model_auto_compact_token_limit`; they become that agent's `codex app-server -c` and do not write `~/.codex/config.toml`.
- Unknown keys, non-Codex CLIs, and `hmz agents add` refuse closed.

## Test plan
- [x] `uv run pre-commit run --all-files`
- [x] Parser / argv / exec-line / saved-agent tests
- [x] `uv run pytest --run-agents tests/agents/test_codex_overrides.py` (Codex reported 47500 for a 50k ask; default stayed 258400; a 1M ask was catalog-clamped to 828400 on this machine)