### PR TITLE
feat(claude): pass native allowed tool rules

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -145,7 +145,8 @@ A config takes `model`, `effort`, an optional [`machine`](#where-the-turns-land)
 whether [goals](/guide/goals) are available to it, and nothing else — the
 [skills it carries](#the-skills-an-agent-carries) are not among them, being its CLI's own and
 its flow's. Codex also takes `overrides`, the app-server `-c` keys that are not already one
-of those fields. It is frozen,
+of those fields. Claude takes `allowed_tools`, exact native `--allowedTools` rules for a
+bounded unattended flow. It is frozen,
 because a session resumes under the settings it opened with — a config that changed mid-flow
 would silently split one conversation across two models.
 
@@ -167,6 +168,15 @@ agent = CodexAgent(
 On a command line the same settings are that agent's `config.KEY=VALUE`, not a flag of
 `hmz exec`. Only `model_context_window` and `model_auto_compact_token_limit` are taken. The
 user's `~/.codex/config.toml` is left as it was.
+
+Claude's exact native allow rule is configured the same way and is handed to
+`--allowedTools`; it does not widen the agent's permission rung:
+
+```sh
+hmz exec -f flow.py:run \
+    -a 'cli=claude,model=claude-opus-5,effort=max,permission=workspace-write,config.allowed_tools=Bash(git diff *)' \
+    task
+```
 
 An agent takes an optional `name=`:
 

--- a/src/hmz/agents/claude.py
+++ b/src/hmz/agents/claude.py
@@ -33,6 +33,10 @@ _CONTINUATION_TOOLS = (
     "CronList",
 )
 
+_ALLOWED_TOOLS_MAX = 32
+
+_ALLOWED_TOOL_RULE_MAX_CHARS = 4096
+
 #: Reasons that leave an answer unfinished even when a broken intermediary labels the result
 #: `success`. Claude normally keeps its own agent loop going for these rather than returning
 #: them as the result of the whole turn.
@@ -125,7 +129,20 @@ def _result_failure(said: dict[str, Any]) -> str | None:
 
 @dataclass(frozen=True, kw_only=True)
 class ClaudeCodeAgentConfig(AgentConfig):
-    """What Claude Code is configured with: the common model and effort, and nothing else."""
+    """The common settings plus exact Claude-native tool allow rules."""
+
+    allowed_tools: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if (
+            len(self.allowed_tools) > _ALLOWED_TOOLS_MAX
+            or self.allowed_tools != tuple(sorted(set(self.allowed_tools)))
+            or any(
+                not rule or len(rule) > _ALLOWED_TOOL_RULE_MAX_CHARS or "," in rule
+                for rule in self.allowed_tools
+            )
+        ):
+            raise ValueError("allowed_tools must be unique sorted Claude tool rules")
 
 
 class ClaudeCodeSession(StreamSessionBase):
@@ -213,6 +230,9 @@ class ClaudeCodeSession(StreamSessionBase):
             # wakeup, anything on the scheduler. Everything else it may reach for is what its
             # permission rung says it may, exactly as before.
             argv += ["--disallowedTools", ",".join(_CONTINUATION_TOOLS)]
+        allowed_tools = getattr(self._agent.config, "allowed_tools", ())
+        if allowed_tools:
+            argv += ["--allowedTools", ",".join(allowed_tools)]
         return argv
 
     def _write(self, text: str, ticket: str = "") -> str:

--- a/src/hmz/backends.py
+++ b/src/hmz/backends.py
@@ -1203,7 +1203,8 @@ def read(
         The CLI may name a provider after an `@`, as `claude@deepseek/MODEL:EFFORT`, which is
         the account that agent's turns run as; `provider=` says the same thing written out.
         The written-out form may also name the agent's permission rung as `permission=`, and
-        for Codex only, app-server `-c` overrides as `config.KEY=VALUE`.
+        backend-native settings as `config.KEY=VALUE`. Codex accepts app-server overrides;
+        Claude accepts one exact `allowed_tools` rule.
 
     Returns:
       The backend, the model, the effort, the provider -- which is "" for an agent that runs
@@ -1264,8 +1265,12 @@ def read(
             "cli=CLI,model=MODEL,effort=EFFORT[,provider=PROVIDER]"
             "[,permission=PERMISSION][,config.KEY=VALUE]"
         )
-    if overrides and profile.name != "codex":
-        raise ValueError("config.KEY is only for Codex")
+    if overrides and profile.name not in {"claude", "codex"}:
+        raise ValueError("config.KEY is only for Claude or Codex")
+    if profile.name == "claude" and any(
+        key != "allowed_tools" for key, _value in overrides
+    ):
+        raise ValueError("Claude config only accepts allowed_tools")
     return (
         profile,
         model.strip(),

--- a/src/hmz/runner.py
+++ b/src/hmz/runner.py
@@ -1325,8 +1325,8 @@ def read_agent(
       spec: The short or written-out form accepted by ``-a``.
 
     Returns:
-      The backend, model, effort, provider, optional permission rung, and Codex
-      ``config.KEY`` pairs.
+      The backend, model, effort, provider, optional permission rung, and
+      backend-native ``config.KEY`` pairs.
 
     Raises:
       ValueError: If the specification is malformed or names no permission rung there is.
@@ -1387,7 +1387,7 @@ def flow_and_agents(
         metavar="CLI/MODEL:EFFORT",
         help="one agent, repeated once for each the flow drives, in the order it takes "
         "them; also written cli=CLI,model=MODEL,effort=EFFORT with optional "
-        "permission=PERMISSION and, for Codex, config.KEY=VALUE. CLI is one of "
+        "permission=PERMISSION and backend-native config.KEY=VALUE. CLI is one of "
         f"{', '.join(sorted(one.name for one in backends.profiles()))}",
     )
     parser.add_argument(
@@ -1437,8 +1437,10 @@ def flow_and_agents(
         extra: dict[str, Any] = {}
         if permission is not None:
             extra["permission"] = permission
-        if overrides:
+        if overrides and profile.name == "codex":
             extra["overrides"] = overrides
+        elif overrides:
+            extra["allowed_tools"] = tuple(value for _key, value in overrides)
         try:
             configured = config(
                 model=model, effort=effort, provider=provider, goals=goals, **extra

--- a/tests/agents/test_permissions.py
+++ b/tests/agents/test_permissions.py
@@ -87,6 +87,29 @@ def test_an_agent_nobody_was_asked_about_is_allowed_everything() -> None:
     assert ClaudeCodeAgentConfig(model="m", effort="high").permission == "bypass"
 
 
+def test_claude_is_given_its_exact_native_allowed_tool_rules() -> None:
+    session = ClaudeCodeAgent(
+        ClaudeCodeAgentConfig(
+            model="m",
+            effort="high",
+            permission="workspace-write",
+            allowed_tools=("Bash(git diff *)",),
+        )
+    ).new()
+    argv = session._command()
+    assert argv.count("--allowedTools") == 1
+    assert argv[argv.index("--allowedTools") + 1] == "Bash(git diff *)"
+
+
+def test_claude_allowed_tool_rules_are_canonical() -> None:
+    with pytest.raises(ValueError, match="unique sorted"):
+        ClaudeCodeAgentConfig(
+            model="m",
+            effort="high",
+            allowed_tools=("Read", "Read"),
+        )
+
+
 @pytest.mark.parametrize(
     ("permission", "mode"),
     [("read-only", "plan"), ("workspace-write", "acceptEdits"), ("auto", "auto")],

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -101,7 +101,7 @@ def test_a_backend_nobody_has_heard_of_is_a_line_to_correct() -> None:
 
 
 def test_a_codex_agent_may_name_app_server_overrides() -> None:
-    """`config.KEY` is that agent's, and only Codex has an app server that takes `-c`."""
+    """`config.KEY` is that agent's, and Codex passes its pairs to app-server `-c`."""
     profile, _, _, _, _, overrides = backends.read(
         "cli=codex,model=gpt-5.6-sol,effort=high,"
         "config.model_context_window=1000000,"
@@ -112,7 +112,16 @@ def test_a_codex_agent_may_name_app_server_overrides() -> None:
         ("model_context_window", "1000000"),
         ("model_auto_compact_token_limit", "900000"),
     )
-    with pytest.raises(ValueError, match="only for Codex"):
+    with pytest.raises(ValueError, match="only accepts allowed_tools"):
         backends.read(
             "cli=claude,model=m,effort=high,config.model_context_window=1000000"
         )
+
+
+def test_a_claude_agent_may_name_one_native_allowed_tools_rule() -> None:
+    profile, _, _, _, _, overrides = backends.read(
+        "cli=claude,model=claude-opus-5,effort=max,"
+        "config.allowed_tools=Bash(git diff *)"
+    )
+    assert profile.name == "claude"
+    assert overrides == (("allowed_tools", "Bash(git diff *)"),)

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -83,6 +83,23 @@ def run(agents: tuple[AgentBase, AgentBase], task: str) -> None:
     )
 """
 
+#: A flow proving that one backend-native command-line setting reaches the
+#: concrete Claude config rather than being treated as a Codex override.
+CLAUDE_NATIVE_CONFIG = """
+import json
+from pathlib import Path
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    Path(__file__).with_suffix(".json").write_text(
+        json.dumps(list(agents[0].config.allowed_tools))
+    )
+"""
+
 #: The same flow, declaring its agents as a named tuple: as many as there are places, and what
 #: each of them is for. It reaches them by name to prove it was handed the type it asked for.
 NAMED = """
@@ -263,6 +280,23 @@ def test_an_agent_may_be_given_a_permission_rung(
     )
 
     assert json.loads((tmp_path / "flow.json").read_text()) == [permission, "bypass"]
+
+
+def test_a_claude_agent_receives_its_native_allowed_tools_rule(
+    tmp_path: Path,
+) -> None:
+    flow = _flow(tmp_path, CLAUDE_NATIVE_CONFIG)
+    main(
+        [
+            "exec",
+            "-f",
+            flow,
+            "-a",
+            ("cli=claude,model=m,effort=high,config.allowed_tools=Bash(git diff *)"),
+            "task",
+        ]
+    )
+    assert json.loads((tmp_path / "flow.json").read_text()) == ["Bash(git diff *)"]
 
 
 def test_a_named_tuple_says_what_each_agent_is_for_as_well_as_how_many(


### PR DESCRIPTION
## Summary

- accept one bounded Claude-native `config.allowed_tools` rule in agent specs
- validate and pass the rule through as Claude Code `--allowedTools`
- preserve the existing permission rung and continuation-tool deny rules
- document the setting and cover parsing, permissions, and command construction

## Verification

- `uv run pre-commit run --all-files` passed
- targeted tests: 79 passed
- full suite under root: 1460 passed, 70 skipped, with only the root-specific chmod smoke failing because root can read mode-000 files
- that exact permission smoke passes when run as the unprivileged `nobody` user
