### PR TITLE
docs(flows): gen-plan stops while a decision is still PENDING

### DIFF
--- a/docs/flows/humanize1.md
+++ b/docs/flows/humanize1.md
@@ -44,6 +44,12 @@ time and reads the plan against the repository. They converge, or the round limi
 `--input` names the draft to plan from, `--discussion` and `--direct` are the two modes, and
 `alternative_plan_language` writes a translated plan beside the plan.
 
+A plan that still says `PENDING` on a `Pending User Decisions` entry stops the run rather
+than finishing it: `rlcr` never waits for a person, so a decision left undecided here would
+idle the loop, not stop it. The plan stays on disk with every position written down —
+answer each `Decision Status` in the file, or run `gen-plan` again with somebody at the
+prompt.
+
 ## 3 · `rlcr`
 
 <HmzFlowShape flow="humanize1-rlcr" />


### PR DESCRIPTION
One paragraph on `gen-plan`'s new ending, matching humanfia/flowverse#9: a finished plan whose `## Pending User Decisions` entries still say `PENDING` stops the run rather than being handed on -- `rlcr` never waits for a person, so an undecided plan would idle the loop, not stop it.

Merge after humanfia/flowverse#9, which is where the behavior lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)