### PR TITLE
fix(coganchor): keep Codex code-mode runtime local

### DIFF
--- a/docs/features/anchor.md
+++ b/docs/features/anchor.md
@@ -48,7 +48,7 @@ Every trapped call is one of three questions, and the router answers them indepe
 | | |
 | --- | --- |
 | **Paths** | A directory on this machine — the mirror — stands for a path on the target. By default the two are spelled identically, so the agent genuinely believes it is working on the target. |
-| **Programs** | Everything the agent spawns runs on the target, except the agent's own runtime: its binary and its re-execs stay here. |
+| **Programs** | Everything the agent spawns runs on the target, except the agent's own runtime: its launcher, interpreter, native binary, runtime helpers and re-execs stay here. |
 | **Redirects** | A path the agent names may be answered with another one — the credentials of the [account](/features/accounts) a turn runs as, rather than whichever account this machine is signed into. What it is answered with is local, so it never reaches the target either. |
 
 ## The mirror, and why writes are whole files
@@ -75,7 +75,8 @@ there kills its local counterpart the same way.
 
 ## What never leaves this machine
 
-- the agent's own executable, and its re-execs
+- the agent's own runtime executables and re-execs — for an npm-installed Codex, that includes
+  Node, the native CLI and its code-mode host
 - its state directory — the known CLIs are known by name, and any other agent keeping state
   inside the workspace has to be named
 - anything a path is answered with, and the paths that answer it: an agent run as somebody

--- a/docs/guide/remote-execution.md
+++ b/docs/guide/remote-execution.md
@@ -81,13 +81,14 @@ it adds nothing. Then check `python3 --version` there. See
 - File contents are pushed in full before any command runs, and again when the session ends.
 - Structural changes — create, remove, rename, link, chmod — are replayed there *first*, so the
   target's own error is what the agent sees.
-- Commands run in the target's copy of the working directory, including helpers bundled with
-  the agent itself.
+- Commands run in the target's copy of the working directory, including work helpers such as
+  ripgrep that are bundled with the agent itself.
 - Whatever those commands reach on the network.
 
 **Stays here**
 
-- The agent's own executable and its re-execs.
+- The agent's own runtime executables and re-execs. For an npm-installed Codex, that includes
+  Node, the native CLI and its code-mode host.
 - Its state directory. humanize knows the ten known CLIs by name — `agy`, `claude`, `codex`,
   `dsh`, `grok`, `kimi`, `mimo`, `opencode`, `pi`, `qwen` — and its own `~/.humanize`. Any
   other agent that keeps state inside the workspace has to be named with `--local-path`.

--- a/docs/reference/remote-execution.md
+++ b/docs/reference/remote-execution.md
@@ -83,13 +83,14 @@ the agent once it exits, and when the session ends nothing it started is left ru
   target, and again when the session ends.
 - **Structural changes.** Creating, removing, renaming, linking and changing permissions are
   replayed on the target first, so the target's error is what the agent sees.
-- **Commands.** Everything the agent spawns, including helpers bundled with the agent itself, in
+- **Commands.** Everything the agent spawns, including bundled work helpers such as ripgrep, in
   the target's copy of the working directory.
 - **Network.** Whatever those commands reach.
 
 ## What stays on this machine
 
-- The agent's own executable and its re-execs.
+- The agent's own runtime executables and re-execs. For an npm-installed Codex, that includes
+  Node, the native CLI and its code-mode host.
 - Its state directory. All ten known CLIs are known by name — `agy`, `claude`, `codex`, `dsh`,
   `grok`, `kimi`, `mimo`, `opencode`, `pi`, `qwen` — as is humanize's own `~/.humanize`; any
   other agent keeping state inside the workspace has to be named with `--local-path`.

--- a/src/hmz/coganchor/statepaths.py
+++ b/src/hmz/coganchor/statepaths.py
@@ -1,9 +1,9 @@
 """Knowing which files belong to the agent rather than to the project.
 
-An agent's own binary, its bundled helpers and its state directory live on
-this machine and must keep working here: rerouting ``~/.codex`` to the target
-would lose the session, and rerouting the agent's own executable would make it
-impossible to start.  Everything else the agent touches belongs to the target.
+An agent's own runtime and state directory live on this machine and must keep
+working here: rerouting ``~/.codex`` to the target would lose the session, and
+rerouting one of the agent's runtime executables would make it impossible to
+start or use its tools.  Everything else the agent touches belongs to the target.
 """
 
 from __future__ import annotations
@@ -97,6 +97,8 @@ COMMON_STATE_PATHS: tuple[str, ...] = (
     "~/.config/humanize",
 )
 
+_CODEX_VENDOR_BIN = os.path.join("vendor", "x86_64-unknown-linux-musl", "bin")
+
 
 @dataclass(slots=True)
 class ResolvedAgent:
@@ -137,14 +139,15 @@ def resolve(command: list[str]) -> ResolvedAgent:
     local_paths = [
         _expand(path) for path in (*profile.state_paths, *COMMON_STATE_PATHS)
     ]
-    # Only the agent's own executable stays here -- enough for it to start and
-    # to re-exec itself.  Bundled helpers such as ripgrep deliberately go to
-    # the target: running them against the partly materialised mirror would
-    # return quietly wrong answers, which is worse than a visible failure.
+    # Only the agent's own runtime stays here. Work helpers such as ripgrep
+    # deliberately go to the target: running them against the partly materialised
+    # mirror would return quietly wrong answers, which is worse than a visible failure.
     local_programs = [located, program]
-    interpreter = _shebang_interpreter(program)
-    if interpreter:
-        local_programs.append(interpreter)
+    shebang = _shebang(program)
+    if shebang:
+        local_programs.append(shebang[0])
+    if profile.name == "codex":
+        local_programs.extend(_codex_runtime_programs(program, shebang))
 
     return ResolvedAgent(
         profile=profile,
@@ -159,14 +162,53 @@ def _expand(path: str) -> str:
     return os.path.normpath(os.path.expanduser(path))
 
 
-def _shebang_interpreter(program: str) -> str | None:
-    """Return the interpreter of a ``#!`` script, so its re-exec stays local."""
+def _shebang(program: str) -> tuple[str, ...]:
+    """Return the command naming a script's interpreter."""
     try:
         with open(program, "rb") as handle:
             first = handle.readline(256)
     except OSError:
-        return None
+        return ()
     if not first.startswith(b"#!"):
-        return None
-    parts = first[2:].decode("utf-8", "replace").strip().split()
-    return parts[0] if parts else None
+        return ()
+    return tuple(first[2:].decode("utf-8", "replace").strip().split())
+
+
+def _codex_runtime_programs(program: str, shebang: tuple[str, ...]) -> list[str]:
+    """Return the Node, native CLI and code-mode host that implement Codex."""
+    programs: list[str] = []
+    node = next((part for part in shebang if os.path.basename(part) == "node"), None)
+    if node:
+        found = shutil.which(node) if os.path.sep not in node else node
+        if found and os.path.exists(found):
+            programs.extend((os.path.abspath(found), os.path.realpath(found)))
+
+    package = os.path.dirname(os.path.dirname(program))
+    candidates = [
+        program,
+        os.path.join(package, _CODEX_VENDOR_BIN, "codex"),
+        os.path.join(
+            package,
+            "node_modules",
+            "@openai",
+            "codex-linux-x64",
+            _CODEX_VENDOR_BIN,
+            "codex",
+        ),
+        os.path.join(
+            os.path.dirname(package),
+            "codex-linux-x64",
+            _CODEX_VENDOR_BIN,
+            "codex",
+        ),
+    ]
+    for candidate in candidates:
+        if os.path.basename(candidate) != "codex" or not os.path.isfile(candidate):
+            continue
+        native = os.path.realpath(candidate)
+        programs.extend((os.path.abspath(candidate), native))
+        for directory in {os.path.dirname(candidate), os.path.dirname(native)}:
+            host = os.path.join(directory, "codex-code-mode-host")
+            if os.path.isfile(host):
+                programs.extend((os.path.abspath(host), os.path.realpath(host)))
+    return programs

--- a/tests/coganchor/test_statepaths.py
+++ b/tests/coganchor/test_statepaths.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
-from hmz.coganchor.statepaths import profile_for
+from typing import TYPE_CHECKING
+
+from hmz.coganchor.statepaths import profile_for, resolve
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def executable(path: Path, content: bytes = b"\x7fELF") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(0o755)
+    return path
 
 
 def test_the_bundled_dsh_runtime_keeps_dsh_state_local() -> None:
@@ -10,3 +24,48 @@ def test_the_bundled_dsh_runtime_keeps_dsh_state_local() -> None:
 
     assert profile.name == "dsh"
     assert profile.state_paths == ("~/.dsh",)
+
+
+def test_codex_standalone_keeps_its_code_mode_host_local(tmp_path: Path) -> None:
+    codex = executable(tmp_path / "release" / "bin" / "codex")
+    host = executable(codex.with_name("codex-code-mode-host"))
+    work_helper = executable(tmp_path / "release" / "codex-path" / "rg")
+
+    resolved = resolve([str(codex)])
+
+    assert str(codex) in resolved.local_programs
+    assert str(host) in resolved.local_programs
+    assert str(work_helper) not in resolved.local_programs
+
+
+def test_codex_node_package_keeps_its_whole_runtime_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = executable(tmp_path / "node-bin" / "node")
+    monkeypatch.setenv("PATH", str(node.parent))
+
+    package = tmp_path / "node_modules" / "@openai" / "codex"
+    script = executable(package / "bin" / "codex.js", b"#!/usr/bin/env node\n")
+    launcher = tmp_path / "bin" / "codex"
+    launcher.parent.mkdir()
+    launcher.symlink_to(script)
+    vendor = (
+        package
+        / "node_modules"
+        / "@openai"
+        / "codex-linux-x64"
+        / "vendor"
+        / "x86_64-unknown-linux-musl"
+    )
+    native = executable(vendor / "bin" / "codex")
+    host = executable(native.with_name("codex-code-mode-host"))
+    work_helper = executable(vendor / "codex-path" / "rg")
+
+    resolved = resolve([str(launcher)])
+
+    assert resolved.program == str(script)
+    assert str(node) in resolved.local_programs
+    assert str(native) in resolved.local_programs
+    assert str(host) in resolved.local_programs
+    assert str(work_helper) not in resolved.local_programs
+    assert str(launcher) in resolved.local_programs


### PR DESCRIPTION
## Problem

Codex 0.149 has more than one executable in its local runtime:

- the npm package starts with `#!/usr/bin/env node`;
- that launcher spawns the vendored native `codex` binary; and
- the native binary starts `codex-code-mode-host` when the model calls exec.

`statepaths.resolve()` only kept the located launcher, its real path, and the literal
shebang interpreter local. For an npm install that meant `/usr/bin/env` stayed local while
the actual Node process and native Codex binary were eligible for forwarding. For a
standalone install the native binary stayed local, but `codex-code-mode-host` was forwarded
to the anchor target.

The usual target does not contain that local helper at the same absolute path. The exec
request therefore failed before `pwd`, `true`, or any other requested command could run:

```text
hmz DEBUG running [.../codex-code-mode-host] on the target
ERROR codex_core::tools::router: error=code-mode host exited during handshake
```

This can look like success to automation because Codex may still finish the turn with status
zero and infer an answer without emitting a completed `command_execution` event.

## Reproduction

With Codex CLI 0.149.1 installed locally, use a Docker target that does not contain the local
Codex installation:

```sh
docker run -d --rm --name hmz-codex-repro \
  --entrypoint sh ghcr.io/humanfia/flowbench-runtime:latest \
  -c 'mkdir -p /tmp/hmz-codex-repro && exec sleep infinity'

hmz anchor \
  --target docker://hmz-codex-repro \
  --workspace /tmp/hmz-codex-repro \
  --shadow "$(mktemp -d)" \
  --log-level debug \
  codex exec --skip-git-repo-check --ephemeral \
  --dangerously-bypass-approvals-and-sandbox \
  'Use the exec tool to run pwd and then true.'
```

Before this change, `codex --version` succeeds but the first exec call routes
`codex-code-mode-host` to the container and fails its handshake.

## Change

- Resolve the actual Node executable named by Codex's shebang.
- Find the native Codex binary in standalone, package-local, hoisted, and fallback npm
  layouts supported on coganchor's x86-64 Linux host.
- Keep the native binary and its sibling `codex-code-mode-host` local, including their
  resolved paths.
- Keep the allowlist exact: bundled work helpers such as ripgrep still run on the target.
- Cover standalone and npm layouts with regression tests and document the runtime/work-helper
  boundary.

## Behavior after the change

The Codex launcher, Node process, native binary, and code-mode host remain beside the agent.
Only the command requested through exec is forwarded to the target. The same Docker
reproduction now records:

```text
hmz DEBUG running .../codex-code-mode-host on this machine
hmz DEBUG running ['/usr/bin/bash'] on the target
```

The emitted command event completes successfully:

```json
{"type":"item.completed","item":{"type":"command_execution","command":"/usr/bin/bash -lc 'pwd\ntrue'","aggregated_output":"/tmp/hmz-codex-repro\n","exit_code":0,"status":"completed"}}
```

No manual `--local-exec` options are required.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests/coganchor/test_statepaths.py -q` — 3 passed
- `uv run pytest tests/coganchor -q -k 'not ssh_transport_bootstraps_and_runs'` — 220 passed,
  33 skipped, 1 deselected
- Installed the published `@openai/codex@0.149.1` npm package and verified that resolution
  selects its actual Node, vendored native binary, and code-mode host.
- Ran the Docker reproduction above with standalone Codex 0.149.1 and no manual local-exec
  overrides; `pwd && true` completed on the target with exit code 0.

The full local suite completed with 1675 passed and 65 skipped. Three environment failures
remain outside this change: localhost SSH rejects a changed host key, and two process-profiler
timing tests fail identically in isolation on this host.
