### PR TITLE
fix(agents): accept Codex turns after reconnect

### DIFF
--- a/src/hmz/agents/codex.py
+++ b/src/hmz/agents/codex.py
@@ -581,16 +581,18 @@ class _AppServer:
                                     running.spends(risen)
                         case "error":
                             failed = json.dumps(told.get("error"))
-                        case "turn/completed" if told.get("turn", {}).get(
-                            "status"
-                        ) not in (None, "completed"):
-                            # A failed or interrupted turn is complete even when the server
-                            # does not follow it with a separate idle notification.
-                            turn_said = told["turn"]
-                            failed = json.dumps(
-                                turn_said.get("error") or turn_said.get("status")
-                            )
-                            break
+                        case "turn/completed":
+                            turn_said = cast("dict[str, Any]", told.get("turn") or {})
+                            if turn_said.get("status") not in (None, "completed"):
+                                # A failed or interrupted turn is complete even when the
+                                # server does not follow it with a separate idle notification.
+                                failed = json.dumps(
+                                    turn_said.get("error") or turn_said.get("status")
+                                )
+                                break
+                            # Codex reports a reconnect attempt as an error notification even
+                            # when a later sampling request completes this same turn.
+                            failed = None
                         case "thread/status/changed" if (
                             begun and told["status"]["type"] == "idle"
                         ):

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -201,6 +201,12 @@ for line in sys.stdin:
         send({"method": "thread/status/changed", "params": {"status": {"type": "idle"}}})
     if call["method"] == "turn/start":
         send({"method": "turn/started", "params": {"turnId": "turn_fake"}})
+        if call["params"]["input"][0]["text"] == "recovering":
+            send({"method": "error", "params": {"error": {
+                "message": "Reconnecting... 1/5",
+                "codexErrorInfo": {"responseStreamDisconnected": {
+                    "httpStatusCode": None}},
+            }}})
         if call["params"]["input"][0]["text"] == "asking":
             # A turn stopping to ask its user something, which the server puts to the client
             # as a request of its own and waits on.
@@ -702,6 +708,15 @@ def test_a_codex_turn_says_what_it_is_doing_while_it_is_doing_it(
     # two things done, and the second is not swallowed as one already seen.
     assert ("tool", "WebSearch what a nameless one is") in shown
     assert ("tool", "WebSearch and the one after it") in shown
+
+
+def test_a_codex_turn_that_reconnects_can_still_complete(
+    working: _FakeServer,
+) -> None:
+    """A transient error is superseded when Codex completes the same turn."""
+    session = CodexAgent(CodexAgentConfig(model="gpt-5-codex", effort="high")).new()
+
+    assert session("recovering") == "done"
 
 
 def test_what_a_codex_turn_spent_is_charged_to_the_turn_that_spent_it(


### PR DESCRIPTION
## Summary

- Treat an intermediate Codex app-server error as superseded when the same turn later completes successfully.
- Preserve immediate failure behavior for terminal failed or interrupted turns.
- Cover a Reconnecting... 1/5 event followed by successful completion.

## Validation

- uv run pre-commit run --all-files
- uv run pytest tests/agents/test_appservers.py -q: 45 passed
- uv run pytest --ignore=tests/coganchor: 1469 passed, 36 skipped

The complete suite was also attempted. Coganchor tests cannot run in this container because pidfd_getfd returns EPERM without CAP_SYS_PTRACE; before interruption, 500 tests passed and 65 skipped, with failures limited to tests/coganchor.