### PR TITLE
docs(features): organize capabilities around five systems

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,39 +61,51 @@ export default defineConfig({
     // a title nobody would write on the page itself, and the page is what it goes to. So the
     // section is the first line, and the groups under it are what they were.
     sidebar: {
-      // One page per feature, each built around a diagram you can push. The first group is
-      // the one to send somebody who wants to know what is unusual about this.
+      // The capability map groups the whole system; the pages beneath it take one mechanism
+      // far enough to explain its trade-offs, each around a diagram the reader can push.
       '/features/': [
         { text: 'Features', link: '/features/' },
+        { text: 'Capability map', link: '/features/capabilities' },
         {
-          text: 'The deep end',
+          text: 'Flow system',
           collapsed: false,
           items: [
-            { text: 'The anchor', link: '/features/anchor' },
-            { text: 'Two accounts of one CLI', link: '/features/accounts' },
-            { text: 'One timeline', link: '/features/tracing' },
-            { text: 'A line typed mid-turn', link: '/features/steering' },
-            { text: 'Answers in a shape', link: '/features/shapes' },
-          ],
-        },
-        {
-          text: 'The shape of a run',
-          collapsed: false,
-          items: [
-            { text: 'Twelve CLIs, one agent', link: '/features/backends' },
+            { text: 'Python becomes a prophecy', link: '/features/prophecy' },
             { text: 'A flow is Python', link: '/features/flows' },
             { text: 'Many turns at once', link: '/features/concurrency' },
             { text: 'Picked up where it stopped', link: '/features/resuming' },
           ],
         },
         {
-          text: 'Who is at the other end',
+          text: 'Agent control plane',
           collapsed: false,
           items: [
+            { text: 'Many backends, one agent', link: '/features/backends' },
+            { text: 'Two accounts of one CLI', link: '/features/accounts' },
+            { text: 'A line typed mid-turn', link: '/features/steering' },
+            { text: 'Answers in a shape', link: '/features/shapes' },
             { text: 'It decides when it is done', link: '/features/goals' },
             { text: 'The moments of a turn', link: '/features/hooks' },
             { text: 'You, as one of the agents', link: '/features/human' },
           ],
+        },
+        {
+          text: 'Execution fabric',
+          collapsed: false,
+          items: [{ text: 'The anchor', link: '/features/anchor' }],
+        },
+        {
+          text: 'Run continuity and observability',
+          collapsed: false,
+          items: [
+            { text: 'The terminal can leave', link: '/features/daemon' },
+            { text: 'One timeline', link: '/features/tracing' },
+          ],
+        },
+        {
+          text: 'Product surfaces',
+          collapsed: false,
+          items: [{ text: 'One system, four ways in', link: '/features/surfaces' }],
         },
       ],
 

--- a/docs/.vitepress/theme/components/HmzBackends.vue
+++ b/docs/.vitepress/theme/components/HmzBackends.vue
@@ -3,6 +3,8 @@
 // The rows are `hmz/backends.py` and the classes in `hmz/agents/`: which session base a
 // backend derives from is what decides whether it can be talked to mid-turn, `shapes` is
 // whether it can be held to a schema, and a `_pursue` of its own is whether it has a goal.
+// `trace` means `hmz/tracing/collector.py` has a reader for the backend's logs; it does not
+// mean only that the backend writes logs or that humanize can tally them while it runs.
 import { computed, ref } from 'vue'
 
 type Driven = 'held' | 'server' | 'command' | 'sdk' | 'protocol'
@@ -16,7 +18,7 @@ interface Backend {
   steer: string
   shape: string
   goal: boolean
-  logs: string
+  trace: boolean
   skills: string
   note: string
 }
@@ -38,7 +40,7 @@ const BACKENDS: Backend[] = [
     steer: 'answered inside the same turn',
     shape: 'held to it',
     goal: true,
-    logs: 'read back',
+    trace: true,
     skills: 'its own, and the project’s',
     note: '“ultracode” is “xhigh” with the turn opted into orchestrating a fleet of its own. It is real, undocumented, and no listing the CLI answers with will ever name it — so humanize writes it down.',
   },
@@ -50,7 +52,7 @@ const BACKENDS: Backend[] = [
     steer: 'a steer on the running turn',
     shape: 'held to it',
     goal: true,
-    logs: 'read back',
+    trace: true,
     skills: 'four places, the shared one included',
     note: 'Its models differ from each other: one takes “ultra” and the one beside it does not, so the ladder is narrowed per model by what the backend itself says when it is asked what it runs.',
   },
@@ -62,7 +64,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'asked in the prompt',
     goal: false,
-    logs: 'none to read',
+    trace: false,
     skills: 'its own, and the project’s',
     note: 'It has no flag for a rung: its models are parameterized, so how hard it thinks and how quickly it is served are written into the model itself — “composer-2.5[effort=high,fast=false]”. A model already spelled with a bracket is passed exactly as it was written.',
   },
@@ -74,7 +76,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'asked in the prompt',
     goal: true,
-    logs: 'read back',
+    trace: true,
     skills: 'none',
     note: 'The one backend that arrives with humanize rather than being found on your PATH — its SDK and the runtime its turns are taken on are ordinary dependencies.',
   },
@@ -87,7 +89,7 @@ const BACKENDS: Backend[] = [
     steer: 'queued, then steered in',
     shape: 'asked in the prompt',
     goal: true,
-    logs: 'read back',
+    trace: true,
     skills: 'its own, the shared one, the project’s',
     note: 'Its effort says how wide as well as how hard: “max” is one agent and “swarmmax” is the same thinking at the width of a fleet, so width is chosen beside the effort rather than among the rungs.',
   },
@@ -99,7 +101,7 @@ const BACKENDS: Backend[] = [
     steer: 'a steer on the run it is making',
     shape: 'asked in the prompt',
     goal: false,
-    logs: 'read back',
+    trace: false,
     skills: 'its own, and the shared one',
     note: '“off” is the model asked not to think at all. That is an effort like any other here: the least of them, not the absence of a setting.',
   },
@@ -111,7 +113,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'held to it',
     goal: false,
-    logs: 'read back',
+    trace: false,
     skills: 'eight places, two of them other harnesses’',
     note: 'The ladder is written as it enumerates them when it refuses one, because a rung it refuses is a turn that never starts.',
   },
@@ -123,7 +125,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'held to it',
     goal: false,
-    logs: 'read back',
+    trace: false,
     skills: 'four places',
     note: 'It has no flag for an effort — they are a setting of its own settings file, so a turn is pointed at one of humanize’s instead of anybody’s being rewritten.',
   },
@@ -135,7 +137,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'held to it',
     goal: false,
-    logs: 'none to read',
+    trace: false,
     skills: 'its own',
     note: 'A conversation here is rows of a database whose payloads are protobuf, so there is no log to read a run’s cost out of as it is spent, and none to gather afterwards.',
   },
@@ -147,7 +149,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'asked in the prompt',
     goal: false,
-    logs: 'none to read',
+    trace: false,
     skills: 'three places',
     note: 'Its effort is the model variant rather than a thinking level of its own, and a provider with no variants takes the flag and ignores it.',
   },
@@ -159,7 +161,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'asked in the prompt',
     goal: false,
-    logs: 'none to read',
+    trace: false,
     skills: 'five places',
     note: 'A fork of opencode, and one directory more: it reads Codex’s skills as well as Claude Code’s.',
   },
@@ -171,7 +173,7 @@ const BACKENDS: Backend[] = [
     steer: 'no',
     shape: 'asked in the prompt',
     goal: true,
-    logs: 'read back',
+    trace: false,
     skills: 'four places, the shared one included',
     note: 'Its ladder is two vocabularies at once, because its models have two: the ones that take a thinking budget answer “max”, “high”, “low” and “nothink”, and the ones that only take thinking or not answer “enabled” or “disabled”. A model narrows it to its own half.',
   },
@@ -180,10 +182,10 @@ const BACKENDS: Backend[] = [
     called: 'anything speaking ACP',
     driven: 'protocol',
     efforts: ['as configured'],
-    steer: 'a word put in',
+    steer: 'no',
     shape: 'asked in the prompt',
     goal: false,
-    logs: 'none to read',
+    trace: false,
     skills: 'none',
     note: 'The protocol says nothing about which models an agent runs or how hard it may be asked to think — both are the agent’s own — so one rung is offered and none is sent.',
   },
@@ -199,7 +201,7 @@ const WANTS: Want[] = [
   { key: 'steer', said: 'takes a word mid-turn', holds: (one) => one.steer !== 'no' },
   { key: 'shape', said: 'held to a shape', holds: (one) => one.shape === 'held to it' },
   { key: 'goal', said: 'has a goal of its own', holds: (one) => one.goal },
-  { key: 'logs', said: 'leaves a log to trace', holds: (one) => one.logs === 'read back' },
+  { key: 'trace', said: 'can be read back into a trace', holds: (one) => one.trace },
   { key: 'swarm', said: 'runs a turn as a fleet', holds: (one) => Boolean(one.swarms) },
 ]
 
@@ -216,24 +218,39 @@ const asked = computed(() => WANTS.filter((one) => wanted.value.includes(one.key
 const fits = (one: Backend) => asked.value.every((each) => each.holds(one))
 const open = computed(() => BACKENDS.find((one) => one.name === opened.value) ?? BACKENDS[0])
 const counted = computed(() => BACKENDS.filter(fits).length)
+
+function backendLabel(one: Backend) {
+  return [
+    one.name,
+    `driven through ${DRIVEN[one.driven]}`,
+    `hardest effort ${one.efforts[0]}`,
+    `mid-turn ${one.steer}`,
+    `shape ${one.shape}`,
+    `goal ${one.goal ? 'yes' : 'no'}`,
+    `trace ${one.trace ? 'read back' : 'no reader'}`,
+  ].join(', ')
+}
 </script>
 
 <template>
   <div class="backends hmz-panel">
     <div class="bar">
       <span class="what">what a flow may ask an agent for</span>
-      <div class="wants">
+      <div class="wants" role="group" aria-label="filter backends by capability">
         <button
           v-for="one in WANTS"
           :key="one.key"
           type="button"
+          :aria-pressed="wanted.includes(one.key)"
           :class="{ on: wanted.includes(one.key) }"
           @click="want(one.key)"
         >
           {{ one.said }}
         </button>
       </div>
-      <span class="count">{{ counted }} of {{ BACKENDS.length }}</span>
+      <span class="count" aria-live="polite">
+        {{ counted }} of {{ BACKENDS.length }}
+      </span>
     </div>
 
     <div class="table">
@@ -244,7 +261,7 @@ const counted = computed(() => BACKENDS.filter(fits).length)
         <span>mid-turn</span>
         <span>a shape</span>
         <span>a goal</span>
-        <span>a log</span>
+        <span>trace</span>
       </div>
       <button
         v-for="one in BACKENDS"
@@ -252,6 +269,9 @@ const counted = computed(() => BACKENDS.filter(fits).length)
         type="button"
         class="row"
         :class="{ dim: !fits(one), on: opened === one.name }"
+        :aria-label="backendLabel(one)"
+        :aria-pressed="opened === one.name"
+        aria-controls="backend-detail"
         @click="opened = one.name"
       >
         <span class="name">
@@ -273,11 +293,11 @@ const counted = computed(() => BACKENDS.filter(fits).length)
         <span :class="{ yes: one.steer !== 'no', no: one.steer === 'no' }">{{ one.steer }}</span>
         <span :class="{ yes: one.shape === 'held to it' }">{{ one.shape }}</span>
         <span :class="one.goal ? 'yes' : 'no'">{{ one.goal ? 'yes' : 'no' }}</span>
-        <span :class="one.logs === 'read back' ? 'yes' : 'no'">{{ one.logs }}</span>
+        <span :class="one.trace ? 'yes' : 'no'">{{ one.trace ? 'read back' : 'no reader' }}</span>
       </button>
     </div>
 
-    <div class="open">
+    <div id="backend-detail" class="open" role="status" aria-live="polite">
       <div class="ladder">
         <span class="lab">{{ open.name }} · its own ladder, hardest first</span>
         <div class="rungs">
@@ -292,6 +312,14 @@ const counted = computed(() => BACKENDS.filter(fits).length)
       </div>
       <div class="said">
         <p class="driven"><strong>driven through</strong> {{ DRIVEN[open.driven] }}</p>
+        <p class="trace">
+          <strong>trace read-back</strong>
+          {{
+            open.trace
+              ? 'humanize can collect this backend’s session log into a Chrome trace'
+              : 'no trace reader yet — it may still write logs or report usage while it runs'
+          }}
+        </p>
         <p class="skills"><strong>skills it would load</strong> {{ open.skills }}</p>
         <p class="note">{{ open.note }}</p>
       </div>
@@ -387,7 +415,7 @@ const counted = computed(() => BACKENDS.filter(fits).length)
 }
 
 .row.dim {
-  opacity: 0.28;
+  opacity: 0.72;
 }
 
 .name {

--- a/docs/.vitepress/theme/components/HmzDaemon.vue
+++ b/docs/.vitepress/theme/components/HmzDaemon.vue
@@ -1,0 +1,887 @@
+<script setup lang="ts">
+// A terminal is a reader, not the owner. Advance the run with either, leave and return to
+// see a current-screen redraw, or stall one reader until only its bounded backlog is dropped.
+// Stopping is a separate axis: the run may unwind, or its holder may be ended where it stands.
+import { computed, reactive, ref } from 'vue'
+
+type RunState = 'running' | 'stopping' | 'stopped' | 'killed'
+type ReaderState = 'live' | 'away' | 'slow' | 'released' | 'replay'
+
+interface Reader {
+  id: 'desk' | 'watcher'
+  name: string
+  place: string
+  attached: boolean
+  slow: boolean
+  released: boolean
+  seen: number
+  backlog: number
+  replayedAt: number | null
+}
+
+const BURST = 384
+const LIMIT = 1024
+
+const runState = ref<RunState>('running')
+const frame = ref(3)
+const journal = ref(5)
+const stateRevision = ref(3)
+const lastEvent = ref('two terminals are reading one PTY')
+
+const readers = reactive<Reader[]>([
+  {
+    id: 'desk',
+    name: 'your terminal',
+    place: 'the shell that opened it',
+    attached: true,
+    slow: false,
+    released: false,
+    seen: 3,
+    backlog: 0,
+    replayedAt: null,
+  },
+  {
+    id: 'watcher',
+    name: 'another terminal',
+    place: 'a second view of the same run',
+    attached: true,
+    slow: false,
+    released: false,
+    seen: 3,
+    backlog: 0,
+    replayedAt: null,
+  },
+])
+
+const attached = computed(() => readers.filter((reader) => reader.attached).length)
+const holderAlive = computed(
+  () => runState.value === 'running' || runState.value === 'stopping',
+)
+
+const runLabel = computed(() => {
+  if (runState.value === 'stopping') return 'the flow is unwinding'
+  if (runState.value === 'stopped') return 'the flow returned'
+  if (runState.value === 'killed') return 'the holder ended here'
+  return `turn ${frame.value} is running`
+})
+
+const screenLines = computed(() => [
+  `round ${frame.value}`,
+  frame.value % 2 ? 'actor is checking the patch' : 'actor is running the tests',
+  !holderAlive.value
+    ? 'the PTY closed with its holder'
+    : attached.value
+    ? `${attached.value} terminal${attached.value === 1 ? '' : 's'} attached`
+    : 'nobody is looking',
+])
+
+function readerState(reader: Reader): ReaderState {
+  if (reader.released) return 'released'
+  if (!reader.attached) return 'away'
+  if (reader.slow) return 'slow'
+  if (reader.replayedAt !== null) return 'replay'
+  return 'live'
+}
+
+function readerLabel(reader: Reader) {
+  if (!holderAlive.value) return 'run ended; terminal restored'
+  const state = readerState(reader)
+  if (state === 'released') return 'slow reader released'
+  if (state === 'away') return 'terminal left; run stayed'
+  if (state === 'slow') return `${reader.backlog} KiB waiting`
+  if (state === 'replay') return `screen redrawn at round ${reader.replayedAt}`
+  return 'live output'
+}
+
+function advance() {
+  if (runState.value !== 'running') return
+  frame.value += 1
+  journal.value += 1
+  stateRevision.value += 1
+  let releasedThisBurst = false
+
+  for (const reader of readers) {
+    if (!reader.attached) continue
+    reader.replayedAt = null
+    if (!reader.slow) {
+      reader.seen = frame.value
+      reader.backlog = 0
+      continue
+    }
+    reader.backlog += BURST
+    if (reader.backlog > LIMIT) {
+      reader.attached = false
+      reader.slow = false
+      reader.released = true
+      reader.backlog = 0
+      releasedThisBurst = true
+      lastEvent.value = `${reader.name} crossed its 1 MiB bound; only that socket closed`
+    }
+  }
+
+  if (!releasedThisBurst) {
+    lastEvent.value = attached.value
+      ? `round ${frame.value} reached every reader that was ready`
+      : `round ${frame.value} was written with no terminal attached`
+  }
+}
+
+function leave(reader: Reader) {
+  reader.attached = false
+  reader.slow = false
+  reader.released = false
+  reader.backlog = 0
+  reader.replayedAt = null
+  lastEvent.value = `${reader.name} left; the daemon and PTY did not`
+}
+
+function reconnect(reader: Reader) {
+  if (runState.value === 'stopped' || runState.value === 'killed') return
+  reader.attached = true
+  reader.slow = false
+  reader.released = false
+  reader.backlog = 0
+  reader.seen = frame.value
+  reader.replayedAt = frame.value
+  lastEvent.value = `${reader.name} received a full-screen redraw, then joined live output`
+}
+
+function toggleSlow(reader: Reader) {
+  if (!reader.attached || runState.value !== 'running') return
+  reader.slow = !reader.slow
+  if (!reader.slow) {
+    reader.backlog = 0
+    reader.seen = frame.value
+    lastEvent.value = `${reader.name} caught up without changing the run`
+  } else {
+    reader.replayedAt = null
+    lastEvent.value = `${reader.name} stopped reading; its own bounded queue is growing`
+  }
+}
+
+function askToStop() {
+  if (runState.value !== 'running') return
+  runState.value = 'stopping'
+  lastEvent.value = 'the holder asked the interface to stop; the flow is unwinding'
+}
+
+function finishStop() {
+  if (runState.value !== 'stopping') return
+  runState.value = 'stopped'
+  journal.value += 1
+  for (const reader of readers) leave(reader)
+  lastEvent.value = 'the flow returned; the journal gained its complete ending'
+}
+
+function kill() {
+  if (runState.value === 'stopped' || runState.value === 'killed') return
+  runState.value = 'killed'
+  for (const reader of readers) leave(reader)
+  lastEvent.value = 'the holder ended where it stood; the last complete writes remain'
+}
+
+function reset() {
+  runState.value = 'running'
+  frame.value = 3
+  journal.value = 5
+  stateRevision.value = 3
+  lastEvent.value = 'two terminals are reading one PTY'
+  readers.forEach((reader) => {
+    reader.attached = true
+    reader.slow = false
+    reader.released = false
+    reader.seen = 3
+    reader.backlog = 0
+    reader.replayedAt = null
+  })
+}
+</script>
+
+<template>
+  <div class="daemon hmz-panel">
+    <div class="bar">
+      <span class="workspace"><i /> one workspace · one holder</span>
+      <span class="count">{{ attached }} attached</span>
+      <div class="spacer" />
+      <button type="button" :disabled="runState !== 'running'" @click="advance">
+        draw next burst
+      </button>
+      <button
+        class="stop"
+        type="button"
+        :disabled="runState !== 'running'"
+        @click="askToStop"
+      >
+        ask to stop
+      </button>
+      <button
+        v-if="runState === 'stopping'"
+        class="finish"
+        type="button"
+        @click="finishStop"
+      >
+        flow returns
+      </button>
+      <button
+        class="kill"
+        type="button"
+        :disabled="runState === 'stopped' || runState === 'killed'"
+        @click="kill"
+      >
+        end holder directly
+      </button>
+      <button class="reset" type="button" @click="reset">start over</button>
+    </div>
+
+    <div class="body">
+      <section class="readers" aria-label="terminals reading the run">
+        <article
+          v-for="reader in readers"
+          :key="reader.id"
+          class="reader"
+          :class="readerState(reader)"
+        >
+          <header>
+            <div>
+              <strong>{{ reader.name }}</strong>
+              <span>{{ reader.place }}</span>
+            </div>
+            <em>{{ reader.attached ? 'socket open' : 'socket closed' }}</em>
+          </header>
+
+          <div class="terminal" :class="{ blank: !reader.attached }">
+            <template v-if="reader.attached">
+              <span>round {{ reader.seen }}</span>
+              <span>{{ reader.seen % 2 ? 'checking the patch' : 'running the tests' }}</span>
+              <span v-if="reader.slow">output waiting behind this screen…</span>
+              <span v-else>❯ live from the shared PTY</span>
+            </template>
+            <template v-else>
+              <span>this terminal is back at its shell</span>
+              <span v-if="holderAlive">the PTY is still held elsewhere</span>
+              <span v-else>the PTY and its holder are gone</span>
+            </template>
+          </div>
+
+          <p class="reader-state">{{ readerLabel(reader) }}</p>
+          <div class="reader-actions">
+            <button v-if="reader.attached" type="button" @click="leave(reader)">leave</button>
+            <button
+              v-else
+              type="button"
+              :disabled="runState === 'stopped' || runState === 'killed'"
+              @click="reconnect(reader)"
+            >
+              reconnect
+            </button>
+            <button
+              v-if="reader.id === 'watcher' && reader.attached"
+              class="slow-toggle"
+              type="button"
+              :disabled="runState !== 'running'"
+              @click="toggleSlow(reader)"
+            >
+              {{ reader.slow ? 'let it catch up' : 'stall this reader' }}
+            </button>
+          </div>
+        </article>
+      </section>
+
+      <section class="holder" :class="runState" aria-label="the workspace daemon">
+        <header>
+          <div>
+            <span class="eyebrow">workspace daemon</span>
+            <strong>{{ holderAlive ? 'detached process' : 'detached process ended' }}</strong>
+          </div>
+          <span class="lock">kernel lock {{ holderAlive ? 'held' : 'released' }}</span>
+        </header>
+
+        <div class="layers">
+          <div class="socket">
+            <span>framed local socket</span>
+            <small>input · output · resize · control</small>
+          </div>
+          <div class="pty">
+            <div class="pty-head">
+              <strong>{{ holderAlive ? 'one PTY' : 'PTY closed' }}</strong>
+              <span>{{ attached }} reader{{ attached === 1 ? '' : 's' }}</span>
+            </div>
+            <div class="screen">
+              <span v-for="line in screenLines" :key="line">{{ line }}</span>
+            </div>
+          </div>
+          <div class="run">
+            <span class="pulse" />
+            <div>
+              <strong>the interface and flow</strong>
+              <small>{{ runLabel }}</small>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside
+        class="disk"
+        :aria-label="holderAlive ? 'records written while the run continues' : 'records left by the run'"
+      >
+        <header>{{ holderAlive ? 'on disk while it runs' : 'what the run left on disk' }}</header>
+        <div class="file identity">
+          <strong>daemon.json</strong>
+          <span v-if="holderAlive">holder identity · whole-file note</span>
+          <span v-else>removed with the closed socket</span>
+        </div>
+        <div class="file journal">
+          <strong>cycle.jsonl</strong>
+          <span>{{ journal }} complete lines · append as events happen</span>
+        </div>
+        <div class="file state">
+          <strong>state.json</strong>
+          <span>revision {{ stateRevision }} · replace when the flow writes</span>
+        </div>
+        <div class="file errors">
+          <strong>daemon.log</strong>
+          <span>append failures that no terminal could show</span>
+        </div>
+        <p>
+          The terminal screen is not kept here. The journal records the run's shape, state is
+          what a resumable flow chose to keep, and the backend owns the conversation.
+        </p>
+      </aside>
+    </div>
+
+    <div class="explain">
+      <p aria-live="polite"><strong>Now:</strong> {{ lastEvent }}.</p>
+      <p class="bound">
+        Each press stands in for a large output burst so the source's per-reader 1 MiB bound
+        is visible. A stalled reader never delays the frame counter or the ready reader.
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.daemon {
+  overflow: hidden;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+}
+
+.workspace {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--vp-c-text-2);
+}
+
+.workspace i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--hmz-accent);
+}
+
+.count {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--vp-c-default-soft);
+  font-size: 10.5px;
+  color: var(--vp-c-text-3);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.bar button,
+.reader-actions button {
+  padding: 5px 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.bar button:first-of-type {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+.bar .stop,
+.bar .finish {
+  border-color: var(--hmz-accent);
+  color: var(--hmz-accent);
+}
+
+.bar .kill {
+  border-color: var(--hmz-warm);
+  color: var(--hmz-warm);
+}
+
+.bar .reset {
+  color: var(--vp-c-text-3);
+  font-weight: 500;
+}
+
+button:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.body {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.85fr) minmax(260px, 1.2fr) minmax(205px, 0.9fr);
+  gap: 12px;
+  padding: 14px;
+}
+
+.readers {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+.reader,
+.holder,
+.disk {
+  min-width: 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg);
+}
+
+.reader {
+  overflow: hidden;
+  transition: border-color 0.2s, opacity 0.2s;
+}
+
+.reader.live,
+.reader.replay {
+  border-color: color-mix(in srgb, var(--hmz-accent) 65%, var(--vp-c-divider));
+}
+
+.reader.slow {
+  border-color: var(--hmz-warm);
+}
+
+.reader.away,
+.reader.released {
+  opacity: 0.72;
+  border-style: dashed;
+}
+
+.reader > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+}
+
+.reader header div {
+  min-width: 0;
+}
+
+.reader header strong,
+.reader header span {
+  display: block;
+}
+
+.reader header strong {
+  font-size: 11.5px;
+  color: var(--vp-c-text-1);
+}
+
+.reader header span {
+  margin-top: 1px;
+  font-size: 9.5px;
+  line-height: 1.35;
+  color: var(--vp-c-text-3);
+}
+
+.reader header em {
+  flex: none;
+  font-size: 9px;
+  font-style: normal;
+  color: var(--hmz-accent);
+}
+
+.reader.away header em,
+.reader.released header em {
+  color: var(--vp-c-text-3);
+}
+
+.terminal {
+  min-height: 76px;
+  margin: 0 8px;
+  padding: 8px 9px;
+  border-radius: 7px;
+  background: #17202c;
+  color: #b9d3e8;
+  font-family: var(--vp-font-family-mono);
+  font-size: 9.5px;
+  line-height: 1.55;
+}
+
+.terminal span {
+  display: block;
+}
+
+.terminal span:first-child {
+  color: #75dacd;
+}
+
+.terminal.blank {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-3);
+}
+
+.terminal.blank span:first-child {
+  color: var(--vp-c-text-2);
+}
+
+.reader-state {
+  min-height: 30px;
+  margin: 0;
+  padding: 7px 9px 0;
+  font-size: 9.5px;
+  line-height: 1.35;
+  color: var(--vp-c-text-3);
+}
+
+.reader.slow .reader-state,
+.reader.released .reader-state {
+  color: var(--hmz-warm);
+}
+
+.reader.replay .reader-state {
+  color: var(--hmz-accent);
+}
+
+.reader-actions {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  padding: 7px 8px 9px;
+}
+
+.reader-actions button {
+  padding: 3px 8px;
+  font-size: 9.5px;
+}
+
+.reader-actions .slow-toggle {
+  border-color: var(--hmz-warm);
+  color: var(--hmz-warm);
+}
+
+.holder {
+  align-self: start;
+  overflow: hidden;
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 0 0 3px var(--vp-c-brand-soft);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.holder.stopping {
+  border-color: var(--hmz-accent);
+}
+
+.holder.stopped,
+.holder.killed {
+  border-color: var(--vp-c-divider);
+  box-shadow: none;
+}
+
+.holder.killed {
+  border-style: dashed;
+}
+
+.holder > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+}
+
+.holder header strong,
+.holder header span {
+  display: block;
+}
+
+.eyebrow {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.holder header strong {
+  font-size: 13px;
+  color: var(--vp-c-text-1);
+}
+
+.holder .lock {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--vp-c-brand-soft);
+  font-size: 9px;
+  color: var(--vp-c-brand-1);
+}
+
+.layers {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.socket,
+.pty,
+.run {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 9px;
+}
+
+.socket {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 9px;
+  color: var(--vp-c-text-2);
+  font-size: 10.5px;
+}
+
+.socket small {
+  color: var(--vp-c-text-3);
+  font-size: 8.5px;
+  text-align: right;
+}
+
+.pty {
+  padding: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+.pty-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.pty-head strong {
+  color: var(--vp-c-brand-1);
+  font-size: 11px;
+}
+
+.pty-head span {
+  color: var(--vp-c-text-3);
+  font-size: 9px;
+}
+
+.screen {
+  min-height: 112px;
+  padding: 10px 11px;
+  border-radius: 7px;
+  background: #17202c;
+  color: #c5daea;
+  font-family: var(--vp-font-family-mono);
+  font-size: 10.5px;
+  line-height: 1.7;
+}
+
+.screen span {
+  display: block;
+}
+
+.screen span:first-child {
+  color: #75dacd;
+}
+
+.screen span:last-child {
+  color: #e8a66f;
+}
+
+.run {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px;
+}
+
+.pulse {
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--hmz-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--hmz-accent) 16%, transparent);
+}
+
+.stopping .pulse {
+  background: var(--hmz-warm);
+}
+
+.stopped .pulse,
+.killed .pulse {
+  background: var(--vp-c-text-3);
+  box-shadow: none;
+}
+
+.run strong,
+.run small {
+  display: block;
+}
+
+.run strong {
+  font-size: 10.5px;
+  color: var(--vp-c-text-1);
+}
+
+.run small {
+  margin-top: 1px;
+  font-size: 9.5px;
+  color: var(--vp-c-text-3);
+}
+
+.disk {
+  align-self: start;
+  overflow: hidden;
+}
+
+.disk > header {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.file {
+  margin: 8px 9px 0;
+  padding: 7px 8px;
+  border-left: 2px solid var(--vp-c-brand-1);
+  background: var(--vp-c-bg-soft);
+}
+
+.file.journal {
+  border-left-color: var(--hmz-accent);
+}
+
+.file.state {
+  border-left-color: var(--hmz-accent-2);
+}
+
+.file.errors {
+  border-left-color: var(--hmz-warm);
+}
+
+.file strong,
+.file span {
+  display: block;
+}
+
+.file strong {
+  font-family: var(--vp-font-family-mono);
+  font-size: 10px;
+  color: var(--vp-c-text-1);
+}
+
+.file span {
+  margin-top: 2px;
+  font-size: 9px;
+  line-height: 1.35;
+  color: var(--vp-c-text-3);
+}
+
+.disk p {
+  margin: 0;
+  padding: 10px;
+  font-size: 9.5px;
+  line-height: 1.5;
+  color: var(--vp-c-text-3);
+}
+
+.explain {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 10px 14px 12px;
+  border-top: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+}
+
+.explain p {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+
+.explain strong {
+  color: var(--vp-c-text-1);
+}
+
+.explain .bound {
+  margin-left: auto;
+  max-width: 390px;
+  color: var(--vp-c-text-3);
+  font-size: 9.5px;
+}
+
+@media (max-width: 860px) {
+  .body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .readers {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .body,
+  .readers {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .readers {
+    grid-column: auto;
+  }
+
+  .explain {
+    display: block;
+  }
+
+  .explain .bound {
+    margin: 6px 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reader,
+  .holder {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/HmzFeatures.vue
+++ b/docs/.vitepress/theme/components/HmzFeatures.vue
@@ -20,8 +20,8 @@ import { withBase } from 'vitepress'
           <circle cx="158" cy="74" r="5.5" />
         </g>
       </svg>
-      <h3>One flow, eleven CLIs</h3>
-      <p>claude · codex · dsh · agy · grok · kimi · qwen · pi · opencode · mimo · zcode</p>
+      <h3>One flow, many coding agents</h3>
+      <p>agy · claude · codex · cursor · dsh · grok · kimi · mimo · opencode · pi · qwen · zcode</p>
     </a>
 
     <a class="card" :href="withBase('/features/steering')">
@@ -51,8 +51,8 @@ import { withBase } from 'vitepress'
         </g>
         <line class="head" x1="20" y1="10" x2="20" y2="78" />
       </svg>
-      <h3>Every run, a timeline</h3>
-      <p><code>hmz trace collect</code> — then open it in Perfetto.</p>
+      <h3>Trace a run on one timeline</h3>
+      <p>Reconstruct the agents and programs, then inspect them together in Perfetto.</p>
     </a>
 
     <a class="card" :href="withBase('/features/anchor')">
@@ -194,7 +194,7 @@ svg text {
   text-anchor: middle;
 }
 
-/* one flow, eleven CLIs */
+/* one flow, many coding agents */
 .fan path {
   fill: none;
   stroke: var(--vp-c-divider);

--- a/docs/.vitepress/theme/components/HmzInstall.vue
+++ b/docs/.vitepress/theme/components/HmzInstall.vue
@@ -45,7 +45,7 @@ onUnmounted(() => clearTimeout(clearing))
     </div>
 
     <p class="under">
-      Python ≥ 3.12 · drives the coding agent CLI you already log into · no API key of its own
+      Python ≥ 3.12 · reuses existing CLI logins · bundled DSH uses provider credentials
     </p>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/HmzMap.vue
+++ b/docs/.vitepress/theme/components/HmzMap.vue
@@ -1,156 +1,244 @@
 <script setup lang="ts">
-// The features, laid out as the thing they belong to: a line you type, a flow that drives
-// agents, an agent driving a CLI, work landing somewhere, and a record of all of it. Hover
-// one to read what it is; click it for the page.
+// The feature tree, compressed into its five systems and nineteen capability groups. Each
+// group names the guarantee it owns and leads to the page that explains it best.
 import { computed, ref } from 'vue'
 import { withBase } from 'vitepress'
 
-interface Feature {
-  said: string
+interface CapabilityGroup {
+  code: string
+  name: string
   link: string
-  about: string
-  deep?: boolean
+  guarantee: string
+  start?: boolean
 }
 
-interface Stage {
+interface SystemDomain {
+  code: string
   name: string
   sub: string
-  features: Feature[]
+  groups: CapabilityGroup[]
 }
 
-const STAGES: Stage[] = [
+const SYSTEMS: SystemDomain[] = [
   {
-    name: 'you',
-    sub: 'at the prompt, or not there at all',
-    features: [
+    code: 'A',
+    name: 'Flow system',
+    sub: 'express · prove · compose · resume',
+    groups: [
       {
-        said: 'a line typed mid-turn',
-        link: '/features/steering',
-        deep: true,
-        about: 'It goes into the turn that is running rather than starting another one after it.',
+        code: 'A1',
+        name: 'Expression & compilation',
+        link: '/features/prophecy',
+        start: true,
+        guarantee:
+          'Free-form Python shares one runtime with an atlas, whose restricted body compiles into a graph.',
       },
       {
-        said: 'you, as one of the agents',
-        link: '/features/human',
-        about: 'A flow puts a decision to a person the same way it puts one to a model, in the same shape.',
+        code: 'A2',
+        name: 'Static correctness & proving',
+        link: '/features/prophecy',
+        guarantee:
+          'Structural mistakes are rejected before a model call costs time, money, or a live run.',
       },
-    ],
-  },
-  {
-    name: 'the flow',
-    sub: 'a directory of Python',
-    features: [
       {
-        said: 'a flow is Python',
+        code: 'A3',
+        name: 'Composition & hot reload',
         link: '/features/flows',
-        about: 'A loop, a subprocess call, a file read between turns — and the agents are its arguments.',
+        guarantee:
+          'Flows and skills can nest; regular flows can reload current source between calls.',
       },
       {
-        said: 'many turns at once',
-        link: '/features/concurrency',
-        about: 'Turns are only sequential inside one session, so two hundred conversations are two hundred turns.',
-      },
-      {
-        said: 'picked up where it stopped',
+        code: 'A4',
+        name: 'Scheduling, state & resumption',
         link: '/features/resuming',
-        about: 'A week-long loop is a loop that will be stopped. What it was keeping track of survives.',
+        guarantee:
+          'Placement and fan-out pair with explicit state or atlas node-level resumption.',
       },
     ],
   },
   {
-    name: 'the agent',
-    sub: 'a CLI, a model, an effort, an account',
-    features: [
+    code: 'B',
+    name: 'Agent control plane',
+    sub: 'sessions · tools · recovery · identity',
+    groups: [
       {
-        said: 'answers in a shape',
-        link: '/features/shapes',
-        deep: true,
-        about: 'A turn given a model answers with that model, so a flow reads a field rather than a paragraph.',
-      },
-      {
-        said: 'it decides when it is done',
-        link: '/features/goals',
-        about: "The backend's own goal feature: a turn that would have ended starts another.",
-      },
-      {
-        said: 'the moments of a turn',
-        link: '/features/hooks',
-        about: 'Python callables hung on the points a turn passes through, and taken down while it runs.',
-      },
-    ],
-  },
-  {
-    name: 'the CLI',
-    sub: 'the one you already have',
-    features: [
-      {
-        said: 'eleven CLIs, one agent',
+        code: 'B1',
+        name: 'Backend unification',
         link: '/features/backends',
-        about: 'Driven through whatever each of them offers, and asked what it runs rather than told.',
+        guarantee:
+          'Different CLIs and app servers expose one session protocol without flattening their capabilities.',
       },
       {
-        said: 'two accounts of one CLI',
+        code: 'B2',
+        name: 'Turn & session control',
+        link: '/features/steering',
+        start: true,
+        guarantee:
+          'Typed, capability-aware controls steer, clone, and pursue goals where a backend supports them.',
+      },
+      {
+        code: 'B3',
+        name: 'Tools & skills',
+        link: '/guide/tools',
+        guarantee:
+          'Skills are selected per session, while flow callbacks can become temporary native tools.',
+      },
+      {
+        code: 'B4',
+        name: 'Failure recovery',
         link: '/features/accounts',
-        deep: true,
-        about: 'A CLI signs in once. humanize runs it as an account it was never signed into, without asking it.',
+        guarantee:
+          'A failed session can recover in place, migrate accounts, or use another CLI without losing intent.',
+      },
+      {
+        code: 'B5',
+        name: 'Accounts & credentials',
+        link: '/features/accounts',
+        guarantee:
+          'Credential inputs can be isolated, redirected, and reused without leaking provider state.',
       },
     ],
   },
   {
-    name: 'where it lands',
-    sub: 'here, or somewhere else entirely',
-    features: [
+    code: 'C',
+    name: 'Execution fabric',
+    sub: 'local control · remote work',
+    groups: [
       {
-        said: 'the anchor',
+        code: 'C1',
+        name: 'Transparent remote execution',
         link: '/features/anchor',
-        deep: true,
-        about: 'The agent runs here and every syscall it makes is decided one at a time: replayed there, or answered here.',
+        start: true,
+        guarantee:
+          'A local agent operates a remote machine within documented process and signal boundaries.',
+      },
+      {
+        code: 'C2',
+        name: 'Shadow workspace & consistent writes',
+        link: '/features/anchor',
+        guarantee:
+          'Remote workspaces appear immediately and writes land atomically as files arrive on demand.',
+      },
+      {
+        code: 'C3',
+        name: 'Portable transport runtime',
+        link: '/features/anchor',
+        guarantee:
+          'Targets need no install: one protocol carries processes, files, environment, and working directory.',
+      },
+      {
+        code: 'C4',
+        name: 'Machine lifecycle',
+        link: '/features/anchor',
+        guarantee:
+          'Machines can be isolated per agent or shared for a run, with explicit lifecycle ownership.',
       },
     ],
   },
   {
-    name: 'what it leaves',
-    sub: 'a run you can read back',
-    features: [
+    code: 'D',
+    name: 'Run continuity & observability',
+    sub: 'detach · recover · reconstruct · scrub',
+    groups: [
       {
-        said: 'one timeline',
+        code: 'D1',
+        name: 'Detached operation',
+        link: '/features/daemon',
+        start: true,
+        guarantee:
+          'Runs outlive terminals: a workspace daemon preserves PTYs, replay, attach, and stop control.',
+      },
+      {
+        code: 'D2',
+        name: 'Persistent state & layered logs',
+        link: '/features/resuming',
+        guarantee:
+          'State and nested journals are written through, so a crash leaves a readable recovery record.',
+      },
+      {
+        code: 'D3',
+        name: 'Trace reconstruction',
         link: '/features/tracing',
-        deep: true,
-        about: 'Every agent, every sub-agent and every program they ran, on one clock, in one document.',
+        guarantee:
+          'Sessions, sub-agents, and processes rebuild onto one calibrated, session-bounded timeline.',
+      },
+      {
+        code: 'D4',
+        name: 'Telemetry privacy',
+        link: '/features/tracing',
+        guarantee:
+          'Reporting has explicit consent state and is scrubbed before anything leaves the machine.',
+      },
+    ],
+  },
+  {
+    code: 'E',
+    name: 'Product surfaces',
+    sub: 'discover · configure · invoke',
+    groups: [
+      {
+        code: 'E1',
+        name: 'Discovery, forking & config',
+        link: '/features/surfaces',
+        guarantee:
+          'Flows can be discovered locally, forked atomically, and configured from their schemas.',
+      },
+      {
+        code: 'E2',
+        name: 'Unified entry points',
+        link: '/features/surfaces',
+        start: true,
+        guarantee:
+          'SDK, CLI, terminal interface, and daemon reach the same underlying flow and run model.',
       },
     ],
   },
 ]
 
-const held = ref<Feature | null>(null)
+const hovered = ref<CapabilityGroup | null>(null)
+const focused = ref<CapabilityGroup | null>(null)
+const active = computed(() => focused.value ?? hovered.value)
+const groupCount = SYSTEMS.reduce((count, system) => count + system.groups.length, 0)
 const caption = computed(
   () =>
-    held.value?.about ??
-    'Six stages, twelve pages. The ones marked are worth reading even if you never run it.',
+    active.value?.guarantee ??
+    `${SYSTEMS.length} systems, ${groupCount} capability groups. Hover or focus a group for its core guarantee; open it for the closest explanation.`,
 )
 </script>
 
 <template>
   <div class="map hmz-panel">
-    <div class="stages">
-      <section v-for="stage in STAGES" :key="stage.name" class="stage">
+    <div class="systems">
+      <section
+        v-for="system in SYSTEMS"
+        :key="system.code"
+        class="system"
+        :aria-labelledby="`domain-${system.code}`"
+      >
         <header>
-          <strong>{{ stage.name }}</strong>
-          <span>{{ stage.sub }}</span>
+          <span class="domain-code">{{ system.code }}</span>
+          <strong :id="`domain-${system.code}`">{{ system.name }}</strong>
+          <span>{{ system.sub }}</span>
         </header>
         <a
-          v-for="one in stage.features"
-          :key="one.link"
+          v-for="group in system.groups"
+          :key="group.code"
           class="chip"
-          :class="{ deep: one.deep, held: held?.link === one.link }"
-          :href="withBase(one.link)"
-          @mouseenter="held = one"
-          @mouseleave="held = null"
-          @focus="held = one"
-          @blur="held = null"
+          :class="{ start: group.start, held: active?.code === group.code }"
+          :href="withBase(group.link)"
+          :aria-label="`${group.code}. ${group.name}`"
+          :aria-describedby="`guarantee-${group.code}`"
+          @mouseenter="hovered = group"
+          @mouseleave="hovered = null"
+          @focus="focused = group"
+          @blur="focused = null"
         >
-          <span>{{ one.said }}</span>
-          <i v-if="one.deep">the deep end</i>
+          <small>{{ group.code }}</small>
+          <span>{{ group.name }}</span>
+          <i v-if="group.start">start here</i>
+          <span :id="`guarantee-${group.code}`" class="guarantee">
+            {{ group.guarantee }}
+          </span>
         </a>
       </section>
     </div>
@@ -159,20 +247,20 @@ const caption = computed(
 </template>
 
 <style scoped>
-.stages {
+.systems {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 10px;
   padding: 16px 16px 0;
   position: relative;
 }
 
-.stages::before {
+.systems::before {
   content: '';
   position: absolute;
   left: 16px;
   right: 16px;
-  top: 74px;
+  top: 92px;
   height: 2px;
   border-radius: 2px;
   background: linear-gradient(
@@ -193,25 +281,45 @@ const caption = computed(
   }
 }
 
-.stage {
+.system {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 
-.stage header {
-  display: flex;
-  flex-direction: column;
-  min-height: 52px;
+.system header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  column-gap: 7px;
+  min-height: 70px;
   margin-bottom: 12px;
 }
 
-.stage header strong {
+.system header .domain-code {
+  grid-row: 1 / 3;
+  align-self: start;
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 7px;
+  color: var(--vp-c-brand-1);
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.system header strong {
+  min-width: 0;
   font-size: 12.5px;
+  line-height: 1.3;
   color: var(--vp-c-text-1);
 }
 
-.stage header span {
+.system header > span:last-child {
   font-size: 10.5px;
   line-height: 1.35;
   color: var(--vp-c-text-3);
@@ -219,6 +327,7 @@ const caption = computed(
 
 .chip {
   display: block;
+  min-width: 0;
   padding: 10px 12px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 11px;
@@ -230,6 +339,15 @@ const caption = computed(
   transition: transform 0.2s, border-color 0.2s, background 0.2s, color 0.2s;
 }
 
+.chip small {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--vp-c-text-3);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
 .chip:hover,
 .chip.held {
   transform: translateY(-2px);
@@ -238,7 +356,12 @@ const caption = computed(
   background: var(--vp-c-brand-soft);
 }
 
-.chip.deep {
+.chip:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+.chip.start {
   border-color: var(--hmz-accent);
 }
 
@@ -258,28 +381,76 @@ const caption = computed(
   font-size: 13px;
   line-height: 1.65;
   color: var(--vp-c-text-2);
-  min-height: 58px;
+  min-height: 74px;
+}
+
+.guarantee {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 980px) {
-  .stages {
+  .systems {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .stages::before {
+  .systems::before {
     display: none;
   }
 }
 
-@media (max-width: 620px) {
-  .stages {
+@media (max-width: 660px) {
+  .systems {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chip .guarantee {
+    position: static;
+    display: block;
+    width: auto;
+    height: auto;
+    padding: 0;
+    margin: 6px 0 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: 0;
+    color: var(--vp-c-text-3);
+    font-size: 10.5px;
+    line-height: 1.45;
+  }
+}
+
+@media (max-width: 420px) {
+  .systems {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .system header {
+    min-height: 0;
+    margin-bottom: 4px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .stages::before {
+  .systems::before {
     animation: none;
+  }
+
+  .chip {
+    transition: none;
+  }
+
+  .chip:hover,
+  .chip.held {
+    transform: none;
   }
 }
 </style>

--- a/docs/.vitepress/theme/components/HmzProphecy.vue
+++ b/docs/.vitepress/theme/components/HmzProphecy.vue
@@ -1,0 +1,1067 @@
+<script setup lang="ts">
+// An atlas is read into a prophecy before its first node runs. This drawing keeps the same
+// small review loop under four lenses: what the compiler settles, what the static reading
+// refuses, which edits change the graph, and where a stopped walk continues.
+import { computed, ref } from 'vue'
+
+type Mode = 'compile' | 'check' | 'evolve' | 'resume'
+type Check = 'sound' | 'dead' | 'shape' | 'verdict'
+type Edit = 'format' | 'body' | 'graph'
+
+interface Choice<T extends string> {
+  key: T
+  name: string
+}
+
+interface Finding extends Choice<Check> {
+  level: 'pass' | 'error' | 'warning'
+  code: string
+  said: string
+}
+
+const MODES: Choice<Mode>[] = [
+  { key: 'compile', name: 'compile it' },
+  { key: 'check', name: 'read it statically' },
+  { key: 'evolve', name: 'change the source' },
+  { key: 'resume', name: 'pick it up' },
+]
+
+const CHECKS: Finding[] = [
+  {
+    key: 'sound',
+    name: 'sound graph',
+    level: 'pass',
+    code: 'prophecy emitted',
+    said: 'Every call is shaped, the branch follows logic, and the loop changes what its head reads.',
+  },
+  {
+    key: 'dead',
+    name: 'unchanged loop head',
+    level: 'error',
+    code: 'dead-loop',
+    said: 'The round changes a draft but never the verdict its head reads, so the next decision cannot differ.',
+  },
+  {
+    key: 'shape',
+    name: 'wrong edge shape',
+    level: 'error',
+    code: 'shape-mismatch',
+    said: 'This connection offers a Draft where the deciding node declares that it takes a Verdict.',
+  },
+  {
+    key: 'verdict',
+    name: 'impossible verdict',
+    level: 'warning',
+    code: 'unknown-verdict',
+    said: 'The declared answer offers “done” and “redo”; comparing it with “DONE” guards nothing.',
+  },
+]
+
+const EDITS: Choice<Edit>[] = [
+  { key: 'format', name: 'comment or layout' },
+  { key: 'body', name: 'node body' },
+  { key: 'graph', name: 'edge or shape' },
+]
+
+const BASE_DIGEST = '06ebb726641e4a5f'
+const MOVED_DIGEST = '4c9a01ab2f7e5510'
+
+const mode = ref<Mode>('compile')
+const nested = ref(false)
+const check = ref<Check>('sound')
+const edit = ref<Edit>('format')
+const shipped = ref(true)
+const graphChanged = ref(false)
+const resumed = ref(false)
+
+const finding = computed(() => CHECKS.find((one) => one.key === check.value) ?? CHECKS[0])
+const currentDigest = computed(() => (edit.value === 'graph' ? MOVED_DIGEST : BASE_DIGEST))
+const drifted = computed(() => shipped.value && currentDigest.value !== BASE_DIGEST)
+
+const rail = computed(() => {
+  if (mode.value === 'compile') {
+    return ['restricted atlas body', 'syntax-tree reading', 'typed prophecy']
+  }
+  if (mode.value === 'check') return ['every Python file', 'zero execution', finding.value.code]
+  if (mode.value === 'evolve') return ['source graph', 'canonical text', currentDigest.value]
+  return ['saved visits', 'same digest?', 'first visit with no answer']
+})
+
+const intro = computed(() => {
+  if (mode.value === 'compile') {
+    return nested.value
+      ? 'Open the supernode: one node in the outer graph is a complete prophecy underneath.'
+      : 'The body is never called. Its call sites, bindings, branches and return become this graph.'
+  }
+  if (mode.value === 'check') {
+    return 'Change one fact. The reading says everything it can establish without importing the flow.'
+  }
+  if (mode.value === 'evolve') {
+    return 'Change the source and compare graph identity. A graph edit is different from an implementation edit.'
+  }
+  return graphChanged.value
+    ? 'The stopped run names another prophecy. Picking it up must begin at the way in.'
+    : 'The stopped run has four answers and stopped inside the fifth visit.'
+})
+
+const aria = computed(() => {
+  if (mode.value === 'check') return `A review-loop prophecy showing ${finding.value.code}`
+  if (mode.value === 'evolve') return `A review-loop prophecy with digest ${currentDigest.value}`
+  if (mode.value === 'resume') {
+    if (!resumed.value) return 'A review-loop prophecy stopped inside review visit two'
+    return graphChanged.value
+      ? 'A changed prophecy starting again at write visit one'
+      : 'The same prophecy continuing at review visit two'
+  }
+  return nested.value
+    ? 'A review-loop prophecy with review expanded as a nested prophecy'
+    : 'A typed review-loop prophecy compiled from an atlas'
+})
+
+const completed = computed(() => {
+  if (mode.value !== 'resume' || graphChanged.value) return new Set<string>()
+  return new Set(['write', 'review', 'settled', 'write2'])
+})
+
+const stale = computed(() => {
+  if (mode.value !== 'resume' || !graphChanged.value || resumed.value) return new Set<string>()
+  return new Set(['write', 'review', 'settled', 'write2'])
+})
+
+const active = computed(() => {
+  if (mode.value !== 'resume' || !resumed.value) return ''
+  return graphChanged.value ? 'write' : 'review2'
+})
+
+const stopped = computed(() =>
+  mode.value === 'resume' && !resumed.value ? 'review2' : '',
+)
+
+const readout = computed(() => {
+  if (mode.value === 'compile') {
+    return nested.value
+      ? {
+          kicker: 'one node outside · one prophecy within',
+          title: 'The nested graph is compiled too',
+          body:
+            'Its nodes, edges and shapes sit beneath reviewing. A path back into a prophecy already being compiled is refused, so the nesting always has a bottom.',
+        }
+      : {
+          kicker: 'nodes · edges · shapes · ways out',
+          title: 'The graph is the executable plan',
+          body:
+            'Mind nodes take turns; logic nodes decide. The back-edge runs settled again with the new review, and the named way out ends the walk.',
+        }
+  }
+  if (mode.value === 'check') {
+    return {
+      kicker: `${finding.value.level} · ${finding.value.code}`,
+      title: finding.value.name,
+      body: finding.value.said,
+    }
+  }
+  if (mode.value === 'evolve') {
+    if (edit.value === 'format') {
+      return {
+        kicker: 'same digest',
+        title: 'Formatting is not graph identity',
+        body:
+          'Comments, docstring layout and line numbers are absent from the prophecy. The source moved; the graph did not.',
+      }
+    }
+    if (edit.value === 'body') {
+      return {
+        kicker: 'same digest · current implementation',
+        title: 'Work may change beneath a stable graph',
+        body:
+          'Function bodies are not graph structure. The next run loads the current node code while completed visits keep the answers they already wrote.',
+      }
+    }
+    return drifted.value
+      ? {
+          kicker: 'error · stale-prophecy',
+          title: 'The source and shipped graph disagree',
+          body:
+            'A run walks the shipped graph, so the static reading reports both digests instead of pretending the package now does what the source draws.',
+        }
+      : {
+          kicker: 'new digest',
+          title: 'A changed graph is another prophecy',
+          body:
+            'Changing an edge, node signature, shape or nested prophecy changes identity. Saved visits from the old graph do not cross that line.',
+        }
+  }
+  if (!resumed.value) {
+    return {
+      kicker: 'stopped · review:2#1',
+      title: 'Four visits already have answers',
+      body:
+        'The current visit was written before it ran. It has no answer yet, which is how the next run knows exactly where work was interrupted.',
+    }
+  }
+  return graphChanged.value
+    ? {
+        kicker: 'digest mismatch · state cleared',
+        title: 'The new graph starts at the top',
+        body:
+          'Node names that happen to survive an edit are not proof that they still mean the same work. The first visit is write#1 again.',
+      }
+    : {
+        kicker: 'same digest · four answers replayed',
+        title: 'The interrupted node runs again',
+        body:
+          'The walk rebuilds the values above it without rerunning their nodes, then reaches review:2#1 with no answer. By default, unfinished work runs again.',
+      }
+})
+
+function chooseMode(next: Mode) {
+  mode.value = next
+  resumed.value = false
+}
+
+function chooseGraph(changed: boolean) {
+  graphChanged.value = changed
+  resumed.value = false
+}
+
+function badNode(id: string) {
+  if (mode.value !== 'check') return false
+  if (check.value === 'shape') return id === 'review' || id === 'settled'
+  if (check.value === 'verdict') return id === 'settled'
+  if (check.value === 'dead') return id === 'write2'
+  return false
+}
+</script>
+
+<template>
+  <div class="prophecy hmz-panel">
+    <div class="bar">
+      <div class="tabs" role="group" aria-label="which property of the prophecy to inspect">
+        <button
+          v-for="one in MODES"
+          :key="one.key"
+          type="button"
+          :aria-pressed="mode === one.key"
+          :class="{ on: mode === one.key }"
+          @click="chooseMode(one.key)"
+        >
+          {{ one.name }}
+        </button>
+      </div>
+
+      <div class="spacer" />
+
+      <label v-if="mode === 'compile'" class="switch">
+        <input v-model="nested" type="checkbox" />
+        open a supernode
+      </label>
+      <label v-else-if="mode === 'evolve'" class="switch">
+        <input v-model="shipped" type="checkbox" />
+        a prophecy is shipped
+      </label>
+      <button
+        v-else-if="mode === 'resume'"
+        class="resume-button"
+        type="button"
+        :disabled="resumed"
+        @click="resumed = true"
+      >
+        {{ resumed ? 'picked up' : 'pick it up' }}
+      </button>
+    </div>
+
+    <p class="intro">{{ intro }}</p>
+
+    <div v-if="mode === 'check'" class="choices" role="group" aria-label="static finding">
+      <button
+        v-for="one in CHECKS"
+        :key="one.key"
+        type="button"
+        :aria-pressed="check === one.key"
+        :class="[{ on: check === one.key }, one.level]"
+        @click="check = one.key"
+      >
+        {{ one.name }}
+      </button>
+    </div>
+
+    <div v-else-if="mode === 'evolve'" class="choices" role="group" aria-label="source edit">
+      <button
+        v-for="one in EDITS"
+        :key="one.key"
+        type="button"
+        :aria-pressed="edit === one.key"
+        :class="{ on: edit === one.key }"
+        @click="edit = one.key"
+      >
+        {{ one.name }}
+      </button>
+    </div>
+
+    <div v-else-if="mode === 'resume'" class="choices" role="group" aria-label="prophecy identity">
+      <button
+        type="button"
+        :aria-pressed="!graphChanged"
+        :class="{ on: !graphChanged }"
+        @click="chooseGraph(false)"
+      >
+        same prophecy
+      </button>
+      <button
+        type="button"
+        :aria-pressed="graphChanged"
+        :class="{ on: graphChanged }"
+        @click="chooseGraph(true)"
+      >
+        graph changed
+      </button>
+    </div>
+
+    <div class="rail">
+      <template v-for="(one, i) in rail" :key="one">
+        <span :class="{ digest: i === rail.length - 1 && mode === 'evolve' }">{{ one }}</span>
+        <i v-if="i < rail.length - 1" aria-hidden="true">→</i>
+      </template>
+    </div>
+
+    <div class="canvas">
+      <svg viewBox="0 0 900 350" role="img" :aria-label="aria">
+        <defs>
+          <marker
+            id="prophecy-arrow"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+          >
+            <path d="M 0 0 L 8 4 L 0 8 z" class="arrow-head" />
+          </marker>
+          <marker
+            id="prophecy-arrow-bad"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+          >
+            <path d="M 0 0 L 8 4 L 0 8 z" class="arrow-head bad" />
+          </marker>
+        </defs>
+
+        <path class="edge" d="M 51 132 L 79 132" />
+        <path class="edge" d="M 211 132 L 264 132" />
+        <path
+          class="edge"
+          :class="{ bad: mode === 'check' && check === 'shape' }"
+          d="M 396 132 L 459 132"
+        />
+        <path
+          class="edge"
+          :class="{
+            bad: mode === 'check' && check === 'verdict',
+            changed: mode === 'evolve' && edit === 'graph',
+          }"
+          d="M 591 132 L 773 132"
+        />
+        <path class="edge" d="M 525 164 L 525 238" />
+        <path
+          v-if="!(mode === 'check' && check === 'dead')"
+          class="edge"
+          d="M 459 270 L 396 270"
+        />
+        <path
+          v-if="!(mode === 'check' && check === 'dead')"
+          class="edge back"
+          d="M 330 238 C 330 198, 420 188, 459 153"
+        />
+        <path
+          v-else
+          class="edge back bad"
+          d="M 459 270 C 375 270, 380 190, 459 153"
+        />
+
+        <text x="238" y="117" class="edge-label">Draft</text>
+        <text
+          x="427"
+          y="117"
+          class="edge-label"
+          :class="{ bad: mode === 'check' && check === 'shape' }"
+        >
+          {{ mode === 'check' && check === 'shape' ? 'Draft ≠ Verdict' : 'Verdict' }}
+        </text>
+        <text
+          x="666"
+          y="117"
+          class="edge-label"
+          :class="{ bad: mode === 'check' && check === 'verdict' }"
+        >
+          {{ mode === 'check' && check === 'verdict' ? 'status = “DONE”' : 'done' }}
+        </text>
+        <text x="542" y="207" class="edge-label">not done</text>
+        <text
+          v-if="mode === 'check' && check === 'dead'"
+          x="378"
+          y="224"
+          class="edge-label bad"
+        >
+          verdict unchanged
+        </text>
+
+        <circle cx="38" cy="132" r="13" class="terminal" />
+        <text x="38" y="105" class="terminal-label">way in</text>
+
+        <g
+          class="node mind"
+          :class="{
+            bad: badNode('write'),
+            done: completed.has('write'),
+            stale: stale.has('write'),
+            active: active === 'write',
+          }"
+        >
+          <rect x="79" y="100" width="132" height="64" rx="11" />
+          <text x="145" y="127" class="node-title">write</text>
+          <text x="145" y="149" class="node-kind">mind · Draft</text>
+        </g>
+
+        <g
+          class="node"
+          :class="[
+            mode === 'compile' && nested ? 'atlas' : 'mind',
+            {
+              bad: badNode('review'),
+              done: completed.has('review'),
+              stale: stale.has('review'),
+            },
+          ]"
+        >
+          <rect x="264" y="100" width="132" height="64" rx="11" />
+          <text x="330" y="127" class="node-title">
+            {{ mode === 'compile' && nested ? 'reviewing' : 'review' }}
+          </text>
+          <text x="330" y="149" class="node-kind">
+            {{ mode === 'compile' && nested ? 'atlas · Verdict' : 'mind · Verdict' }}
+          </text>
+        </g>
+
+        <g
+          class="node logic"
+          :class="{
+            bad: badNode('settled'),
+            done: completed.has('settled'),
+            stale: stale.has('settled'),
+          }"
+        >
+          <rect x="459" y="100" width="132" height="64" rx="11" />
+          <text x="525" y="127" class="node-title">settled</text>
+          <text x="525" y="149" class="node-kind">logic · Verdict</text>
+        </g>
+
+        <g
+          class="node mind"
+          :class="{
+            bad: badNode('write2'),
+            done: completed.has('write2'),
+            stale: stale.has('write2'),
+          }"
+        >
+          <rect x="459" y="238" width="132" height="64" rx="11" />
+          <text x="525" y="265" class="node-title">write:2</text>
+          <text x="525" y="287" class="node-kind">mind · Draft</text>
+        </g>
+
+        <g
+          v-if="!(mode === 'check' && check === 'dead')"
+          class="node"
+          :class="[
+            mode === 'compile' && nested ? 'atlas' : 'mind',
+            {
+              done: completed.has('review2'),
+              stale: stale.has('review2'),
+              active: active === 'review2',
+              stopped: stopped === 'review2',
+            },
+          ]"
+        >
+          <rect x="264" y="238" width="132" height="64" rx="11" />
+          <text x="330" y="265" class="node-title">
+            {{ mode === 'compile' && nested ? 'reviewing:2' : 'review:2' }}
+          </text>
+          <text x="330" y="287" class="node-kind">
+            {{
+              active === 'review2'
+                ? 'runs again'
+                : stopped === 'review2'
+                  ? 'stopped here'
+                  : mode === 'compile' && nested
+                    ? 'atlas · Verdict'
+                    : 'mind · Verdict'
+            }}
+          </text>
+        </g>
+
+        <circle cx="800" cy="132" r="19" class="terminal end" />
+        <circle cx="800" cy="132" r="9" class="terminal end inner" />
+        <text x="800" y="96" class="terminal-label">way out</text>
+
+        <g v-if="mode === 'compile' && nested" class="under">
+          <path d="M 330 164 C 470 188, 540 205, 615 224" class="under-line" />
+          <rect x="615" y="198" width="250" height="119" rx="13" />
+          <text x="740" y="220" class="under-title">under reviewing</text>
+          <rect x="634" y="237" width="88" height="48" rx="8" class="under-node mind" />
+          <text x="678" y="257" class="under-name">review</text>
+          <text x="678" y="275" class="under-kind">mind</text>
+          <path d="M 722 261 L 752 261" class="under-line arrow" />
+          <rect x="752" y="237" width="94" height="48" rx="8" class="under-node logic" />
+          <text x="799" y="257" class="under-name">settled</text>
+          <text x="799" y="275" class="under-kind">logic</text>
+          <text x="740" y="304" class="under-foot">one node outside · one graph inside</text>
+        </g>
+      </svg>
+    </div>
+
+    <div
+      class="readout"
+      :class="[
+        mode,
+        mode === 'check' ? finding.level : '',
+        { drifted: mode === 'evolve' && drifted },
+      ]"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <section class="explain">
+        <span class="kicker">{{ readout.kicker }}</span>
+        <strong>{{ readout.title }}</strong>
+        <p>{{ readout.body }}</p>
+      </section>
+
+      <aside v-if="mode === 'compile'" class="facts">
+        <span><b class="mind-dot" />mind <em>one turn · one way out</em></span>
+        <span><b class="logic-dot" />logic <em>Python · may decide</em></span>
+        <span><b class="atlas-dot" />atlas <em>another prophecy beneath it</em></span>
+      </aside>
+
+      <aside v-else-if="mode === 'check'" class="finding">
+        <code>{{ finding.code }}</code>
+        <span>{{ finding.level === 'pass' ? 'the graph may run' : 'file and line are named' }}</span>
+        <small>the reading imported nothing and ran nothing</small>
+      </aside>
+
+      <aside v-else-if="mode === 'evolve'" class="digests">
+        <span><em>source now</em><code>{{ currentDigest }}</code></span>
+        <span v-if="shipped"><em>shipped</em><code>{{ BASE_DIGEST }}</code></span>
+        <span v-else><em>shipped</em><code>none</code></span>
+        <small>
+          shipped bytes may name only the seven tuple types a prophecy is made of
+        </small>
+      </aside>
+
+      <aside v-else class="state">
+        <span><em>prophecy</em><code>{{ BASE_DIGEST }}</code></span>
+        <span><em>current graph</em><code>{{ graphChanged ? MOVED_DIGEST : BASE_DIGEST }}</code></span>
+        <span><em>at</em><code>{{ resumed && graphChanged ? 'write#1' : 'review:2#1' }}</code></span>
+        <span><em>done</em><code>{{ resumed && graphChanged ? '0 visits' : '4 visits' }}</code></span>
+      </aside>
+    </div>
+
+    <p class="drawn">drawn example · no flow or model was run</p>
+  </div>
+</template>
+
+<style scoped>
+.prophecy {
+  overflow: hidden;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.tabs button,
+.choices button,
+.resume-button {
+  padding: 5px 12px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+
+.tabs button.on,
+.choices button.on,
+.resume-button {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+.tabs button:focus-visible,
+.choices button:focus-visible,
+.resume-button:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+}
+
+.switch input {
+  accent-color: var(--vp-c-brand-1);
+}
+
+.resume-button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.intro {
+  margin: 0;
+  padding: 12px 16px 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
+.choices {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+  padding: 11px 16px 0;
+}
+
+.choices button {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 550;
+}
+
+.choices button.error.on,
+.choices button.warning.on {
+  border-color: var(--hmz-warm);
+  background: color-mix(in srgb, var(--hmz-warm) 12%, transparent);
+  color: var(--hmz-warm);
+}
+
+.rail {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  padding: 16px 16px 2px;
+  color: var(--vp-c-text-3);
+}
+
+.rail span {
+  padding: 4px 9px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 7px;
+  background: var(--vp-c-bg);
+  font-size: 10.5px;
+  font-family: var(--vp-font-family-mono);
+}
+
+.rail span.digest {
+  color: var(--vp-c-brand-1);
+}
+
+.rail i {
+  font-style: normal;
+  color: var(--vp-c-brand-1);
+}
+
+.canvas {
+  overflow-x: auto;
+  padding: 0 12px;
+}
+
+svg {
+  display: block;
+  width: 100%;
+  min-width: 760px;
+  height: auto;
+}
+
+.edge,
+.under-line {
+  fill: none;
+  stroke: var(--vp-c-text-3);
+  stroke-width: 1.7;
+  marker-end: url(#prophecy-arrow);
+  transition: stroke 0.25s, stroke-width 0.25s, stroke-dasharray 0.25s;
+}
+
+.edge.back {
+  stroke: var(--hmz-accent);
+}
+
+.edge.bad,
+.edge.changed {
+  stroke: var(--hmz-warm);
+  stroke-width: 2.4;
+  stroke-dasharray: 6 5;
+  marker-end: url(#prophecy-arrow-bad);
+}
+
+.arrow-head {
+  fill: var(--vp-c-text-3);
+}
+
+.arrow-head.bad {
+  fill: var(--hmz-warm);
+}
+
+.edge-label,
+.terminal-label {
+  fill: var(--vp-c-text-3);
+  font-size: 10.5px;
+  text-anchor: middle;
+  font-family: var(--vp-font-family-mono);
+}
+
+.edge-label.bad {
+  fill: var(--hmz-warm);
+  font-weight: 700;
+}
+
+.terminal {
+  fill: var(--vp-c-bg);
+  stroke: var(--vp-c-text-3);
+  stroke-width: 1.8;
+}
+
+.terminal.end {
+  stroke: var(--vp-c-brand-1);
+}
+
+.terminal.end.inner {
+  fill: var(--vp-c-brand-1);
+  stroke: none;
+}
+
+.node rect {
+  fill: var(--vp-c-bg);
+  stroke: var(--tone);
+  stroke-width: 1.7;
+  transition: fill 0.25s, stroke 0.25s, stroke-width 0.25s, opacity 0.25s;
+}
+
+.node.mind {
+  --tone: var(--hmz-lane-1);
+}
+
+.node.logic {
+  --tone: var(--hmz-accent);
+}
+
+.node.atlas {
+  --tone: var(--hmz-accent-2);
+}
+
+.node-title {
+  fill: var(--vp-c-text-1);
+  font-size: 13px;
+  font-weight: 700;
+  text-anchor: middle;
+  font-family: var(--vp-font-family-mono);
+}
+
+.node-kind {
+  fill: var(--tone);
+  font-size: 10.5px;
+  text-anchor: middle;
+  font-family: var(--vp-font-family-mono);
+}
+
+.node.done rect {
+  fill: color-mix(in srgb, var(--hmz-accent) 14%, var(--vp-c-bg));
+  stroke: var(--hmz-accent);
+}
+
+.node.active rect {
+  fill: var(--vp-c-brand-soft);
+  stroke: var(--vp-c-brand-1);
+  stroke-width: 2.8;
+}
+
+.node.stopped rect,
+.node.bad rect {
+  fill: color-mix(in srgb, var(--hmz-warm) 11%, var(--vp-c-bg));
+  stroke: var(--hmz-warm);
+  stroke-width: 2.4;
+  stroke-dasharray: 5 4;
+}
+
+.node.stopped .node-kind,
+.node.bad .node-kind {
+  fill: var(--hmz-warm);
+}
+
+.node.stale rect {
+  opacity: 0.5;
+  stroke-dasharray: 3 4;
+}
+
+.under > rect {
+  fill: var(--vp-c-bg-soft);
+  stroke: var(--hmz-accent-2);
+  stroke-width: 1.4;
+  stroke-dasharray: 4 4;
+}
+
+.under-line {
+  stroke: var(--hmz-accent-2);
+  marker-end: none;
+}
+
+.under-line.arrow {
+  marker-end: url(#prophecy-arrow);
+}
+
+.under-title,
+.under-foot,
+.under-name,
+.under-kind {
+  text-anchor: middle;
+  font-family: var(--vp-font-family-mono);
+}
+
+.under-title {
+  fill: var(--hmz-accent-2);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.under-foot {
+  fill: var(--vp-c-text-3);
+  font-size: 9.5px;
+}
+
+.under-node {
+  fill: var(--vp-c-bg);
+  stroke-width: 1.4;
+}
+
+.under-node.mind {
+  stroke: var(--hmz-lane-1);
+}
+
+.under-node.logic {
+  stroke: var(--hmz-accent);
+}
+
+.under-name {
+  fill: var(--vp-c-text-1);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.under-kind {
+  fill: var(--vp-c-text-3);
+  font-size: 9px;
+}
+
+.readout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.7fr);
+  border-top: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+}
+
+.explain {
+  padding: 15px 18px;
+}
+
+.kicker {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--vp-c-brand-1);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.readout.error .kicker,
+.readout.warning .kicker,
+.readout.drifted .kicker {
+  color: var(--hmz-warm);
+}
+
+.explain strong {
+  display: block;
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+}
+
+.explain p {
+  margin: 5px 0 0;
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.facts,
+.finding,
+.digests,
+.state {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 7px;
+  padding: 13px 18px;
+  border-left: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg-soft);
+}
+
+.facts span {
+  display: grid;
+  grid-template-columns: 10px 44px minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  color: var(--vp-c-text-2);
+  font-size: 11px;
+  font-family: var(--vp-font-family-mono);
+}
+
+.facts b {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.mind-dot {
+  background: var(--hmz-lane-1);
+}
+
+.logic-dot {
+  background: var(--hmz-accent);
+}
+
+.atlas-dot {
+  background: var(--hmz-accent-2);
+}
+
+.facts em {
+  color: var(--vp-c-text-3);
+  font-style: normal;
+}
+
+.finding code {
+  color: var(--vp-c-brand-1);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.readout.error .finding code,
+.readout.warning .finding code {
+  color: var(--hmz-warm);
+}
+
+.finding span,
+.finding small,
+.digests small {
+  color: var(--vp-c-text-3);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.digests span,
+.state span {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.digests em,
+.state em {
+  color: var(--vp-c-text-3);
+  font-size: 10.5px;
+  font-style: normal;
+}
+
+.digests code,
+.state code {
+  color: var(--vp-c-brand-1);
+  font-size: 10.5px;
+}
+
+.readout.drifted .digests code {
+  color: var(--hmz-warm);
+}
+
+.drawn {
+  margin: 0;
+  padding: 7px 16px;
+  border-top: 1px solid var(--hmz-panel-border);
+  color: var(--vp-c-text-3);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+@media (max-width: 760px) {
+  .spacer {
+    display: none;
+  }
+
+  .switch,
+  .resume-button {
+    margin-left: auto;
+  }
+
+  .readout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .facts,
+  .finding,
+  .digests,
+  .state {
+    border-top: 1px solid var(--hmz-panel-border);
+    border-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs button,
+  .choices button,
+  .resume-button,
+  .edge,
+  .under-line,
+  .node rect {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/HmzSurfaces.vue
+++ b/docs/.vitepress/theme/components/HmzSurfaces.vue
@@ -1,0 +1,938 @@
+<script setup lang="ts">
+// A flow found in a flowverse becomes the local copy without changing its name; the model
+// it declares becomes every setup surface; and each way into humanize reaches the same
+// workspace, loader and runner without pretending that every way in has the same job.
+import { computed, ref } from 'vue'
+
+type LookupState = 'hit' | 'miss' | 'later'
+type PlanMode = 'discussion' | 'direct'
+type SurfaceKey = 'python' | 'cli' | 'tui' | 'daemon'
+
+const PLAN_MODES: PlanMode[] = ['discussion', 'direct']
+
+interface LookupRow {
+  key: string
+  name: string
+  note: string
+  state: LookupState
+}
+
+interface Surface {
+  key: SurfaceKey
+  label: string
+  about: string
+  path: string[]
+  nodes: string[]
+}
+
+interface GraphNode {
+  id: string
+  label: string
+  x: number
+  y: number
+  width: number
+}
+
+interface GraphEdge {
+  id: string
+  d: string
+}
+
+const forked = ref(false)
+const genIdea = ref(true)
+const genPlan = ref(true)
+const planMode = ref<PlanMode>('discussion')
+const surface = ref<SurfaceKey>('tui')
+const attached = ref(1)
+
+const lookup = computed<LookupRow[]>(() =>
+  forked.value
+    ? [
+        {
+          key: 'local',
+          name: 'this project',
+          note: 'the whole fork is here',
+          state: 'hit',
+        },
+        { key: 'user', name: 'your home', note: 'not reached', state: 'later' },
+        { key: 'builtin', name: 'built in', note: 'not reached', state: 'later' },
+        {
+          key: 'official',
+          name: 'official',
+          note: 'still there, not reached',
+          state: 'later',
+        },
+        { key: 'added', name: 'added flowverses', note: 'not reached', state: 'later' },
+      ]
+    : [
+        { key: 'local', name: 'this project', note: 'no flow by this name', state: 'miss' },
+        { key: 'user', name: 'your home', note: 'no flow by this name', state: 'miss' },
+        { key: 'builtin', name: 'built in', note: 'no flow by this name', state: 'miss' },
+        {
+          key: 'official',
+          name: 'official',
+          note: 'the first match',
+          state: 'hit',
+        },
+        { key: 'added', name: 'added flowverses', note: 'not reached', state: 'later' },
+      ],
+)
+
+const configAccepted = computed(() => !genIdea.value || genPlan.value)
+const configState = computed(() =>
+  configAccepted.value
+    ? [
+        'accepted',
+        `idea ${genIdea.value ? 'on' : 'off'}`,
+        `plan ${genPlan.value ? 'on' : 'off'}`,
+        planMode.value,
+      ].join(' · ')
+    : 'refused · gen idea is on while gen plan is off',
+)
+const resolved = computed(() =>
+  forked.value
+    ? 'this project’s humanize1:gen-plan'
+    : 'official’s humanize1:gen-plan',
+)
+
+const SURFACES: Surface[] = [
+  {
+    key: 'python',
+    label: 'Python SDK',
+    about:
+      'Builds a Run around the loaded runner and task, then runs it here or on a ' +
+      'thread of its own.',
+    path: [
+      'python-workspace',
+      'workspace-run',
+      'run-runner',
+      'runner-conversations',
+      'runner-cycle',
+    ],
+    nodes: ['python', 'workspace', 'run', 'runner', 'conversations', 'cycle'],
+  },
+  {
+    key: 'cli',
+    label: 'CLI',
+    about:
+      'Reads the line into the same flow, agents, task and setup, then drives the SDK ' +
+      'Run to its return.',
+    path: [
+      'cli-workspace',
+      'workspace-run',
+      'run-runner',
+      'runner-conversations',
+      'runner-cycle',
+    ],
+    nodes: ['cli', 'workspace', 'run', 'runner', 'conversations', 'cycle'],
+  },
+  {
+    key: 'tui',
+    label: 'TUI',
+    about:
+      'Keeps the workspace and runner in hand so it can configure, watch and steer the ' +
+      'agent conversations while they run.',
+    path: ['tui-workspace', 'workspace-runner', 'runner-conversations', 'runner-cycle'],
+    nodes: ['tui', 'workspace', 'runner', 'conversations', 'cycle'],
+  },
+  {
+    key: 'daemon',
+    label: 'daemon',
+    about:
+      'Holds the same terminal interface apart from any terminal. Its Session boundary ' +
+      'counts readers and lets them detach.',
+    path: [
+      'daemon-session',
+      'session-tui',
+      'tui-workspace',
+      'workspace-runner',
+      'runner-conversations',
+      'runner-cycle',
+    ],
+    nodes: ['daemon', 'session', 'tui', 'workspace', 'runner', 'conversations', 'cycle'],
+  },
+]
+
+const NODES: GraphNode[] = [
+  { id: 'python', label: 'Python SDK', x: 88, y: 42, width: 146 },
+  { id: 'cli', label: 'CLI', x: 88, y: 102, width: 146 },
+  { id: 'tui', label: 'terminal interface', x: 88, y: 162, width: 146 },
+  { id: 'daemon', label: 'daemon', x: 88, y: 238, width: 146 },
+  { id: 'workspace', label: 'one Hmz workspace', x: 304, y: 102, width: 166 },
+  { id: 'session', label: 'Session boundary', x: 304, y: 238, width: 166 },
+  { id: 'run', label: 'Run lifecycle', x: 510, y: 54, width: 150 },
+  { id: 'runner', label: 'one runner', x: 710, y: 102, width: 150 },
+  { id: 'cycle', label: 'cycle record', x: 510, y: 222, width: 150 },
+  { id: 'conversations', label: 'agent conversations', x: 710, y: 222, width: 166 },
+]
+
+const EDGES: GraphEdge[] = [
+  { id: 'python-workspace', d: 'M 161 42 C 205 42, 207 82, 221 94' },
+  { id: 'cli-workspace', d: 'M 161 102 L 221 102' },
+  { id: 'tui-workspace', d: 'M 161 162 C 202 162, 205 122, 221 110' },
+  { id: 'daemon-session', d: 'M 161 238 L 221 238' },
+  { id: 'session-tui', d: 'M 221 230 C 202 217, 202 172, 161 164' },
+  { id: 'workspace-run', d: 'M 387 92 C 414 72, 426 58, 435 56' },
+  { id: 'run-runner', d: 'M 585 56 C 617 58, 621 88, 635 96' },
+  { id: 'workspace-runner', d: 'M 387 116 C 482 154, 576 151, 635 112' },
+  { id: 'runner-conversations', d: 'M 710 124 L 710 200' },
+  { id: 'runner-cycle', d: 'M 650 124 C 620 174, 592 207, 585 216' },
+]
+
+const pickedSurface = computed(() => SURFACES.find((one) => one.key === surface.value)!)
+const activeEdges = computed(() => new Set(pickedSurface.value.path))
+const activeNodes = computed(() => new Set(pickedSurface.value.nodes))
+const graphDescription = computed(
+  () => `${pickedSurface.value.label}. ${pickedSurface.value.about}`,
+)
+
+function forkFlow() {
+  forked.value = true
+}
+
+function reset() {
+  forked.value = false
+  genIdea.value = true
+  genPlan.value = true
+  planMode.value = 'discussion'
+  surface.value = 'tui'
+  attached.value = 1
+}
+</script>
+
+<template>
+  <div class="surfaces hmz-panel">
+    <div class="bar">
+      <span>one flow, one accepted setup, one runtime</span>
+      <button type="button" class="reset" @click="reset">start over</button>
+    </div>
+
+    <div class="upper">
+      <section class="pane discovery">
+        <header>
+          <span class="step">1</span>
+          <div>
+            <strong>Find it near you, then make it yours</strong>
+            <p>An unqualified name stops at the first place that holds it.</p>
+          </div>
+        </header>
+
+        <div class="query">
+          <span>humanize1 : gen-plan</span>
+          <em>nearest first</em>
+        </div>
+        <ol class="lookup" aria-label="flow lookup order">
+          <li v-for="(one, i) in lookup" :key="one.key" :class="one.state">
+            <span class="number">{{ i + 1 }}</span>
+            <strong>{{ one.name }}</strong>
+            <span>{{ one.note }}</span>
+          </li>
+        </ol>
+
+        <div class="fork">
+          <button type="button" :disabled="forked" @click="forkFlow">
+            {{ forked ? 'forked into this project' : 'fork the official flow' }}
+          </button>
+          <p aria-live="polite">
+            <template v-if="forked">
+              Staged beside the destination, then moved into place whole. The source is
+              unchanged.
+            </template>
+            <template v-else>
+              The entry point, helpers and skills travel together; an existing local flow is
+              never overwritten.
+            </template>
+          </p>
+        </div>
+
+        <p class="qualified">
+          <strong>official / humanize1 : gen-plan</strong> stays pinned to the source, before
+          and after the fork.
+        </p>
+      </section>
+
+      <section class="pane config">
+        <header>
+          <span class="step">2</span>
+          <div>
+            <strong>Let the flow draw its own setup</strong>
+            <p>A few fields from this flow's model, grouped the way the model groups them.</p>
+          </div>
+        </header>
+
+        <div class="group">gen-idea</div>
+        <label class="field switch">
+          <span class="field-copy">
+            <strong>gen idea</strong>
+            <span>open the idea into a grounded draft</span>
+          </span>
+          <span class="toggle">
+            <input v-model="genIdea" type="checkbox" />
+            {{ genIdea ? 'on' : 'off' }}
+          </span>
+        </label>
+
+        <div class="group plan">gen-plan</div>
+        <label class="field switch">
+          <span class="field-copy">
+            <strong>gen plan</strong>
+            <span>turn the draft into a plan</span>
+          </span>
+          <span class="toggle">
+            <input v-model="genPlan" type="checkbox" />
+            {{ genPlan ? 'on' : 'off' }}
+          </span>
+        </label>
+
+        <div class="field">
+          <div class="field-copy">
+            <strong>plan mode</strong>
+            <span>converge, or write it once</span>
+          </div>
+          <div class="choices" role="group" aria-label="plan mode">
+            <button
+              v-for="one in PLAN_MODES"
+              :key="one"
+              type="button"
+              :aria-pressed="planMode === one"
+              :class="{ on: planMode === one }"
+              @click="planMode = one"
+            >
+              {{ one }}
+            </button>
+          </div>
+        </div>
+
+        <p
+          id="surface-config-state"
+          class="validation"
+          :class="{ wrong: !configAccepted }"
+          aria-live="polite"
+        >
+          {{ configState }}
+        </p>
+        <p class="model-note">
+          Turn gen plan off while gen idea remains on. The model refuses the relationship;
+          the interface only shows what it said. The whole set is validated again when the
+          current flow is loaded.
+        </p>
+      </section>
+    </div>
+
+    <section class="runtime">
+      <header>
+        <span class="step">3</span>
+        <div>
+          <strong>Enter through the surface that fits the job</strong>
+          <p>The highlighted path changes. The resolved flow and accepted setup do not.</p>
+        </div>
+      </header>
+
+      <div class="surface-tabs" role="group" aria-label="way into humanize">
+        <button
+          v-for="one in SURFACES"
+          :key="one.key"
+          type="button"
+          :aria-pressed="surface === one.key"
+          :class="{ on: surface === one.key }"
+          @click="surface = one.key"
+        >
+          {{ one.label }}
+        </button>
+      </div>
+
+      <div class="context" :class="{ blocked: !configAccepted }">
+        <div>
+          <span>resolved flow</span>
+          <strong>{{ resolved }}</strong>
+        </div>
+        <div>
+          <span>flow setup</span>
+          <strong>
+            {{ configAccepted ? configState.replace('accepted · ', '') : 'refused' }}
+          </strong>
+        </div>
+        <div>
+          <span>run</span>
+          <strong>{{ configAccepted ? 'ready to start' : 'not made' }}</strong>
+        </div>
+      </div>
+
+      <div class="graph">
+        <svg
+          viewBox="0 0 820 280"
+          role="img"
+          :aria-label="graphDescription"
+        >
+          <title>How each product surface reaches the shared runtime</title>
+          <desc>{{ graphDescription }}</desc>
+          <defs>
+            <marker
+              id="surface-arrow"
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M 0 0 L 8 4 L 0 8 z" class="arrow" />
+            </marker>
+            <marker
+              id="surface-arrow-active"
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M 0 0 L 8 4 L 0 8 z" class="arrow active" />
+            </marker>
+          </defs>
+
+          <path
+            v-for="edge in EDGES"
+            :key="edge.id"
+            :d="edge.d"
+            class="edge"
+            :class="{ on: activeEdges.has(edge.id) }"
+            :marker-end="
+              activeEdges.has(edge.id)
+                ? 'url(#surface-arrow-active)'
+                : 'url(#surface-arrow)'
+            "
+          />
+
+          <g
+            v-for="node in NODES"
+            :key="node.id"
+            class="node"
+            :class="{
+              on: activeNodes.has(node.id),
+              blocked: !configAccepted && node.id === 'run',
+            }"
+          >
+            <rect
+              :x="node.x - node.width / 2"
+              :y="node.y - 22"
+              :width="node.width"
+              height="44"
+              rx="10"
+            />
+            <text :x="node.x" :y="node.y + 5">{{ node.label }}</text>
+          </g>
+
+          <text x="304" y="272" class="session-count">
+            <template v-if="surface === 'daemon'">
+              {{ attached }} terminal{{ attached === 1 ? '' : 's' }} reading
+            </template>
+            <template v-else>used only when the interface is held</template>
+          </text>
+        </svg>
+      </div>
+
+      <div class="surface-note">
+        <p aria-live="polite">
+          <strong>{{ pickedSurface.label }}</strong>
+          {{ pickedSurface.about }}
+          <span v-if="surface === 'daemon'">
+            {{ attached }} terminal{{ attached === 1 ? '' : 's' }} attached.
+          </span>
+        </p>
+        <div v-if="surface === 'daemon'" class="session-actions">
+          <button type="button" :disabled="attached >= 3" @click="attached += 1">
+            another terminal arrives
+          </button>
+          <button type="button" :disabled="attached === 0" @click="attached = 0">
+            detach all
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.surfaces {
+  overflow: hidden;
+  border: 1px solid var(--hmz-panel-border);
+  border-radius: 14px;
+  background: var(--hmz-panel-bg);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.reset {
+  padding: 4px 11px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  font-size: 11.5px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.upper {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pane {
+  min-width: 0;
+  padding: 16px;
+}
+
+.pane + .pane {
+  border-left: 1px solid var(--hmz-panel-border);
+}
+
+header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.step {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+header strong {
+  display: block;
+  color: var(--vp-c-text-1);
+  font-size: 13.5px;
+}
+
+header p {
+  margin: 3px 0 0;
+  color: var(--vp-c-text-3);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.query {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 14px 0 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 9px;
+  background: var(--vp-c-bg);
+}
+
+.query span {
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+}
+
+.query em {
+  color: var(--vp-c-text-3);
+  font-size: 10.5px;
+  font-style: normal;
+}
+
+.lookup {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lookup li {
+  display: grid;
+  grid-template-columns: 22px minmax(92px, 0.8fr) minmax(0, 1.2fr);
+  gap: 8px;
+  align-items: center;
+  min-height: 29px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+}
+
+.lookup li.hit {
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+.lookup li.later {
+  opacity: 0.58;
+}
+
+.lookup .number {
+  font-family: var(--vp-font-family-mono);
+  text-align: center;
+}
+
+.lookup strong {
+  color: inherit;
+  font-size: 11.5px;
+}
+
+.fork {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.fork button {
+  padding: 5px 12px;
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 999px;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.fork p,
+.qualified,
+.model-note {
+  margin: 0;
+  color: var(--vp-c-text-3);
+  font-size: 10.8px;
+  line-height: 1.5;
+}
+
+.qualified {
+  margin-top: 10px;
+}
+
+.qualified strong {
+  color: var(--vp-c-text-2);
+  font-family: var(--vp-font-family-mono);
+  font-size: 10.8px;
+}
+
+.group {
+  margin: 14px 0 4px;
+  color: var(--vp-c-brand-1);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.field-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.field-copy strong {
+  color: var(--vp-c-text-2);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11.5px;
+}
+
+.field-copy span {
+  color: var(--vp-c-text-3);
+  font-size: 10.8px;
+}
+
+.choices {
+  display: flex;
+  gap: 5px;
+}
+
+.choices button,
+.surface-tabs button,
+.session-actions button {
+  padding: 4px 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  font-size: 11.5px;
+}
+
+.choices button.on,
+.surface-tabs button.on {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--vp-c-text-2);
+  font-size: 11.5px;
+}
+
+.toggle input {
+  accent-color: var(--vp-c-brand-1);
+}
+
+.group.plan {
+  margin-top: 10px;
+}
+
+.validation {
+  margin: 11px 0 7px;
+  color: var(--hmz-accent);
+  font-family: var(--vp-font-family-mono);
+  font-size: 10.8px;
+}
+
+.validation.wrong {
+  color: var(--hmz-warm);
+}
+
+.runtime {
+  padding: 16px;
+  border-top: 1px solid var(--hmz-panel-border);
+  background: var(--vp-c-bg);
+}
+
+.surface-tabs {
+  display: flex;
+  gap: 6px;
+  margin: 14px 0 10px;
+  flex-wrap: wrap;
+}
+
+.context {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-divider);
+}
+
+.context div {
+  min-width: 0;
+  padding: 8px 10px;
+  background: var(--vp-c-bg-soft);
+}
+
+.context span,
+.context strong {
+  display: block;
+}
+
+.context span {
+  margin-bottom: 2px;
+  color: var(--vp-c-text-3);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.context strong {
+  overflow-wrap: anywhere;
+  color: var(--vp-c-text-2);
+  font-size: 11.5px;
+}
+
+.context.blocked div:last-child strong {
+  color: var(--hmz-warm);
+}
+
+.graph {
+  overflow-x: auto;
+  margin-top: 8px;
+}
+
+svg {
+  display: block;
+  width: 100%;
+  min-width: 700px;
+  height: auto;
+}
+
+.edge {
+  fill: none;
+  stroke: var(--vp-c-divider);
+  stroke-width: 1.5;
+  opacity: 0.72;
+  transition: stroke 0.25s, stroke-width 0.25s, opacity 0.25s;
+}
+
+.edge.on {
+  stroke: var(--vp-c-brand-1);
+  stroke-width: 2.5;
+  opacity: 1;
+}
+
+.arrow {
+  fill: var(--vp-c-divider);
+}
+
+.arrow.active {
+  fill: var(--vp-c-brand-1);
+}
+
+.node rect {
+  fill: var(--vp-c-bg);
+  stroke: var(--vp-c-divider);
+  transition: fill 0.25s, stroke 0.25s;
+}
+
+.node text {
+  fill: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11.5px;
+  text-anchor: middle;
+  transition: fill 0.25s;
+}
+
+.node.on rect {
+  fill: var(--vp-c-brand-soft);
+  stroke: var(--vp-c-brand-1);
+}
+
+.node.on text {
+  fill: var(--vp-c-brand-1);
+}
+
+.node.blocked rect {
+  stroke: var(--hmz-warm);
+  stroke-dasharray: 4 4;
+}
+
+.node.blocked text {
+  fill: var(--hmz-warm);
+}
+
+.session-count {
+  fill: var(--vp-c-text-3);
+  font-size: 10.5px;
+  text-anchor: middle;
+}
+
+.surface-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  min-height: 46px;
+  padding-top: 10px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.surface-note p {
+  margin: 0;
+  color: var(--vp-c-text-3);
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+.surface-note strong {
+  margin-right: 5px;
+  color: var(--vp-c-brand-1);
+}
+
+.session-actions {
+  display: flex;
+  flex: none;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.session-actions button:last-child {
+  border-color: var(--hmz-warm);
+  color: var(--hmz-warm);
+}
+
+@media (max-width: 800px) {
+  .upper {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pane + .pane {
+    border-top: 1px solid var(--hmz-panel-border);
+    border-left: 0;
+  }
+
+  .surface-note {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .session-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .fork {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .fork button {
+    justify-self: start;
+  }
+
+  .context {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lookup li {
+    grid-template-columns: 22px minmax(86px, 0.8fr) minmax(0, 1.2fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .edge,
+  .node rect,
+  .node text {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -8,6 +8,7 @@ import DefaultTheme from 'vitepress/theme'
 import HmzAccounts from './components/HmzAccounts.vue'
 import HmzAnchor from './components/HmzAnchor.vue'
 import HmzBackends from './components/HmzBackends.vue'
+import HmzDaemon from './components/HmzDaemon.vue'
 import HmzFeatures from './components/HmzFeatures.vue'
 import HmzFlowShape from './components/HmzFlowShape.vue'
 import HmzFlows from './components/HmzFlows.vue'
@@ -19,11 +20,13 @@ import HmzMap from './components/HmzMap.vue'
 import HmzMoments from './components/HmzMoments.vue'
 import HmzOrchestra from './components/HmzOrchestra.vue'
 import HmzPerson from './components/HmzPerson.vue'
+import HmzProphecy from './components/HmzProphecy.vue'
 import HmzResume from './components/HmzResume.vue'
 import HmzShape from './components/HmzShape.vue'
 import HmzStack from './components/HmzStack.vue'
 import HmzSteer from './components/HmzSteer.vue'
 import HmzSyscalls from './components/HmzSyscalls.vue'
+import HmzSurfaces from './components/HmzSurfaces.vue'
 import HmzTimeline from './components/HmzTimeline.vue'
 import HmzTurns from './components/HmzTurns.vue'
 import './style.css'
@@ -34,6 +37,7 @@ export default {
     app.component('HmzAccounts', HmzAccounts)
     app.component('HmzAnchor', HmzAnchor)
     app.component('HmzBackends', HmzBackends)
+    app.component('HmzDaemon', HmzDaemon)
     app.component('HmzFeatures', HmzFeatures)
     app.component('HmzFlowShape', HmzFlowShape)
     app.component('HmzFlows', HmzFlows)
@@ -45,11 +49,13 @@ export default {
     app.component('HmzMoments', HmzMoments)
     app.component('HmzOrchestra', HmzOrchestra)
     app.component('HmzPerson', HmzPerson)
+    app.component('HmzProphecy', HmzProphecy)
     app.component('HmzResume', HmzResume)
     app.component('HmzShape', HmzShape)
     app.component('HmzStack', HmzStack)
     app.component('HmzSteer', HmzSteer)
     app.component('HmzSyscalls', HmzSyscalls)
+    app.component('HmzSurfaces', HmzSurfaces)
     app.component('HmzTimeline', HmzTimeline)
     app.component('HmzTurns', HmzTurns)
   },

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -25,7 +25,7 @@ inbound links moving is a red build rather than a 404 somebody finds later.
 docs/
 ├── .vitepress/config.mts     nav, sidebars, the root's redirect, everything
 ├── .vitepress/theme/         the palette, and every diagram on the site
-├── features/                 one page per feature, each built on a diagram you can push
+├── features/                 one capability map, then feature pages built on diagrams
 ├── flows/                    one page per flow, each with its own loop played on it
 ├── tutorials/                six, in order, each a whole piece of work
 ├── guide/                    one page per feature, answering "how do I use this?"
@@ -49,7 +49,7 @@ Five kinds of page, and a page that is two of them is two pages.
 
 | | | |
 | --- | --- | --- |
-| **Features** | understanding | One page per feature, built around a diagram the reader can push. What it is and why it works the way it does. **No commands and no code**: a reader who wants to run it is one click from the guide, which every page ends by naming. Its index is the front of the site. |
+| **Features** | understanding | A system-wide capability map, then one page per deep feature, built around a diagram the reader can push. What it is and why it works the way it does. The map and deep pages have **no commands and no code**: a reader who wants to run it is one click from the guide. The index is the front of the site, so its one install line and recorded demos are the deliberate exception. |
 | **Flows** | what there is to run | One page per flow humanize or the official flowverse ships, named the way `-f` takes it, opening with the `hmz exec` line and the shape of its loop. What it is for, what it takes, and what a run picked up carries in. |
 | **Tutorials** | learning | Taken in order, start to finish, with every command written out. A reader following one is not choosing anything; they are being led. Six of them, and adding a seventh means arguing that one of the six should go. |
 | **Guides** | doing | "How do I use X?" One feature each. Opens with a `## Try it` section short enough to paste, then explains the rest. A reader here has a job and knows what they want. |
@@ -80,9 +80,11 @@ otherwise.
 ## The front of the site
 
 `features/index.md` is what somebody arriving is handed: one line of install with the way to
-the quickstart beside it, four drawings, the recorded demos, and the index of the feature
-pages. It explains nothing at length — a reader who wants to know how to use something is one
-click from a tutorial, a guide or the reference, and every one of those is a better page for it.
+the quickstart beside it, the unusual features drawn, the five-system capability map, the
+recorded demos, and the index of the feature pages. `features/capabilities.md` expands that map
+into the reader's path to the right explanation without turning internal implementation units
+into a second product vocabulary. The map and deep pages do not explain how to run something
+— a tutorial, guide or reference page is one click away and better at that job.
 
 ```
 .vitepress/theme/
@@ -123,19 +125,22 @@ One page, one diagram, one component, registered in the same `index.ts` — the 
 and the one elsewhere that is built the same way:
 
 ```
-HmzMap.vue          features/            the six stages, and every page hung off one
+HmzMap.vue          features/            five systems, nineteen reader-facing capability groups
+HmzProphecy.vue     features/prophecy    Python becoming a checked, resumable graph
 HmzSyscalls.vue     features/anchor      a call, the seccomp verdict, and where it lands
 HmzAccounts.vue     features/accounts    the path swap, then the chain and its waits
 HmzTimeline.vue     features/tracing     a trace, with the programs and the clock as switches
 HmzSteer.vue        features/steering    type a line into a running turn, or queue behind it
 HmzShape.vue        features/shapes      a model, how a backend is held to it, what comes back
-HmzBackends.vue     features/backends    twelve backends against what a flow may ask for
+HmzBackends.vue     features/backends    backends against what a flow may ask for
 HmzLoops.vue        features/flows       the shapes a loop takes, stepped through
 HmzTurns.vue        features/concurrency twelve prompts, scheduled across n conversations
 HmzResume.vue       features/resuming    pull the plug, then run it again
+HmzDaemon.vue       features/daemon      leave, attach again, and see the held PTY
 HmzGoal.vue         features/goals       the model deciding, beside your code deciding
 HmzMoments.vue      features/hooks       hang a hook, run the turn, read what it said
 HmzPerson.vue       features/human       a questionnaire built out of a pydantic model
+HmzSurfaces.vue     features/surfaces    several entry points converging on one run
 HmzStack.vue        contributing/architecture
                                          the layers, and what each is allowed to name
 ```

--- a/docs/features/backends.md
+++ b/docs/features/backends.md
@@ -2,14 +2,14 @@
 pageClass: hmz-feature
 ---
 
-# Twelve CLIs, one agent
+# Many backends, one agent
 
-humanize never talks to a model provider. It drives the coding agent CLI you already have,
-logged in the way you already log in — twelve of them, plus anything that speaks the Agent
-Client Protocol. There is no API key for it to hold.
+Most humanize backends do not talk to a model provider. They drive a supported coding agent
+under its existing login, through a built-in adapter or the Agent Client Protocol. humanize
+does not need the provider's API key for those backends.
 
-The one exception ships inside it: DeepSeek Harness arrives with humanize, because it has no
-subscription login to use instead.
+The exception ships inside it: DeepSeek Harness arrives as an SDK-backed agent and uses its
+own DeepSeek provider credentials because it has no subscription login to reuse.
 
 <HmzBackends />
 
@@ -19,16 +19,13 @@ A backend, a model, an effort, and the [account](/features/accounts) its turns r
 agents of one spelling are two agents, so a flow of an actor and a reviewer at one
 configuration is what it says it is.
 
-## What it runs is asked, never written down
+## What it runs is discovered for the account
 
-A model id is not a fact that keeps. These CLIs ship models without asking anybody, and which
-of them your account may name is your account's business — so a list written down here would be
-wrong the day the CLI ships one, and would say nothing about what you may actually run.
+A model id is not usually a fact that keeps. Coding agents add models, and which of them an
+account may name is the account's business. Wherever a backend can report its catalogue,
+humanize asks it under that account and keeps the answer:
 
-So the backend itself is asked, by whatever mechanism that backend offers for being asked, and
-what it says is kept:
-
-- **Asked as the account whose it would be** — under that account's own credential paths and
+- **It is asked as the account whose it would be** — under that account's own credential paths and
   variables, and without the ones its backend would otherwise take an account from. Which is
   exactly how a turn of that account is run. Two accounts of one CLI are two catalogues.
 - **Kept with the account**, so taking the account away takes its catalogue with it.
@@ -38,11 +35,14 @@ what it says is kept:
   to ask. A backend that would not answer leaves the account made — an account whose models are
   not known yet is one to ask again, not one that failed.
 
-Nothing is added to what a backend answered. Claude Code will report a model named by
-`ANTHROPIC_CUSTOM_MODEL_OPTION` without checking that the account can run it, so humanize
-never sets that variable to put a model in front of you: a catalogue is what the account said
-it runs. One you set yourself is passed through untouched, and is kept under the alias you
-chose rather than the id Claude resolves it to — the alias is what `--model` takes.
+DeepSeek Harness and Qwen Code cannot list their models dynamically. Their adapters provide
+small advisory catalogues instead: the official DeepSeek adapter's current models, and the
+models Qwen Code ships pointed at. Those lists make initial setup possible; they are not proof
+of what an account or compatible endpoint will accept.
+
+For a discovered catalogue, nothing is added to what the backend answered. Claude Code may
+report a custom alias without proving the account can run it, so humanize preserves the alias
+exactly as that account supplied it rather than silently manufacturing another model entry.
 
 ## The efforts are a vocabulary, so they are written down
 

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -1,0 +1,363 @@
+---
+pageClass: hmz-feature
+---
+
+# Capability map
+
+This is a wayfinding map, not an exhaustive product contract. It groups related behavior by
+the user problem it solves; one group may combine several implementations, and one feature may
+support more than one group. Availability still depends on the backend, account, operating
+system, and shape of the run.
+
+Use the interactive map to choose an area, then follow **Learn** for the design, **Use** for a
+task-oriented guide, or **Reference** for the complete interface and its limits.
+
+<HmzMap />
+
+## A. Flow system
+
+Express work as ordinary Python or as an inspectable graph, then compose, schedule, and recover
+it without hiding which execution model is in use.
+
+### A1. Expression and compilation
+
+**Outcome.** Choose unrestricted runtime behavior or a graph whose structure is settled before
+the first agent turn.
+
+- A regular flow is unrestricted Python; its next step is whatever its body decides at runtime.
+- An atlas uses a restricted declarative body that compiles into a typed prophecy graph.
+- Calls, shaped values, branches, loops, and returns become explicit nodes, edges, and exits.
+- Canonical graph identities separate structural changes from formatting and node-body changes.
+- Shipped graphs are checked for drift and rebuilt only from allowlisted prophecy types.
+
+**Learn:** [Python becomes a prophecy](/features/prophecy) · **Use:**
+[Writing a flow](/guide/writing-a-flow), [Atlas](/guide/atlas) · **Reference:**
+[Flows](/reference/flows#an-atlas)
+
+### A2. Static correctness and proving
+
+**Outcome.** Find structural mistakes and exercise hostile paths before spending a real model
+turn.
+
+- Zero-execution checking reads flow structure without importing or running user code.
+- Atlas checks cover edge shapes, bound values, recursion, returns, and loop progress.
+- Ordinary flow checks catch selected liveness and shaped-answer mistakes without claiming to
+  prove arbitrary Python.
+- Nested flows and changed configuration schemas are validated before their work begins.
+- Stand-in agents, adversarial scenarios, and virtual time can exercise execution without a
+  real model.
+
+**Learn:** [Python becomes a prophecy](/features/prophecy) · **Use:**
+[Checking flows](/guide/checking-flows), [Testing flows](/guide/testing-flows) ·
+**Reference:** [Flows](/reference/flows#checking-a-flow)
+
+### A3. Composition and hot reload
+
+**Outcome.** Reuse flows and their supporting assets while keeping each nested run visible and
+independently scoped.
+
+- A regular flow may load and call another flow while preserving nested run context.
+- An atlas may contain another atlas as a typed supernode in the outer prophecy.
+- Remote skill repositories are fetched and cached; selected flow skills are mounted for the
+  scope that needs them and removed when it ends.
+- Flow entry points and side modules are read again so current source is used for later work.
+- Synchronous and asynchronous flows share the same runner and failure model.
+
+**Learn:** [A flow is Python](/features/flows) · **Use:**
+[Calling flows](/guide/calling-flows), [Skills](/guide/skills) · **Reference:**
+[Flows](/reference/flows#a-flow-that-calls-another-flow)
+
+### A4. Scheduling, state, and resumption
+
+**Outcome.** Place and fan out work deliberately, then continue the workflow state that was
+actually recorded.
+
+- Flows declare agent roles, capabilities, and working locations without binding them to one
+  backend implementation.
+- Independent sessions may run concurrently; turns sharing one session remain sequential.
+- Resumable regular flows keep an explicit state mapping and resume by running current flow
+  code again.
+- Atlases record completed node visits and resume the first unfinished visit under the same
+  prophecy identity.
+- Neither form restores a backend conversation; repositories and explicit flow state carry the
+  work forward.
+
+**Learn:** [Many turns at once](/features/concurrency),
+[Picked up where it stopped](/features/resuming) · **Use:**
+[Async flows](/guide/async-flows), [Picking a run up](/guide/resuming) · **Reference:**
+[Flows](/reference/flows#a-flow-that-can-be-picked-up)
+
+## B. Agent control plane
+
+Drive different coding agents through one orchestration model while preserving their real
+capabilities, identities, conversations, and ways of collaborating with a person.
+
+### B1. Backend unification
+
+**Outcome.** Configure one agent abstraction across different CLIs and protocols without
+pretending every backend supports the same controls.
+
+- Agent and session contracts normalize turns, events, answers, and lifecycle operations.
+- Native app servers, streaming command-line adapters, and Agent Client Protocol (ACP) servers
+  keep their own transport semantics behind that contract.
+- A capability matrix exposes what each backend can do, so a flow can require capabilities and
+  reject an incompatible backend.
+- Model catalogues are usually discovered for the account that will run them; backends that
+  cannot list models begin with a small advisory catalogue instead.
+- Shaped answers are reconstructed into the same typed result where a backend supports them.
+
+**Learn:** [Many backends, one agent](/features/backends),
+[Answers in a shape](/features/shapes) · **Use:** [Providers](/guide/providers),
+[Efforts](/guide/efforts) · **Reference:**
+[Agents](/reference/agents#what-each-backend-can-do)
+
+### B2. Turn and session control
+
+**Outcome.** Keep live work steerable and make human collaboration part of the run rather than
+an out-of-band interruption.
+
+- Per-turn controls, lifecycle hooks, and typed failures give flows explicit decision points.
+- Steering delivers an acknowledged instruction into a supported turn that is already running.
+- Goals continue across controlled turns, while cloning creates a separate conversation branch.
+- Side questions through /btw read a frozen conversation snapshot without changing the main
+  session.
+- Agent questions and the human agent share an answer path; away mode returns no answer instead
+  of leaving a run blocked.
+- The board carries non-blocking, durable lines between a person and a flow while both
+  continue.
+
+**Learn:** [A line typed mid-turn](/features/steering),
+[It decides when it is done](/features/goals), [The moments of a turn](/features/hooks),
+[You, as one of the agents](/features/human) · **Use:** [Questions](/guide/questions),
+[Side questions (/btw)](/guide/btw), [Board](/guide/board),
+[Human agent](/guide/human-agent), [Being away](/guide/afk) · **Reference:**
+[Agents](/reference/agents#turns), [Flows](/reference/flows#the-person-at-the-prompt)
+
+### B3. Tools and skills
+
+**Outcome.** Give each session only the reusable instructions and temporary callable tools its
+role needs.
+
+- Each session receives the flow-owned skills selected for its role and scope.
+- Backends expose the native skills already installed where their own CLI reads them.
+- Flow-owned skills are mounted for the session and removed when that scope ends.
+- A flow callback can become a native tool from the next turn until it is withdrawn or the
+  session ends, on a capable backend.
+
+**Learn:** [Many backends, one agent](/features/backends) · **Use:**
+[Skills](/guide/skills), [Callbacks as tools](/guide/tools) · **Reference:**
+[Agents](/reference/agents#the-skills-an-agent-carries),
+[Flows](/reference/flows#the-skills-a-flow-brings)
+
+### B4. Failure recovery
+
+**Outcome.** Respond to a failed turn according to what failed, while making conversation loss
+an explicit boundary.
+
+- Backends distinguish failures worth another attempt from explicitly unrecoverable ones;
+  configured policy then retries, walks accounts, and finally walks places.
+- Retries and waits are policy for a place, not an automatic response to every failure.
+- An account chain stays inside one backend and may continue the same backend conversation.
+- Cross-backend fallback opens a new session and carries compatible agent settings and the
+  pending turn, but not the earlier conversation.
+- Recovery stops on loops, missing destinations, unsupported capabilities, and failures another
+  attempt cannot fix.
+
+**Learn:** [Two accounts of one CLI](/features/accounts) · **Use:**
+[Falling back](/guide/fallback) · **Reference:**
+[Account recovery](/reference/agents#when-an-account-goes-down),
+[Cross-backend recovery](/reference/agents#when-the-place-has-nowhere-left-to-run)
+
+### B5. Accounts and credentials
+
+**Outcome.** Run the same CLI under separate identities without changing the agent's command or
+leaking another account into the turn.
+
+- Where a CLI provides a native login, capture lets it create and refresh credentials in its
+  own format; other backends use their configured credential inputs.
+- Credential paths and environment variables are redirected only for the account taking a turn.
+- Ambient credential variables are removed so the shell cannot silently select another account.
+- Compatible vendor credentials can be reused across CLI backends under each backend's
+  spelling.
+- Concurrent accounts keep private files, and updates to stored account state land atomically.
+- The machine's existing login may start an account chain, but humanize does not own or copy
+  it.
+
+**Learn:** [Two accounts of one CLI](/features/accounts) · **Use:**
+[Providers](/guide/providers) · **Reference:** [Providers](/reference/providers)
+
+## C. Execution fabric
+
+Let a local coding agent operate another machine while keeping process behavior, workspace
+movement, transport, and machine ownership explicit.
+
+### C1. Transparent remote execution
+
+**Outcome.** Keep the agent local while selected work behaves as though its processes and files
+belong to the target machine.
+
+- A supervisor decides selected system calls and can replay them remotely one at a time.
+- Program launches, descendants, network access, paths, and executables follow explicit routes.
+- Control files and backend state that should remain local stay on the local side.
+- Remote results preserve target errors, exit status, and common signals; rarer or repeated
+  signals have documented limits.
+- The anchor is routing and transport, not a sandbox or an authorization boundary.
+
+**Learn:** [The anchor](/features/anchor) · **Use:**
+[Remote execution](/guide/remote-execution), [Security](/guide/security) · **Reference:**
+[Remote execution](/reference/remote-execution)
+
+### C2. Shadow workspace and consistent writes
+
+**Outcome.** Make a remote workspace available quickly without exposing readers to partial file
+updates.
+
+- A sparse local shadow presents the target workspace before every file has crossed the wire.
+- Missing files and virtual exports are materialized when the agent actually reaches them.
+- Writes stream to the target and become visible atomically when the complete file arrives.
+
+**Learn:** [The anchor](/features/anchor) · **Use:**
+[Remote execution](/guide/remote-execution) · **Reference:**
+[What the agent observes](/reference/remote-execution#what-the-agent-observes)
+
+### C3. Portable transport runtime
+
+**Outcome.** Reach different targets through one session protocol without installing humanize
+on the target first.
+
+- A compact target runtime carries process, file, environment, and working-directory
+  operations.
+- One multiplexed connection can keep independent requests and streamed results in flight.
+- Targets may use different transports while preserving the same remote-execution semantics.
+- Local and target environments are composed deliberately rather than replacing each other.
+- Each remote command uses the target-resolved counterpart of the tracee's current working
+  directory.
+
+**Learn:** [The anchor](/features/anchor) · **Use:**
+[Remote execution](/guide/remote-execution) · **Reference:**
+[Targets](/reference/remote-execution#targets)
+
+### C4. Machine lifecycle
+
+**Outcome.** Give agents isolated or shared machines with a clear owner for startup, reuse, and
+cleanup.
+
+- An agent may receive a dedicated container whose lifetime follows that agent.
+- A run may share one container when the participants need the same environment.
+- Existing remote targets remain externally owned; managed targets are closed by the scope that
+  created them.
+- Workspace placement is declared separately from which backend performs the turn.
+
+**Learn:** [The anchor](/features/anchor) · **Use:** [Containers](/guide/containers) ·
+**Reference:** [Machines](/reference/machines)
+
+## D. Run continuity and observability
+
+Keep long work reachable, leave a readable record after failure, reconstruct its timeline, and
+separate local traces from optional outbound reporting.
+
+### D1. Detached operation
+
+**Outcome.** Let an interactive run survive terminal or SSH loss and reattach to its current
+screen later.
+
+- One workspace daemon owns the interface pseudoterminal (PTY) while terminals act as
+  attachable readers.
+- A new terminal receives a redraw of the live screen rather than a promised full transcript.
+- Slow readers have independent buffers and cannot stall the run or other attached terminals.
+- Detaching, cooperative stopping, and forced stopping remain distinct operations.
+- Detachment does not survive host or daemon loss; persisted state can support a later run, not
+  resurrect the old process.
+
+**Learn:** [The terminal can leave](/features/daemon) · **Use:**
+[Unattended runs](/guide/unattended), [Stopping](/guide/stopping) · **Reference:**
+[Daemon](/reference/daemon)
+
+### D2. Persistent state and layered logs
+
+**Outcome.** Preserve enough structured evidence to inspect an abrupt stop and continue a flow
+that explicitly supports it.
+
+- Each run's cycle record gains complete journal entries as events happen.
+- Ordinary flow state is written through on assignment, with a final save for nested mutations.
+- Atlas state records completed node visits under the prophecy identity and nesting path.
+- Called flows keep layered journals and state beside the run without overwriting their caller.
+- These records preserve workflow state, not the backend conversation or a terminal transcript.
+
+**Learn:** [Picked up where it stopped](/features/resuming),
+[The terminal can leave](/features/daemon) · **Use:**
+[Picking a run up](/guide/resuming), [History](/guide/history) · **Reference:**
+[Resumable flows](/reference/flows#a-flow-that-can-be-picked-up),
+[Cycle records](/reference/tracing#cycles)
+
+### D3. Trace reconstruction
+
+**Outcome.** Rebuild agent activity and the programs it started onto one timeline that can be
+inspected after the run.
+
+- Backend session logs and profiled processes are combined without copying their source
+  records.
+- Process clocks are calibrated so agent events and operating-system activity can be compared.
+- Cycle records bound collection to the sessions opened by the run being inspected.
+- Subagent relationships become explicit topology rather than anonymous extra sessions.
+- Dense lane packing and lazy attachments keep large traces navigable without dropping detail.
+- A trace is a local artifact; creating or opening it does not opt into outbound telemetry.
+
+**Learn:** [One timeline](/features/tracing) · **Use:** [Tracing](/guide/tracing) ·
+**Reference:** [Tracing](/reference/tracing)
+
+### D4. Telemetry privacy
+
+**Outcome.** Send diagnostic reporting only after consent, with content limits enforced before
+anything leaves the machine.
+
+- Consent may remain unanswered, be enabled, or be disabled; unanswered machines send nothing.
+- Data suppliers run only while a report is actually being assembled and provide names,
+  counts, and configuration rather than prompts, transcripts, tool output, or file content.
+- Final filters remove command lines, credentials, external paths, frame context, and logging
+  breadcrumbs before an outbound report is sent.
+- Local run journals, session logs, profiles, and traces are separate from optional reporting.
+
+**Learn:** [One timeline](/features/tracing) · **Use:** [Reporting](/guide/reporting),
+[Tracing](/guide/tracing) · **Reference:** [SDK](/reference/sdk),
+[Tracing](/reference/tracing)
+
+## E. Product surfaces
+
+Discover, own, configure, and start the same flows through interfaces suited to interactive,
+scripted, embedded, or detached work.
+
+### E1. Discovery, forking, and configuration
+
+**Outcome.** Find the nearest flow, make a safe local copy when it should become yours, and
+configure it from the contract the flow declares.
+
+- Built-in, fetched, project, and user flows participate in explicit catalogue and resolution
+  precedence.
+- Qualified names select a source directly; unqualified names prefer the nearest local version.
+- Forking stages a complete copy and refuses to overwrite an existing local flow.
+- A flow's pydantic model drives setup fields, validation, defaults, and grouped presentation.
+- Remembered settings are revalidated against the model the flow declares now.
+
+**Learn:** [One system, four ways in](/features/surfaces) · **Use:**
+[Flowverses](/guide/flowverses), [Flow settings](/guide/flow-settings) · **Reference:**
+[Flows](/reference/flows#flowverses)
+
+### E2. Unified entry points
+
+**Outcome.** Choose a terminal, command line, or Python entry point without creating a second
+definition of what a flow or run means.
+
+- The SDK, command line, and terminal interface share workspace stores, flow loading,
+  validation, and the underlying runner where their responsibilities overlap.
+- The daemon holds the terminal interface but does not interpret flows or become another
+  engine.
+- Each surface keeps its purpose: composable SDK, scriptable command line, conversational
+  interface, and detached terminal continuity.
+- A user-facing run is written as a cycle record that history, state, and tracing can inspect.
+- Shared semantics do not imply identical interaction or backend capability on every surface.
+
+**Learn:** [One system, four ways in](/features/surfaces) · **Use:**
+[Quickstart](/tutorials/quickstart), [Status](/guide/status) · **Reference:**
+[SDK](/reference/sdk), [CLI](/reference/cli), [TUI](/reference/tui),
+[Daemon](/reference/daemon)

--- a/docs/features/daemon.md
+++ b/docs/features/daemon.md
@@ -1,0 +1,101 @@
+---
+pageClass: hmz-feature
+---
+
+# The terminal can leave
+
+A flow may work longer than an SSH connection or the shell that started it. For an interactive
+run, humanize makes that terminal a reader rather than the owner: one process for the workspace
+holds the interface on a pseudoterminal (PTY) of its own, and terminals come and go over a
+local socket.
+
+Close every reader and the run still has its terminal. Open the same workspace later and the
+screen is drawn there again.
+
+<HmzDaemon />
+
+## The PTY belongs to the daemon
+
+The holder is put in a session of its own and left with no controlling terminal. Its standard
+input, output and errors are moved onto one PTY, and the interface draws there exactly as it
+would have drawn on the shell that opened it. Nothing in the interface has to know whether a
+person is still at the other end.
+
+It is the machinery underneath a terminal multiplexer, built in rather than delegated to one:
+detach the process, keep a PTY alive, and proxy bytes between that PTY and whichever terminals
+are reading.
+
+## One workspace, one holder
+
+Two runs in one workspace would both claim the same current setup and the same run history.
+When a holder binds, it takes a kernel-held lock before an old socket can be removed and
+replaced. However the process ends, the kernel drops that lock. Another checkout has another
+full path and therefore another holder.
+
+A process number and a socket file are not proof that anything is alive: process numbers are
+reused and socket files outlive their listeners. A holder counts only when its process still
+exists and its socket accepts a connection.
+
+The socket carries framed terminal output, input, resize notices and control requests. More
+than one terminal may be attached at once, all reading the same PTY. The terminal type is fixed
+by the shell that started the holder; the PTY's size changes when an attached terminal reports
+that its window changed.
+
+## Leaving is not stopping
+
+Letting go closes readers. It does not signal the flow, close the interface or end the holder.
+That separation is the point: a disappearing terminal and a decision to stop the work are two
+different events.
+
+A cooperative stop asks the interface to close the flow and gives it time to unwind. A forced
+stop ends the holder itself, leaving the work exactly where the process was. The second is the
+last resort for a run that will not complete a cooperative stop.
+
+This protects a run from terminal and SSH loss, not from the loss of its host or the daemon
+process. After either of those, persistence makes the run inspectable and a resumable flow may
+start another run from saved state; it does not bring the old process back. A non-interactive
+invocation also stays in its own process because there is no terminal to proxy.
+
+## Replay is a screen, not a transcript
+
+A newly attached terminal begins empty and may have different modes and dimensions from the
+one before it. The daemon first sizes the PTY for it, then asks the interface to draw the whole
+current screen from the top. The first terminal may also receive the bounded output drawn
+before anybody had ever attached.
+
+After a terminal has attached once, output drawn while nobody is reading is discarded. A
+later reconnect still sees the current screen because the interface redraws it, not because
+the daemon recorded every byte. The backend's own session log and the run journal are the
+history; terminal replay is only a way back into the live view.
+
+## A slow reader pays its own cost
+
+PTY output is read once and offered to each attached terminal without waiting on any of them.
+Each reader has its own pending buffer. If one stops taking bytes and that buffer grows past
+one mebibyte, only that reader is released; the run, the PTY and every other terminal keep
+moving.
+
+The same non-blocking rule applies in the other direction. A large paste is queued for the PTY
+rather than allowed to make the only thread carrying screen output wait on the run it serves.
+
+## What is written while it runs
+
+The daemon writes a small, whole-file note saying which process and workspace it holds, when
+it began and which terminal type it draws for. Failures that cannot be shown on a terminal are
+appended to a log beside that note.
+
+The run has a record of its own. Its journal gains one complete line for each event as the
+event happens, so an abrupt end still leaves everything written before it. If the flow is
+resumable, each change to its state mapping writes a complete replacement file into place; a
+reader sees either the old state or the new one, never a half-written state.
+
+Those records are not another terminal buffer and not another transcript. They preserve the
+shape and state of the run; the coding-agent backend remains the owner of the conversation.
+
+## Where the detail is
+
+- [Run it unattended](/guide/unattended) — running with no interactive reader at all
+- [Picking a run up](/guide/resuming) — what saved state can do after a process has ended
+- [Stopping](/guide/stopping) — how a flow unwinds, and what a harder stop leaves behind
+- [Daemon reference](/reference/daemon) — lifecycle, terminal rules and the on-disk note
+- [Tracing](/guide/tracing) — the run journal, session links and traces made from them

--- a/docs/features/flows.md
+++ b/docs/features/flows.md
@@ -4,12 +4,14 @@ pageClass: hmz-feature
 
 # A flow is Python
 
-A flow is a directory holding a function that takes the agents and the task. Everything else
-about it is ordinary Python — a loop, a subprocess call, a file read between two turns, a
-condition on what the last answer said.
+A flow is a directory holding Python that takes the agents and the task. Most are ordinary
+functions: a loop, a subprocess call, a file read between two turns, a condition on what the
+last answer said. An **atlas** makes a different bargain: its deliberately narrow body is read
+before it runs and compiled into a typed graph called a prophecy.
 
-There is no graph to declare, no YAML, and no engine deciding what happens next. The flow *is*
-what happens next.
+Both are Python, discovered the same way and driven by the same run. Choose an ordinary flow
+when its shape should remain free; choose an atlas when the shape must be checked, compared or
+resumed node by node before any agent starts.
 
 <HmzLoops />
 
@@ -38,11 +40,16 @@ What the mark carries is what a command line cannot otherwise know:
 A flow may also declare **settings of its own** as a pydantic model, which become fields on the
 sheet where it is set up and lines in a file a scripted run can hand it.
 
-## Reading one means running it
+## Ordinary flows are loaded as code
 
-There is no static description of a flow to read instead, and none is cached. A flow rewritten
-between two runs — by hand, or by an agent that flow is itself driving — runs as it is *now*.
-That is what makes a flow, and the skills it brings, a thing a run can improve.
+There is no static description of an ordinary flow to run instead, and none is cached. A flow
+rewritten between two runs — by hand, or by an agent that flow is itself driving — runs as it
+is *now*. That is what makes a flow, and the skills it brings, a thing a run can improve.
+
+The static checker can inspect a flow's source without importing it. An atlas goes further: its
+body is the description, so compiling it produces a prophecy without executing that body. Its
+node functions and the rest of its module remain ordinary Python, which is why a flowverse is
+still trusted as code rather than treated as data.
 
 Its own directory is importable while it runs and only while, since what a flow imports is not
 something the rest of the process should be able to.
@@ -108,6 +115,8 @@ somebody had thought to add it would be a list that hid what there is to run.
 
 - [Writing a flow](/guide/writing-a-flow) · [Loops](/guide/loops) · [Testing a
   flow](/guide/testing-flows)
+- [An atlas](/guide/atlas) · [Checking a flow](/guide/checking-flows) · [Python becomes a
+  prophecy](/features/prophecy)
 - [Settings of its own](/guide/flow-settings) · [A flow that calls a
   flow](/guide/calling-flows) · [Flowverses](/guide/flowverses)
 - [Flows reference](/reference/flows) — the contract, in full

--- a/docs/features/human.md
+++ b/docs/features/human.md
@@ -78,4 +78,5 @@ is about to use.
 
 - [The person as an agent](/guide/human-agent) — driving one from a flow
 - [Questions](/guide/questions) — an agent asking its user
+- [The mission board](/guide/board) — work the flow and the person can change without waiting
 - [Being away](/guide/afk) — deciding what happens when nobody is at the prompt

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -9,13 +9,13 @@ import { withBase } from 'vitepress'
 # Features
 
 humanize runs **flows**: directories of Python that drive one or more coding agents in a loop
-and write down everything they did. It does not talk to a model provider — it drives the coding
-agent CLI you already have, logged in the way you already log in.
+and write down everything they did. Most backends drive a coding agent you already have under
+its existing login; the bundled DeepSeek Harness is the SDK-backed exception.
 
-This is the front of the documentation, and it is what there is rather than how to use it.
-Nothing on this page is a command to type: the [tutorials](/tutorials/) teach it in order
-starting with the [Quickstart](/tutorials/quickstart), the [guides](/guide/) answer "how do I
-use this?", and [Flows](/flows/) is what it can run out of the box.
+This is the front of the documentation: one way to install it, then what the system is rather
+than how to operate each part. The [tutorials](/tutorials/) teach it in order starting with the
+[Quickstart](/tutorials/quickstart), the [guides](/guide/) answer "how do I use this?", and
+[Flows](/flows/) is what it can run out of the box.
 
 <HmzInstall />
 
@@ -50,45 +50,71 @@ you are deliberately not entitled to:
 <a :href="withBase('/reference/remote-execution')">its reference</a>.
 </p>
 
-## Where each page sits
+## How the capabilities fit together
+
+A run crosses five systems: the flow that describes the work, the control plane that drives
+agents, the execution fabric that decides where work lands, the run record that keeps it
+continuous and readable, and the surfaces through which people start and inspect it. Hover or
+focus a group to read the guarantee it owns; follow it to the best explanation.
 
 <HmzMap />
 
-### The deep end
+<p class="hmz-note">
+The complete map adds the boundaries, related guides and reference for every group:
+<a :href="withBase('/features/capabilities')">Capability map</a>.
+</p>
 
-The five that are worth reading even if you never install it.
+## Feature deep dives
 
-| | |
-| --- | --- |
-| [The anchor](/features/anchor) | The agent runs here. Every syscall it makes is decided one at a time — replayed on another machine, or answered on this one. It is told none of it. |
-| [Two accounts of one CLI](/features/accounts) | A CLI signs in once. humanize runs it as an account it was never signed into, by answering the paths it opens with other paths. |
-| [One timeline](/features/tracing) | Every agent, every sub-agent and every program those turns ran, on one clock, in one document you open in Perfetto. |
-| [A line typed mid-turn](/features/steering) | It goes *into* the turn that is running. Not queued behind it, and never quietly counted as said. |
-| [Answers in a shape](/features/shapes) | A turn given a pydantic model answers with that model. The model is the whole of the question, and the answer is read back through it. |
+The map is broad. These pages take one mechanism far enough that its trade-offs make sense,
+each around a diagram you can push.
 
-### The shape of a run
+### Flow system
 
 | | |
 | --- | --- |
-| [Twelve CLIs, one agent](/features/backends) | Twelve coding agents and anything speaking the Agent Client Protocol, each driven through whatever it actually offers. |
-| [A flow is Python](/features/flows) | A loop, a subprocess call, a file read between turns. The agents are its arguments, and the shapes a loop takes are few. |
-| [Many turns at once](/features/concurrency) | Turns are sequential only inside one session. Two hundred conversations are two hundred turns. |
-| [Picked up where it stopped](/features/resuming) | A loop meant to run for a week is a loop that will be stopped. What it was keeping track of survives; the conversation does not. |
+| [Python becomes a prophecy](/features/prophecy) | A deliberately narrow flow becomes a typed graph that can be checked, compared and resumed node by node. |
+| [A flow is Python](/features/flows) | Ordinary Python and compiled atlases live side by side, chosen by how much of the work must be knowable before it runs. |
+| [Many turns at once](/features/concurrency) | Turns are sequential inside one session; concurrency comes from having several conversations to run. |
+| [Picked up where it stopped](/features/resuming) | Ordinary flows preserve explicit state; atlases preserve completed node visits. Neither recreates a conversation. |
 
-### Who is at the other end
+### Agent control plane
 
 | | |
 | --- | --- |
-| [It decides when it is done](/features/goals) | The backend's own goal feature: a turn that would have ended starts another, until the model says the objective is met. |
-| [The moments of a turn](/features/hooks) | Seven points a turn passes through, and Python callables hung on them — and taken down again while it runs. |
-| [You, as one of the agents](/features/human) | A flow puts a decision to a person the way it puts one to a model, in the same shape, with the same branch for an answer that never came. |
+| [Many backends, one agent](/features/backends) | Native servers, streaming CLIs and Agent Client Protocol backends meet one session contract. |
+| [Two accounts of one CLI](/features/accounts) | Credentials, model catalogues and failure chains stay isolated while a session changes where it runs. |
+| [A line typed mid-turn](/features/steering) | Acknowledged queues put guidance into the turn that is working rather than behind it. |
+| [Answers in a shape](/features/shapes) | A pydantic model is both the question and the contract the answer must satisfy. |
+| [It decides when it is done](/features/goals) | A backend-owned pursuit loop continues until the model settles the objective. |
+| [The moments of a turn](/features/hooks) | Typed lifecycle moments let a flow react without teaching the backend about the flow. |
+| [You, as one of the agents](/features/human) | Questions, the mission board and a person-shaped agent put human decisions on the same run. |
+
+### Execution fabric
+
+| | |
+| --- | --- |
+| [The anchor](/features/anchor) | A local agent can work against a remote target while paths, processes, networks and ownership keep their meaning. |
+
+### Run continuity and observability
+
+| | |
+| --- | --- |
+| [The terminal can leave](/features/daemon) | A workspace daemon owns the PTY, so watchers may disconnect and return without owning the run. |
+| [One timeline](/features/tracing) | Agent events, sub-agents and sampled processes are reconstructed on one calibrated clock. |
+
+### Product surfaces
+
+| | |
+| --- | --- |
+| [One system, four ways in](/features/surfaces) | Local discovery, schema-driven setup, Python, CLI, TUI and the daemon all reach the same run and session model. |
 
 ## The flows it comes with
 
-Eleven of them, between the package and the flowverse humanize fetches: a ralph loop and a
-stateful one, two agents alternating, an actor with a reviewer between its rounds, a loop the
-model itself decides is over, and three isolated lanes with a coordinator over them. Each has a
-page with its own loop played on it.
+Between the package and the official flowverse are a ralph loop and a stateful one, two agents
+alternating, an actor with a reviewer between its rounds, a loop the model itself decides is
+over, and isolated lanes with a coordinator over them. Each has a page with its own loop
+played on it.
 
 <p class="hmz-note">
 Every one of them, with the shape of each: <a :href="withBase('/flows/')">Flows</a>. How to write
@@ -106,25 +132,20 @@ Recorded against a stand-in coding agent, in a container of its own — see
 <a :href="withBase('/contributing/docs#the-terminal-demos')">Working on these docs</a>.
 </p>
 
-## And the rest
-
-Everything above is one page because it is unusual. The ordinary parts of humanize have a guide
-apiece and no page here: [efforts](/guide/efforts) and [permissions](/guide/permissions),
-[skills](/guide/skills) and [questions](/guide/questions), [containers](/guide/containers) and
-[worktrees](/guide/worktrees), [cost and rate](/guide/tally), [flowverses](/guide/flowverses),
-[history](/guide/history), [completion](/guide/completion) and [what a project
-remembers](/guide/settings).
-
 ## Where to go next
 
 <div class="hmz-paths">
+  <a :href="withBase('/features/capabilities')">
+    <strong>Map the whole system</strong>
+    <span>Five domains, every capability group, and the right explanation for each.</span>
+  </a>
   <a :href="withBase('/tutorials/quickstart')">
     <strong>Never used it</strong>
     <span>Nothing installed to a run you can open in Perfetto, in fifteen minutes.</span>
   </a>
   <a :href="withBase('/flows/')">
     <strong>What it can run</strong>
-    <span>Eleven flows, the shape of each one drawn and played.</span>
+    <span>The flows it ships, with the shape of each one drawn and played.</span>
   </a>
   <a :href="withBase('/guide/')">
     <strong>One feature</strong>
@@ -138,6 +159,7 @@ remembers](/guide/settings).
 
 ::: warning Before you point one at a repository you care about
 humanize runs every agent with permission prompts disabled, and nothing turns them back on. A
-flow is a directory of Python, and reading one means running it. Read
+flow is trusted Python: loading or running it may execute its code, even though static checks
+can inspect selected structure without doing so. Read
 [Security](/guide/security).
 :::

--- a/docs/features/prophecy.md
+++ b/docs/features/prophecy.md
@@ -1,0 +1,123 @@
+---
+pageClass: hmz-feature
+---
+
+# Python becomes a prophecy
+
+A regular flow is deliberately unconstrained Python: its next step is whatever its body does.
+An **atlas** makes the other bargain. Its small declarative body is read before its first node
+runs and compiled into a **prophecy** — a typed, canonical graph of every node, edge, branch,
+loop and way out.
+
+The graph is not a picture made after the run. It is the thing the run walks.
+
+<HmzProphecy />
+
+## The narrowness stops at the atlas body
+
+An atlas body may bind the answer of one call, branch on a value already bound, loop back to
+the node that answered it, and return. Arithmetic, nested calls, exception handling and every
+other piece of work belong in a node.
+
+That leaves the work itself as ordinary Python:
+
+- A **mind** is one agent turn. It has one way out, because what a model happened to say is
+  not yet a decision the graph can promise.
+- A **logic** node is Python that drives no agent. It may count, reshape an answer, enforce a
+  budget, and make the decision a branch reads.
+- A **supernode** is another atlas. From outside it is one node; inside it is another complete
+  prophecy.
+
+Only the declarative body is restricted. A node may use the full language, and the ordinary
+[flow](/features/flows) remains the better choice when the shape of the work is meant to emerge
+while it runs.
+
+## Compiling settles the graph before model time
+
+The compiler reads syntax trees without importing or executing the flow. Each call site becomes
+a node with a stable id; calling the same function twice makes two nodes. The node inputs and
+outputs name their shapes, and every connection is checked before a turn can spend a token.
+
+A loop becomes an explicit back-edge. Its head is run again with the values the body changed.
+If the body changes nothing the head reads, the loop would make the same decision forever and
+is refused. A return becomes a named way out of the graph, so a supernode answers with what the
+return chose rather than whatever happened to run last.
+
+The result is all or nothing. A call inside another call, a branch hung straight off a mind,
+an incompatible shape, an unbound value, or a graph nested back inside itself produces findings
+and no prophecy to guess from.
+
+## The static reader proves only what it can see
+
+The same zero-execution reading checks ordinary node code and regular flows. It can establish
+useful absences one function at a time:
+
+- a constant loop with no exit, or one that only sleeps, is an error;
+- a loop whose every exit waits for an agent's shaped verdict is warned about unless the
+  function also owns a bound;
+- a suppressed shaped answer whose field is read before the answer is guarded is warned about;
+- a field compared with a literal its declared shape can never hold is warned about.
+
+It deliberately does not pretend to prove that an exit is reachable, follow a value through
+arbitrary calls, or predict a model. Those questions belong to tests that drive the flow with
+stand-in agents and adversarial answers. Static reading and executable proof meet at the same
+boundary: neither needs a real model.
+
+## One graph has one identity
+
+A prophecy has a canonical text: nodes, edges, shapes and nested prophecies are ordered by what
+they are, not by source formatting. Its identity is the first sixteen hexadecimal characters
+of the canonical text's SHA-256 digest. Reflowing a docstring or adding a comment therefore
+does not invent a new graph.
+
+Changing a node's implementation does not change the graph either. Changing a call site, an
+edge, a shape or a nested prophecy does. That distinction is what lets the work under a stable
+graph evolve without pretending a changed graph is the old one.
+
+A flowverse may ship the compiled prophecy beside its atlas. A run then walks that shipped
+graph, while the static reading still compiles the source and reports when the two digests have
+drifted apart. The shipped bytes may rebuild only the small set of tuple types a prophecy is
+made of; malformed bytes or a pickle naming anything else are refused rather than executed or
+silently replaced with a newly guessed graph.
+
+## A graph may contain another graph
+
+A supernode is compiled into the prophecy that reaches it. Its own nodes and shapes remain
+visible underneath, and its answer is checked against the outer node that receives it. An
+atlas may reach only another atlas this way: a dynamically loaded ordinary flow could have any
+shape, which would leave a hole where the promised graph should be.
+
+The compiler follows the nesting before the outer run begins and refuses a path that reaches
+back into a prophecy already being compiled. During one run, a reached atlas is read once and
+held; code is not swapped underneath a graph halfway through a round.
+
+That is a deliberate difference from a regular flow. A regular flow handle keeps a name and
+reads the target, including modules beside it, again at each call; a running flow may rewrite
+that target and load it again. An atlas gives up that within-run hot reload so its prophecy
+has no holes. Its files are read again by the next run.
+
+## Picking up is another walk over the same graph
+
+Every completed visit writes its answer under both the node id and the visit number. That last
+part matters inside a loop: the third visit to one node is not allowed to overwrite the first
+two. Visits inside a supernode are kept beneath the outer visit, however deep the nesting goes.
+
+When a stopped run is picked up, humanize starts at the graph's way in and rebuilds the values
+already written down. Completed visits return their kept answers without running. The first
+visit with no answer is exactly where work continues; by default, a node interrupted partway
+runs again. A side-effecting node that has certainly taken effect may instead declare that it
+should be skipped on resume, but it must answer with nothing so no missing value is hidden.
+
+This is precise workflow recovery, not process recovery. Backend conversations do not come
+back. And the saved state carries the prophecy digest: if the graph changed, the old visits are
+cleared and the run starts at the top. If only a node body changed, the digest still matches,
+so completed visits stay completed and the first unfinished visit runs its node's current
+code.
+
+## Where the detail is
+
+- [An atlas](/guide/atlas) — writing the restricted body and reading the compiled graph
+- [Checking a flow](/guide/checking-flows) — the zero-execution findings and their limits
+- [Testing a flow](/guide/testing-flows) — stand-in agents instead of model calls
+- [Picking a run up](/guide/resuming) — how runs and saved state relate
+- [Flows reference](/reference/flows) — every mark, graph field and finding

--- a/docs/features/resuming.md
+++ b/docs/features/resuming.md
@@ -5,10 +5,23 @@ pageClass: hmz-feature
 # Picked up where it stopped
 
 A loop meant to run for a week is a loop that will be stopped: somebody presses escape, a
-machine goes down, a turn takes the process with it. So a flow may say that it can be picked up
-where its last run left off — and then running it again is what picks it up. There is no flag.
+machine goes down, a turn takes the process with it. humanize has two answers. An ordinary
+flow may preserve the state it explicitly owns; an atlas preserves its completed node visits.
+Starting the flow again is what picks either one up.
 
 <HmzResume />
+
+## State in one case, completed visits in the other
+
+The diagram shows an ordinary resumable flow. It starts its Python function again with the
+dict it last wrote, so the flow decides what progress means and where to continue. It also runs
+the current version of that function: saved state is an input to today's code, not a frozen
+copy of yesterday's code.
+
+An [atlas](/features/prophecy) has a stronger coordinate. Every completed visit's answer is
+written beside the identity of the prophecy it belongs to. A later run walks those answers to
+the first unfinished visit and continues there. If the graph has changed, its identity has
+changed and the run starts at the beginning rather than putting an old answer into a new edge.
 
 ## What a flow keeps is its own handful of things
 
@@ -53,10 +66,11 @@ of it recorded. A flow is a directory on disk, and what can happen next is what 
 
 ## What does not come back
 
-The conversation. A session is opened rather than reopened, so a run picked up again starts
-from the task and the repository with none of the rounds before it in context. A stateful loop
-stopped on its fortieth round says round 41 when it is started again — and remembers nothing
-else about the forty.
+The conversation. Neither a state dict nor a prophecy is a copy of a backend session. An
+ordinary flow opens a session rather than reconstructing one; an atlas reuses completed visit
+answers rather than recreating the context in which an agent produced them. A stateful loop
+stopped on its fortieth round says round 41 when it starts again — and remembers nothing else
+about the forty unless the flow wrote it down.
 
 Which is the argument for keeping little: the repository is the memory, and the handful of
 things the flow tracks is what has to survive.
@@ -64,5 +78,6 @@ things the flow tracks is what has to survive.
 ## Where the detail is
 
 - [Picking a run up](/guide/resuming) — declaring it, and where the file lives
+- [An atlas](/guide/atlas#stopping-and-starting) — graph identity and node-level continuation
 - [Tracing](/guide/tracing#what-a-run-writes-down) — what else a run writes down
 - [Stopping](/guide/stopping) — what escape does to a turn

--- a/docs/features/surfaces.md
+++ b/docs/features/surfaces.md
@@ -1,0 +1,107 @@
+---
+pageClass: hmz-feature
+---
+
+# One system, four ways in
+
+humanize has a Python SDK, a command line, a terminal interface and a daemon, but none of
+them is a second orchestration engine. They reach the same workspace stores, flow loader and
+runner. What changes is how the question is asked and how long the caller stays attached.
+
+The route starts before a run does: find the nearest flow, fork it when it should become
+yours, let its own pydantic model describe its setup, then enter through whichever surface
+fits the job.
+
+<HmzSurfaces />
+
+## A flow starts near you
+
+A flowverse is one place flows come from. A fetched flowverse is a Git repository whose
+flows directory is the only part offered to humanize; the built-in flows are read from the
+package instead. The project flow directory and the flow directory in your home are places
+too, called local and user, even though nothing fetches either of them.
+
+That gives a name two different orders. The catalogue opens with the flows humanize ships,
+then the official flowverse, added flowverses, and finally the local places where either has
+something to show. Resolution is deliberately different: an unqualified name looks in this
+project first, then your home, then everywhere else. What is nearest wins.
+
+A qualified name names its flowverse outright and bypasses that precedence. This is why the
+catalogue can show the original and a local variant beside each other, while an unqualified
+name quietly picks the one meant for this project.
+
+Discovery is also a trust boundary. Listing the files in a repository is cheap, but finding
+the marked flows and the lines they say about themselves means loading their entry points.
+Only the flows directory is considered; what is in that directory is still Python code. A
+flowverse should be trusted the way a package that will run on this machine is trusted.
+
+## Forking changes ownership, not ancestry
+
+Forking copies a flow into this project's local flow directory. A directory flow arrives
+whole: its entry point, the modules it imports beside itself and every skill it brings. A
+single-file flow remains a single file. The fetched source stays untouched, so refreshing
+its flowverse later cannot erase the local edits.
+
+The copy is staged beside its destination and then moved into place. If copying fails, no
+half-flow is left under the name; if a local file or directory already owns that name,
+forking refuses to write over it. Once the copy lands, nearest-first resolution makes the
+unqualified name mean the local copy. The qualified source name still reaches the original.
+
+This is a source decision, not a runtime capability switch. Forking a flow does not add a
+goal feature to a backend, make an unsupported hook available or change where an agent can
+work. The flow's declared requirements are checked separately against the agents chosen for
+the run.
+
+## The model is the setup surface
+
+A flow that needs settings declares a pydantic model as its third argument. The model is the
+complete vocabulary of that setup: field names, annotations, defaults, descriptions, bounds
+and validators. Optional section metadata lets a large model group related fields without
+teaching the terminal interface what any of them mean.
+
+The interface reads those declarations directly. A boolean becomes a switch, a fixed set of
+literal values becomes a list to step through, numbers move one at a time or accept typed
+input, and other values are written. The description appears beside the field. When the
+reader accepts the sheet, the model validates the whole set, including relationships between
+fields, and returns its own refusal when the combination cannot run.
+
+The command line and Python surface do not get a weaker contract. Values read from a setup
+file or handed to the SDK are validated by the same model. Loading a flow runs its file
+again, so the earlier model class is not trusted as the current one: its fields are read back
+through the class the flow declares now. A remembered setup that no longer fits starts over;
+a bad setup presented to a run is refused before its first turn.
+
+## Shared core does not mean identical interfaces
+
+The SDK's workspace object is the composition point. It reaches the same settings, flows,
+agents, accounts and cycles that the other surfaces show, and loads each of them only when it
+is asked for. Adding a flowverse through one surface and seeing it in another is not a sync
+operation. Both are reading the same store.
+
+Python and the execution command both use the SDK Run: a loaded runner plus its task, with
+one lifecycle for running here, starting in the background, waiting, stopping and closing
+the agent conversations. The command line chooses the blocking path; Python may choose
+either.
+
+The terminal interface has a different job. It keeps the same workspace object and runner in
+hand so it can configure the flow, watch several conversations, accept questions and steer a
+turn while the run is live. It does not need to wrap that runner in a second orchestration
+engine merely to draw it.
+
+The daemon is narrower still. It does not interpret flows at all. It holds the same terminal
+interface in a detached process and carries its screen through a pseudoterminal. The interface
+sees only the SDK Session boundary: how many terminals are reading and how to detach them
+without stopping the run. That protocol keeps daemon machinery out of the interface while a
+closed terminal leaves the work going on the same host.
+
+So unified means common state, validation and runtime semantics where the surfaces overlap.
+It does not mean feature parity or identical interaction. The SDK is composable, the command
+line is scriptable, the terminal interface is conversational, and the daemon owns
+continuity. Each remains small because none has to redefine what a flow, setup, run or
+session means.
+
+## Where the detail is
+
+- [Flowverses and forking](/guide/flowverses) · [Flow settings](/guide/flow-settings)
+- [Python SDK](/reference/sdk) · [CLI](/reference/cli) · [TUI](/reference/tui) ·
+  [Daemon](/reference/daemon)

--- a/docs/features/tracing.md
+++ b/docs/features/tracing.md
@@ -86,6 +86,18 @@ and the traces collected of it. Runs are named so that they sort in the order th
 **to the millisecond**: two started inside one second would otherwise be ordered at random, and
 what a flow is picked up from is the last run of it.
 
+## A local trace is not a report
+
+Collecting a trace reads local run records and backend logs into another local file. Opening it
+in Perfetto does not send it to humanize, and the trace may contain prompts, answers and tool
+output because it is the record its owner asked to inspect.
+
+Reporting failures is a separate, opt-in path. It has three states — nobody has answered, yes
+and no — and the unanswered state sends nothing. Report suppliers provide names, counts and
+configuration rather than transcripts or trace files; final filters remove command lines,
+credentials, external paths, frame context and logging breadcrumbs. The full promise, and the
+switch that controls it, is in [Reporting](/guide/reporting).
+
 ## Which backends can be read back
 
 Four backends have a reader today, and so are what a trace is made of: Claude Code, Codex,
@@ -96,11 +108,12 @@ about the backend, kept where every other fact about it is.
 Several more write a log humanize reads *as a run happens*, which is where the running cost and
 rate come from. And a backend that keeps its conversation in a database — rows rather than
 files, with protobuf payloads — has nothing to read either way: no slices afterwards, and no
-tally while it runs. Which of them is which is on [Twelve CLIs, one agent](/features/backends).
+tally while it runs. Which of them is which is on [Many backends, one agent](/features/backends).
 
 ## Where the detail is
 
 - [Tracing](/guide/tracing) — collecting one, and what to look for in your first
 - [Tracing reference](/reference/tracing) — the cycle format, the trace format, what a slice
   carries
+- [Reporting](/guide/reporting) — what may leave the machine, and only after consent
 - [Many turns at once](/features/concurrency) — why a fan-out is one process and many tracks

--- a/docs/flows/flame-chase.md
+++ b/docs/flows/flame-chase.md
@@ -47,4 +47,4 @@ once is counted once.
 
 - [official/rlar](/flows/rlar) — two agents, but one of them reviews rather than works
 - [official/parallel_flame_chase](/flows/parallel-flame-chase) — three of these at once, in isolation
-- [Twelve CLIs, one agent](/features/backends) — what you can put on either side of it
+- [Many backends, one agent](/features/backends) — what you can put on either side of it

--- a/docs/guide/atlas.md
+++ b/docs/guide/atlas.md
@@ -273,9 +273,10 @@ thing and reads as another
 ```
 
 ::: warning
-A shipped prophecy is a pickle, and reading one runs what it says. That is the trust a
-flowverse already has — [a flow is a directory of Python and reading one means running
-it](/guide/security) — but it is worth knowing that `prophecy.pkl` is code and not data.
+A shipped prophecy uses pickle's format, but humanize does not open it with a general-purpose
+pickle reader. It rebuilds only the seven allowlisted tuple types that make up a prophecy,
+checks their canonical shape, and refuses anything else. The flow's Python is still trusted
+code when it is loaded, as [the security guide](/guide/security) explains.
 :::
 
 ## When to write one, and when not to

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -59,6 +59,8 @@ These are for looking things up. If you have not used humanize before, the
 | [Settings of its own](/guide/flow-settings) | A pydantic model that becomes `/config` fields |
 | [Many turns at once](/guide/async-flows) | `async def run`, and awaiting several turns |
 | [A flow that calls a flow](/guide/calling-flows) | Composition, and whose agents the inner one gets |
+| [An atlas](/guide/atlas) | Restricted Python compiled into a typed, resumable prophecy |
+| [Checking a flow](/guide/checking-flows) | Static findings and executable proof before a real turn |
 | [Testing a flow](/guide/testing-flows) | Checking the loop without spending a turn |
 | [Flowverses](/guide/flowverses) | A git repository of flows, offered by name |
 

--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -1326,9 +1326,10 @@ Hmz().flows.prophecy("official/review")   # reads what the source compiles to
 ```
 
 or [`hmz check --ship`](/reference/cli#hmz-check) from a command line. The flow's own Python
-still has to be there: a prophecy names the functions its nodes are. Reading a shipped
-prophecy runs what its bytes say, which is the trust a [flowverse](/guide/security) already
-has.
+still has to be there: a prophecy names the functions its nodes are. The shipped-file reader
+rebuilds only the seven allowlisted tuple types a prophecy uses and validates the resulting
+shape. Any other class or malformed shape is refused; loading the flow's Python remains the
+separate trust boundary described in [Security](/guide/security).
 
 ## Testing a flow
 


### PR DESCRIPTION
## Summary

- reorganize the Feature information architecture around five reader-facing systems and nineteen capability groups
- add a complete capability map plus interactive deep dives for prophecy compilation, detached runs, and shared product surfaces
- clarify boundaries across ordinary flows and atlases, resumption, backend capabilities, tracing, telemetry, credentials, and remote execution

## Verification

- corepack pnpm build
- corepack pnpm check:anchors
- uv run pre-commit run --all-files
- targeted feature tests: 323 passed, 1 skipped

Full uv run pytest was not completed locally: on this macOS arm64 host, collection stops in tests/coganchor/test_redirect.py and tests/coganchor/test_smoke.py when the x86_64-only coganchor interception layer is imported. The full suite runs in CI on Ubuntu x64 for Python 3.12–3.14.