### PR TITLE
[usage] recommend pipx for isolated installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ Three things to know before pointing one at a repository you care about. Each is
 
 ```sh
 pip install git+https://github.com/humanfia/humanize2.git
+# or, in an isolated environment
+pipx install git+https://github.com/humanfia/humanize2.git
+uv tool install git+https://github.com/humanfia/humanize2.git
 ```
+
+We recommend installing with `pipx` or `uv tool`, which give `hmz` an isolated environment of
+its own; `pip install` of the same URL works too.
 
 DeepSeek Harness arrives with humanize: its Python SDK and the runtime its turns are taken on
 are ordinary dependencies, so there is nothing extra to install for it.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -20,6 +20,10 @@ Linux on x86-64 here plus `python3` on the far machine.
 pip install git+https://github.com/humanfia/humanize2.git
 ```
 
+```sh [pipx]
+pipx install git+https://github.com/humanfia/humanize2.git
+```
+
 ```sh [uv tool]
 uv tool install git+https://github.com/humanfia/humanize2.git
 ```
@@ -32,7 +36,11 @@ uv sync
 
 :::
 
-Either way the command is `hmz`:
+We recommend `pipx` or `uv tool`: both give `hmz` an isolated environment of its own and put
+it on your `PATH` from every directory, whereas `pip` installs into whichever environment is
+active at the time.
+
+Whichever way, the command is `hmz`:
 
 ```sh
 hmz --version


### PR DESCRIPTION
Recommend `pipx` or `uv tool` for installing `hmz`, since both give it an isolated environment of its own.

- **README**: the install block lists `pip install` first, then `pipx install` and `uv tool install`, followed by a one-sentence recommendation for the latter two.
- **Installation guide**: adds a `pipx` tab after `pip`, before `uv tool` and `from a checkout`, with the same one-sentence recommendation.
