### PR TITLE
fix(tui): make agent and flow saves explicit

### DIFF
--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -132,7 +132,7 @@ list appears under the editor with a line about each.
 
 | Command | Takes | What it does |
 | --- | --- | --- |
-| `/flow` | `[flow]` | The menu of two pages: [which flow runs](#choosing-a-flow) and [what each of its agents is](#what-each-agent-is). With a name or a path, opens already holding that one — and is refused outright while a flow is running, since that name would be choosing one. Without a name it opens on the agents page, which is never shut. Nothing lands until you save on the way out. |
+| `/flow` | `[flow]` | The menu of two pages: [which flow runs](#choosing-a-flow) and [what each of its agents is](#what-each-agent-is). With a name or a path, opens already holding that one — and is refused outright while a flow is running, since that name would be choosing one. Without a name it opens on the agents page, which is never shut. Its Agents page saves the complete setup; esc remains the way to save or discard on the way out. |
 | `/flowverses` | | [Where flows come from](/guide/flowverses): what places there are, what one of them holds, and one added, fetched again or taken away. Not which flow to run — that is `/flow`, where the arrows step between the same places. |
 | `/agents` | | [The agents saved under a name](#agents-kept-under-a-name), to be imported wherever a flow's agent is set up. Not the agents of the flow — those are the second page of `/flow`. |
 | `/cycles` | | The runs of this directory, newest first: what each was, how it went, and what there is to do with one — gather its [trace](/guide/tracing), say where it is written, and carry it on where its flow says it can be picked up. |
@@ -321,10 +321,11 @@ true of all of them:
   a modifier held down.
 - **Typing does not search.** Every letter is a key, so a search is asked for with **s** and
   left with **esc**, which clears what was typed. While one is running the letters go into it.
-- **Nothing lands until you save on the way out.** Esc asks — a box in the middle of the
-  screen, over the menu rather than instead of it, with the two answers there are: save and
-  close, or discard and close. Esc on the box is the way back to the menu. A menu you only
-  looked at asks nothing.
+- **Nothing lands until you save.** `/flow` has a `save` row on its Agents page for the
+  complete flow setup. Esc remains available on every menu: it asks in a box in the middle of
+  the screen, over the menu rather than instead of it, whether to save and close or discard
+  and close. Esc on the box is the way back to the menu. A menu you only looked at asks
+  nothing.
 
 `/cycles` and `/flowverses` are lists of the same kind, and the first two are true of them as
 well. The third is not: neither holds a draft of anything, so what is asked for there happens
@@ -377,7 +378,8 @@ and taking one away are [`/flowverses`](#where-flows-come-from).
 
 Choosing a flow reads back what that flow was last set up with here, asks
 [what the flow itself takes](#setting-a-flow-up) where it takes anything, and lands on the
-**Agents** page, which is the next thing to answer.
+**Agents** page, which is the next thing to answer. Its last row, `save`, validates every
+agent and applies the flow and all its agents together.
 
 **The Flow page is shut while a flow is running** — a flow is chosen in order to be started,
 and there is one going. The Agents page never is: an agent thinking too little, on the wrong
@@ -439,8 +441,7 @@ enter opens one. Everything that agent is is a row of one sheet:
   Set up builder
 
   What this one agent is. Enter opens the row under the cursor, and the arrows step the ones
-  that are a rung rather than a list. Nothing is applied until this sheet is left and saving is
-  confirmed.
+  that are a rung rather than a list. Save accepts this setup; save as keeps a reusable copy.
 
     1. import       ▸                          copy a saved agent into this one
   ❯ 2. cli          claude ▸                   which coding agent takes its turns
@@ -451,7 +452,8 @@ enter opens one. Everything that agent is is a row of one sheet:
     7. permission   bypass                     what it may do without being asked
     8. goals        on                         whether the backend's own goals are available
     9. where        this machine ▸             the machine its work lands on
-   10. save         ▸                          save this as an agent you can import
+   10. save                                    accept this agent setup
+   11. save as      ▸                          save a reusable agent you can import
 
   Enter to open · Esc to close
 ```
@@ -471,8 +473,10 @@ a row only for an agent [the flow says may be pointed at a machine](#where-each-
 for one the flow put in a container it is read rather than opened, and for one that works here
 it is not there at all.
 
-Esc off the sheet asks about anything you changed and hands it back to the menu, which is still
-holding it: nothing is written down until the menu itself is saved.
+`save` accepts this agent and returns straight to the flow's Agents page. It changes only the
+flow draft; the complete setup is written down when `save` is chosen on that outer page.
+`save as` instead asks for a name and immediately keeps a reusable copy without applying the
+flow. Esc off the agent sheet remains a fallback: it asks whether to accept or discard changes.
 
 ## Which CLI, and which account
 
@@ -544,13 +548,17 @@ what it may do — none of which is a thing about the flow that happens to be dr
 | `a` | Add one. It has a `name` row of its own, which a flow's agent has not. |
 | `d` `d` | Take one away. |
 
+The setup sheet for a named agent also ends with `save`, which accepts that agent and returns
+to this list. The outer menu still holds all additions, edits and removals together until the
+menu itself is saved.
+
 They live in `~/.humanize/agents.yaml`, and land there when the menu is saved. The same store
 is on the command line as [`hmz agents`](/reference/cli#hmz-agents), for a machine being set up or a
 CI job.
 
 **A flow imports a copy.** The `import` row of a flow's agent copies everything the saved one
-is; changing it afterwards changes that flow's agent alone. The `save` row is the other half:
-what you tuned inside a flow, written down under a new name or over one already there.
+is; changing it afterwards changes that flow's agent alone. The `save as` row is the other
+half: what you tuned inside a flow, written down under a new name or over one already there.
 
 ## Where each agent works
 

--- a/src/hmz/tui/pick.py
+++ b/src/hmz/tui/pick.py
@@ -989,6 +989,7 @@ _HALVES = "\x1f"
 
 #: The pages the flow menu is, in the order they are turned between.
 _FLOW_PAGE, _AGENT_PAGE = 0, 1
+_SAVE = "save"
 
 
 #: What this project's own flows are listed under, which is where a copy of one lands: the
@@ -1019,8 +1020,8 @@ class Flows(Drafts[Chosen]):
     settings is chosen in order to be run with settings, and the moment it is chosen is the
     one moment somebody is thinking about that flow rather than about its agents.
 
-    Nothing is applied by turning a page or by walking out. What the menu holds is a draft of
-    the whole of it, and it lands when it is saved on the way out.
+    Nothing is applied by turning a page. What the menu holds is a draft of the whole of it,
+    and it lands together from the save row or when saving is confirmed on the way out.
     """
 
     TABS: ClassVar = ("Flow", "Agents")
@@ -1228,7 +1229,7 @@ class Flows(Drafts[Chosen]):
             if self._tab == _FLOW_PAGE
             else f"What each agent {escape(self._flow)} drives is: the CLI that takes its "
             "turns, the account they run as, the model at an effort, and what it may do. "
-            "Enter opens one. Nothing lands until this menu is saved on the way out."
+            "Enter opens one, and save applies the complete flow setup."
         )
         if self._tab != _FLOW_PAGE:
             self.tabbed(self._tab_line())
@@ -1429,13 +1430,14 @@ class Flows(Drafts[Chosen]):
         return ""
 
     def _agents_page(self) -> None:
-        """Puts up one row per agent the flow drives, and what each of them is now."""
+        """Puts up each agent the flow drives, followed by saving the complete setup."""
         listing = self.query_one("#choices", OptionList)
         named = tuple(place.name for place in self._places)
         lines = reads(named, self._runs)
-        self._counting = len(str(max(len(self._places), 1)))
-        at = min(listing.highlighted or 0, max(len(self._places) - 1, 0))
-        listing.set_options(
+        total = len(self._places) + 1
+        self._counting = len(str(total))
+        at = min(listing.highlighted or 0, total - 1)
+        rows = [
             Option(
                 self._row(
                     seen,
@@ -1449,14 +1451,31 @@ class Flows(Drafts[Chosen]):
                 id=f"={seen}",
             )
             for seen in range(len(self._places))
+        ]
+        rows.append(
+            Option(
+                self._row(
+                    len(self._places),
+                    _SAVE,
+                    "save the flow and all of its agents",
+                    here=at == len(self._places),
+                    inforce=False,
+                ),
+                id=f"={_SAVE}",
+            )
         )
-        listing.highlighted = at if self._places else None
+        listing.set_options(rows)
+        listing.highlighted = at
         self._drawn = listing.highlighted
         said = self._said or ("" if self._places else self._noagents())
         self.query_one("#tuning", Label).update(
             f"[$text-muted]{said}[/]" if said else ""
         )
-        self.query_one("#keys", Label).update("Enter to set one up · Esc to close")
+        self.query_one("#keys", Label).update(
+            "Enter to save · Esc to close"
+            if at == len(self._places)
+            else "Enter to set one up · Esc to close"
+        )
 
     def _noagents(self) -> str:
         """Why there is no agent to set up, which is not always the same reason."""
@@ -1572,7 +1591,15 @@ class Flows(Drafts[Chosen]):
             if name:
                 self._chose(name)
             return
-        self._configuring(int(str(event.option.id or "=0").removeprefix("=")))
+        held = str(event.option.id or "").removeprefix("=")
+        if held == _SAVE:
+            self.applied()
+            return
+        try:
+            at = int(held)
+        except ValueError:
+            return
+        self._configuring(at)
 
     def _chose(self, name: str) -> None:
         """Takes a flow as the one to run, and reads back what it was last set up with.
@@ -4239,7 +4266,7 @@ _SKILLS = "skills"
 _PERMIT = "permission"
 _GOALS = "goals"
 _WHERE = "where"
-_SAVE = "save"
+_SAVE_AS = "save as"
 
 #: Which of them are stepped along where they stand rather than opened, and which are opened.
 _STEPPED = (_EFFORT, _SWARM, _PERMIT, _GOALS)
@@ -4259,9 +4286,9 @@ class Agent(Drafts[Fitted]):
     settles which of them it may name. Changing the CLI therefore lets go of the model, which
     belonged to the CLI before it.
 
-    A saved agent can be copied in at the top and saved out at the bottom. What is imported is
-    a copy: an agent tuned inside a flow is that flow's, and writing the changes back into the
-    thing it was copied from would change every other flow that had imported it.
+    A saved agent can be copied in at the top and saved as a reusable copy at the bottom. What
+    is imported is a copy: an agent tuned inside a flow is that flow's, and writing the changes
+    back into the thing it was copied from would change every other flow that had imported it.
     """
 
     BINDINGS: ClassVar = [
@@ -4334,10 +4361,14 @@ class Agent(Drafts[Fitted]):
     def _ask(self) -> None:
         """Says whose agent this is, and what setting it up settles."""
         self.query_one("#asked", Label).update(f"Set up {escape(self._named)}")
+        saving = (
+            "Save accepts this setup; save as keeps a reusable copy."
+            if self._place is not None
+            else "Save accepts this setup."
+        )
         self.query_one("#about", Label).update(
             "What this one agent is. Enter opens the row under the cursor, and the arrows "
-            "step the ones that are a rung rather than a list. Nothing is applied until this "
-            "sheet is left and saving is confirmed."
+            f"step the ones that are a rung rather than a list. {saving}"
         )
         self._fill()
         self.query_one("#choices", OptionList).focus()
@@ -4398,8 +4429,9 @@ class Agent(Drafts[Fitted]):
             )
         elif image := _settled(self._place):
             rows.append((_WHERE, f"in a container of {image}", "the flow settled this"))
-        if not self._is_named:
-            rows.append((_SAVE, "", "save this as an agent you can import"))
+        rows.append((_SAVE, "", "accept this agent setup"))
+        if self._place is not None:
+            rows.append((_SAVE_AS, "", "save a reusable agent you can import"))
         return rows
 
     def _fill(self) -> None:
@@ -4426,6 +4458,10 @@ class Agent(Drafts[Fitted]):
             if held in _STEPPED
             else "Type to name it · Esc to close"
             if held == _NAME
+            else "Enter to save · Esc to close"
+            if held == _SAVE
+            else "Enter to save a copy · Esc to close"
+            if held == _SAVE_AS
             else "Enter to open · Esc to close"
         )
 
@@ -4448,7 +4484,7 @@ class Agent(Drafts[Fitted]):
         # opened: without it a blank name reads as a row nothing can be typed into.
         caret = "[reverse] [/reverse]" if here and held == _NAME else ""
         # A row that opens something says so, as a menu anywhere says it.
-        opens = "" if held in _STEPPED or held == _NAME else " ▸"
+        opens = "" if held in _STEPPED or held in (_NAME, _SAVE) else " ▸"
         # Padded on what is shown rather than on what is written: markup is not columns.
         named = escape(held) + " " * max(1, _ASPECT - len(held))
         room = _HOW - len(value) - len(opens) - (1 if caret else 0)
@@ -4597,7 +4633,10 @@ class Agent(Drafts[Fitted]):
         if held in _STEPPED:
             self._step(-1)
             return
-        if held in (_CLI, _ACCOUNT, _MODEL, _SKILLS, _WHERE, _IMPORT, _SAVE):
+        if held == _SAVE:
+            self.applied()
+            return
+        if held in (_CLI, _ACCOUNT, _MODEL, _SKILLS, _WHERE, _IMPORT, _SAVE_AS):
             self._opens(held)
 
     @work
@@ -4623,8 +4662,8 @@ class Agent(Drafts[Fitted]):
             await self._chose_where(showing)
         elif held == _IMPORT:
             await self._imports(showing)
-        else:
-            await self._saves(showing)
+        elif held == _SAVE_AS:
+            await self._saves_as(showing)
         self._fill()
 
     async def _chose_cli(self, showing: App[None]) -> None:
@@ -4730,7 +4769,7 @@ class Agent(Drafts[Fitted]):
         )
         self.changed()
 
-    async def _saves(self, showing: App[None]) -> None:
+    async def _saves_as(self, showing: App[None]) -> None:
         """Writes this agent down under a name, new or one already there."""
         from hmz.kept import Templates
 

--- a/tests/tui/test_agent_sheet.py
+++ b/tests/tui/test_agent_sheet.py
@@ -175,6 +175,7 @@ async def test_one_agent_is_one_sheet_of_rows_in_the_order_they_depend(
             "goals",
             "where",
             "save",
+            "save as",
         ]
         # The account nobody chose is always the first row of the list it is chosen from.
         assert "as local" in _value(app, "provider")
@@ -196,9 +197,9 @@ async def test_two_agents_are_two_rows_and_a_sheet_apiece(
         await driver.press("tab")
         await until(lambda: sheet._tab == 1, driver)
         listing = sheet.query_one("#choices", OptionList)
-        await until(lambda: len(listing.options) == 2, driver)
+        await until(lambda: len(listing.options) == 3, driver)
 
-        assert rows(app) == ["0", "1"]
+        assert rows(app) == ["0", "1", "save"]
         assert "builder" in str(listing.get_option_at_index(0).prompt)
         assert "reviewer" in str(listing.get_option_at_index(1).prompt)
 
@@ -213,6 +214,74 @@ async def test_two_agents_are_two_rows_and_a_sheet_apiece(
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Agent), driver)
         assert "reviewer" in _asked(app)
+
+
+@pytest.mark.timeout(60)
+@unittest.mock.patch("hmz.tui.app.installed", return_value=CLAUDE)
+async def test_explicit_saves_accept_two_agents_then_apply_the_complete_flow(
+    _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
+    flows: Path,
+    tmp_path: Path,
+) -> None:
+    """A two-agent flow can be set up and saved without backing through either sheet."""
+    app = Humanize()
+    async with app.run_test() as driver:
+        await _open(app, driver, "pair")
+        await onto(app, driver, "effort")
+        await driver.press("left")
+        await driver.pause()
+
+        await opens(app, driver, "save")
+        await until(lambda: isinstance(app.screen, Flows), driver)
+        assert rows(app) == ["0", "1", "save"]
+
+        await onto(app, driver, "1")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Agent), driver)
+        await onto(app, driver, "effort")
+        await driver.press("right")
+        await driver.pause()
+        await opens(app, driver, "save")
+        await until(lambda: isinstance(app.screen, Flows), driver)
+
+        await onto(app, driver, "save")
+        await driver.press("enter")
+        await until(lambda: not isinstance(app.screen, Flows), driver)
+
+    chosen = [
+        Runs("claude/claude-opus-5:high"),
+        Runs("claude/claude-opus-5:max"),
+    ]
+    assert app._flow_named == "pair"
+    assert app._models == chosen
+    assert Settings(tmp_path).agents("pair") == chosen
+
+
+@pytest.mark.timeout(60)
+@unittest.mock.patch("hmz.tui.app.installed", return_value={})
+async def test_explicit_flow_save_refuses_an_agent_with_no_model(
+    _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
+    flows: Path,
+) -> None:
+    """The save row uses the same completeness check as saving on the way out."""
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/flow here")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Flows), driver)
+        sheet = cast("Flows", app.screen)
+        if sheet._tab != 1:
+            await driver.press("tab")
+            await until(lambda: sheet._tab == 1, driver)
+
+        await onto(app, driver, "save")
+        await driver.press("enter")
+        await driver.pause()
+
+        assert app.screen is sheet
+        assert "builder has no model yet" in str(
+            sheet.query_one("#tuning", Label).content
+        )
 
 
 @pytest.mark.timeout(60)

--- a/tests/tui/test_saved_agents.py
+++ b/tests/tui/test_saved_agents.py
@@ -104,6 +104,31 @@ async def test_one_is_added_named_and_written_down_when_the_menu_is_saved(
 
 @pytest.mark.timeout(60)
 @unittest.mock.patch("hmz.tui.app.installed", return_value=CLAUDE)
+async def test_save_accepts_a_named_agent_without_backing_out(
+    _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
+) -> None:
+    """The explicit action returns to the outer draft, which still saves the complete list."""
+    Templates().keep([Kept("reviewer", Runs("claude/claude-opus-5:max"))])
+    app = Humanize()
+    async with app.run_test() as driver:
+        await _into_saved(app, driver)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Agent), driver)
+
+        await onto(app, driver, "effort")
+        await driver.press("left")
+        await driver.pause()
+        await opens(app, driver, "save")
+        await until(lambda: isinstance(app.screen, Saved), driver)
+
+        assert Templates().all()[0].runs == Runs("claude/claude-opus-5:max")
+        await keeps(app, driver)
+
+    assert Templates().all()[0].runs == Runs("claude/claude-opus-5:high")
+
+
+@pytest.mark.timeout(60)
+@unittest.mock.patch("hmz.tui.app.installed", return_value=CLAUDE)
 async def test_one_is_taken_away_by_pressing_d_twice(
     _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
 ) -> None:
@@ -210,11 +235,12 @@ async def test_a_flows_agent_is_saved_out_under_a_new_name_or_over_one(
     """The other half of importing: what was tuned in a flow is worth keeping."""
     Templates().keep([Kept("reviewer", Runs("claude/claude-opus-5:max"))])
     app = Humanize()
+    was = (app._flow_named, list(app._models))
     async with app.run_test() as driver:
         await into_flows(app, driver)
         await into_agent(app, driver)
 
-        await opens(app, driver, "save")
+        await opens(app, driver, "save as")
         await until(lambda: isinstance(app.screen, Names), driver)
         # The ones already there, to be written over, and what this one is called as a new
         # one under them.
@@ -227,6 +253,7 @@ async def test_a_flows_agent_is_saved_out_under_a_new_name_or_over_one(
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Agent), driver)
         await until(lambda: "saved as builder" in _under(app), driver)
+        assert (app._flow_named, app._models) == was
 
     held = {one.name: one.runs for one in Templates().all()}
     assert held["reviewer"] == Runs("claude/claude-opus-5:max")


### PR DESCRIPTION
## Summary

- add an explicit `save` action that accepts the current Agent configuration
- distinguish reusable Agent templates with a separate `save as` action
- add a final `save` action on the Flow Agents page for the complete Flow setup
- preserve Esc save/discard confirmation as a fallback and update the TUI reference

## Validation

- manually configured both agents in `official/flame_chase` and saved the Flow without using Esc
- `uv run pre-commit run --all-files`
- `uv run pytest` (1539 passed, 70 skipped)