### PR TITLE
fix(flows): expose unrecoverable turn failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ read back, in fifteen minutes.
 
 [@futrime](https://github.com/futrime), [@SihaoLiu](https://github.com/SihaoLiu), [@lyken17](https://github.com/lyken17).
 
-This project was initiated by Sihao Liu at UCLA [PolyArch/humanize](https://github.com/PolyArch/humanize), then contributed 
+This project was initiated by Sihao Liu at UCLA [PolyArch/humanize](https://github.com/PolyArch/humanize), then contributed
 by NVIDIA Research, MIT HAN LAB, NUNCHAKU and many community members.
 
 ## Contributing

--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -33,11 +33,13 @@ moments a hook hangs on, what a turn cost, what an agent is configured with, wha
 runs — all come from that one name:
 
 ```python
-from hmz.flows import Agent, Moment, Person, Session, calls, flow
+from hmz.flows import Agent, Moment, Person, Session, Unrecoverable, calls, flow
 ```
 
 A flow that named `hmz.agents` for the type of what it drives would be a flow written against
 which CLI is behind it, and it would break the day humanize moved anything. It never has to.
+`Unrecoverable` is exposed here too, so bounded flows can distinguish a transient failed turn
+from one whose next attempt would necessarily fail the same way.
 
 | Name | Is |
 | --- | --- |

--- a/src/hmz/flows/__init__.py
+++ b/src/hmz/flows/__init__.py
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
         Remote,
         Stopped,
         Unhooked,
+        Unrecoverable,
         Usage,
         Verdict,
     )
@@ -146,6 +147,7 @@ __all__ = [
     "Session",
     "Stopped",
     "Unhooked",
+    "Unrecoverable",
     "Usage",
     "Verdict",
     "about",
@@ -206,6 +208,7 @@ _ELSEWHERE = {
     "SWARM": "hmz.agents",
     "Stopped": "hmz.agents",
     "Unhooked": "hmz.agents",
+    "Unrecoverable": "hmz.agents",
     "Usage": "hmz.agents",
     "Verdict": "hmz.agents",
     "WINDOW": "hmz.agents",

--- a/tests/test_flow_interface.py
+++ b/tests/test_flow_interface.py
@@ -17,7 +17,9 @@ import pytest
 
 import hmz.flows
 from hmz.agents import HumanAgent
+from hmz.agents import Unrecoverable as AgentUnrecoverable
 from hmz.flows import BUILTIN_AT, Agent, Person, Session
+from hmz.flows import Unrecoverable as FlowUnrecoverable
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -63,6 +65,11 @@ def test_a_name_it_does_not_offer_is_an_attribute_error() -> None:
     """Handing names through must not turn a typo into something that is silently None."""
     with pytest.raises(AttributeError):
         _ = hmz.flows.ClaudeCodeAgent  # type: ignore[attr-defined]
+
+
+def test_an_unrecoverable_turn_is_the_same_exception_a_flow_can_catch() -> None:
+    """The flow-facing vocabulary is handed through, not redefined at the boundary."""
+    assert FlowUnrecoverable is AgentUnrecoverable
 
 
 def _members(protocol: type) -> set[str]:


### PR DESCRIPTION
## Summary
- expose `Unrecoverable` through the backend-neutral `hmz.flows` API
- document why flow authors need the exception in bounded retry loops
- add a contract test proving the flow-facing name is the agent-layer exception object
- remove the pre-existing README trailing whitespace that made the repository's all-files pre-commit CI fail on a clean runner

## Why
The official `humanize1:gen-plan` flow must distinguish transient turn failures from failures that cannot succeed on retry. Importing `hmz.agents` directly would violate the flow layering contract, so the vocabulary needs to be forwarded by `hmz.flows`.

This is the prerequisite for https://github.com/humanfia/flowverse/pull/2, which contains the complete backend-neutral gen-plan convergence fix.

## Verification
- `uv run pytest -q tests/test_flow_interface.py`
- `uv run pre-commit run --all-files`
- GitHub CI `check` job passed on commit `d66ad04`
