### PR TITLE
fix(codex): stop on failed turn completion

### DIFF
--- a/src/hmz/agents/codex.py
+++ b/src/hmz/agents/codex.py
@@ -461,13 +461,13 @@ class _AppServer:
                         case "turn/completed" if told.get("turn", {}).get(
                             "status"
                         ) not in (None, "completed"):
-                            # A turn can end by failing or by being interrupted, and the
-                            # thread goes idle either way: a turn that did not land must not
-                            # answer as if it had.
+                            # A failed or interrupted turn is complete even when the server
+                            # does not follow it with a separate idle notification.
                             turn_said = told["turn"]
                             failed = json.dumps(
                                 turn_said.get("error") or turn_said.get("status")
                             )
+                            break
                         case "thread/status/changed" if (
                             begun and told["status"]["type"] == "idle"
                         ):

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -225,8 +225,6 @@ for line in sys.stdin:
             send({"method": "turn/completed",
                   "params": {"turn": {"id": "turn_fake", "status": "failed",
                                       "error": {"type": "usageLimitExceeded"}}}})
-            send({"method": "thread/status/changed",
-                  "params": {"status": {"type": "idle"}}})
             continue
         send({"method": "item/agentMessage/delta", "params": {"delta": "workspace-write"}})
         send({"method": "item/completed",
@@ -694,12 +692,13 @@ def test_a_codex_session_with_no_turn_running_cannot_be_talked_to() -> None:
         session.interject("hello?")
 
 
-def test_a_codex_turn_that_failed_does_not_answer_as_if_it_landed(
+@pytest.mark.timeout(5)
+def test_a_codex_turn_that_failed_does_not_wait_for_the_thread_to_idle(
     codex: _FakeServer,
 ) -> None:
-    """The thread goes idle either way, so a turn that failed must say so rather than "".
+    """A completed turn is terminal even when Codex never says its thread is idle.
 
-    Otherwise a loop feeds an empty answer forward as the work of the turn before it.
+    A failed turn must say so rather than leave the flow waiting forever for another event.
     """
     agent = CodexAgent(CodexAgentConfig(model="gpt-5-codex", effort="high"))
     session = agent.new()


### PR DESCRIPTION
## Summary

- treat failed or interrupted `turn/completed` notifications as terminal without waiting for thread idle
- cover an app server that remains alive and emits no idle notification after failed completion

## Why

Codex can report a terminal turn failure, including retry exhaustion after a 429, without following it with `thread/status/changed=idle`. Humanize recorded the failure but continued blocking on the shared message queue, which prevented suppress, retry/fallback, and the surrounding flow from progressing.

## Tests

- `uv run pre-commit run --all-files`
- `uv run pytest` (1559 passed, 70 skipped)