### PR TITLE
ci: run the tests on macOS as well as Linux, and raise coverage 85% → 88%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,5 @@ jobs:
       # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest -q --durations=25
+          uv run --frozen pytest -q --durations=25 --timeout-method=thread
           --cov=hmz --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,11 @@ jobs:
   test:
     name: test (${{ matrix.os }}, python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-    # Room for the slowest combination the matrix has. Ubuntu finishes in about thirteen
-    # minutes and macOS on 3.12 and 3.14 in about fourteen; macOS on 3.13 takes three times
-    # that, reproducibly, for reasons that are the interface suite's and not this repository's
-    # to fix. Generous rather than tight on purpose: a job killed at the wall reports nothing
-    # at all about what it was doing, which is the one outcome worth spending minutes to
-    # avoid. What bounds a single test is `timeout` in pyproject.toml, not this.
-    timeout-minutes: 60
+    # Both systems finish in about a quarter of an hour. Twice that, because a job killed at
+    # the wall reports nothing at all about what it was doing -- which is the one outcome
+    # worth spending minutes to avoid, and the one this matrix spent a morning learning.
+    # What bounds a single test is `timeout` in pyproject.toml, not this.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -86,5 +84,5 @@ jobs:
       # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest tests/tracing/test_profile.py -v --timeout-method=thread --timeout=120
-          --no-cov
+          uv run --frozen pytest -q --durations=25 --timeout-method=thread
+          --cov=hmz --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,5 @@ jobs:
       # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest -q --durations=25 --timeout-method=thread
+          uv run --frozen pytest -v --durations=25 --timeout-method=thread
           --cov=hmz --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,5 @@ jobs:
       # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest -v --durations=25 --timeout-method=thread
+          uv run --frozen pytest -v --durations=25 --timeout-method=thread --timeout=120
           --cov=hmz --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,5 @@ jobs:
       # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest -v --durations=25 --timeout-method=thread --timeout=120
-          --cov=hmz --cov-report=term-missing --cov-report=xml
+          uv run --frozen pytest tests/tracing/test_profile.py -v --timeout-method=thread --timeout=120
+          --no-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
   test:
     name: test (${{ matrix.os }}, python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-    # Room for the slower of the two systems and for every test that has to time out before
-    # the run can say so: a job killed at the wall reports nothing about what it was doing.
-    # macOS spends about four seconds apiece on the suites that spawn a CLI per test, which
-    # is most of the difference between the two.
-    timeout-minutes: 45
+    # Room for the slowest combination the matrix has. Ubuntu finishes in about thirteen
+    # minutes and macOS on 3.12 and 3.14 in about fourteen; macOS on 3.13 takes three times
+    # that, reproducibly, for reasons that are the interface suite's and not this repository's
+    # to fix. Generous rather than tight on purpose: a job killed at the wall reports nothing
+    # at all about what it was doing, which is the one outcome worth spending minutes to
+    # avoid. What bounds a single test is `timeout` in pyproject.toml, not this.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         run: uv build
 
   test:
-    name: test (python ${{ matrix.python }})
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -54,6 +54,15 @@ jobs:
         # Every stable minor at or above the floor `requires-python` sets. A new one
         # ships, a new one goes here -- that is what the README promises.
         python: ["3.12", "3.13", "3.14"]
+        # Both systems humanize is installed on. The half that runs an agent under an
+        # anchor is a seccomp filter and a ptrace supervisor, which is Linux on x86-64
+        # and says so by skipping everywhere else; everything above it -- the interface,
+        # the flows, the backends, the daemon, the serving half of an anchor -- is meant
+        # to work on either, and this is what holds it to that.
+        #
+        # `macos-latest` rather than a pinned Intel runner: the DeepSeek runtime, which
+        # is an ordinary dependency, publishes a macOS wheel for arm64 alone.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Room for the slower of the two systems and for every test that has to time out before
     # the run can say so: a job killed at the wall reports nothing about what it was doing.
-    timeout-minutes: 30
+    # macOS spends about four seconds apiece on the suites that spawn a CLI per test, which
+    # is most of the difference between the two.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +79,10 @@ jobs:
 
       # Everything except the `agent`-marked tests, which drive real coding agents and
       # need `--run-agents`. `-ra` in pyproject names whatever got skipped.
+      # `--durations` because the two systems are not the same speed and the difference is
+      # not spread evenly: a suite that spawns a CLI per test costs far more on one of them,
+      # and a list of the slowest twenty-five is how that stays visible.
       - name: pytest
         run: >
-          uv run --frozen pytest -q
+          uv run --frozen pytest -q --durations=25
           --cov=hmz --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
   test:
     name: test (${{ matrix.os }}, python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # Room for the slower of the two systems and for every test that has to time out before
+    # the run can say so: a job killed at the wall reports nothing about what it was doing.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # The second gate. The first is `.pre-commit-config.yaml`; this runs the same hooks over
 # every file rather than the ones one commit touched, and it is the only place the tests
-# run, on every Python the package claims.
+# run -- on every Python the package claims, and on both systems it is installed on.
 
 name: CI
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -256,4 +256,6 @@ Run them through `uv run`, not `uvx`: the lockfile pins the versions the hooks a
   pyright rule or it does not exist.
 - Google-style docstrings, and type annotations everywhere.
 
-CI runs all of it over every file, and the tests on each Python the package claims.
+CI runs all of it over every file, and the tests on each Python the package claims, on both
+Linux and macOS. The tests that run an agent under an anchor need Linux on x86-64 and skip
+aloud anywhere else; the serving half, and everything above it, is held to both.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -29,8 +29,10 @@ Installing the hooks once means every commit is checked before it is made.
 | `uv run pytest` | The tests, against [stand-in agents](/reference/flows#testing-a-flow) |
 | `uv run pytest --run-agents` | Also the `agent`-marked tests, which drive the real coding agent CLIs and spend real tokens |
 
-Both of the first two have to pass. CI runs them over every file and on each Python the package
-claims, and never runs the third. `ruff` and `pyright` come from this project's own environment
+Both of the first two have to pass. CI runs them over every file, on each Python the package
+claims and on both Linux and macOS, and never runs the third. What a machine cannot do it says
+so and skips: running an agent under an anchor is a seccomp filter and a ptrace supervisor, so
+those tests are Linux on x86-64's, and everything above them is held to both systems. `ruff` and `pyright` come from this project's own environment
 rather than one pre-commit builds, so bump them with `uv lock --upgrade-package ruff` rather
 than by editing a second pin.
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -4,7 +4,7 @@
 
 | | |
 | --- | --- |
-| **Python 3.12 or newer** | 3.12, 3.13 and 3.14 are the ones CI runs the tests on. |
+| **Python 3.12 or newer** | 3.12, 3.13 and 3.14 are the ones CI runs the tests on, on Linux and macOS. |
 | **At least one supported backend** | `agy`, `claude`, `codex`, `cursor-agent`, `grok`, `kimi`, `mimo`, `opencode`, `pi`, `qwen` or `zcode` on your `PATH` — or nothing at all, since DeepSeek Harness arrives with humanize and needs only a DeepSeek API key. |
 | **A project you are willing to have rewritten** | Read [Security](/user/security) first. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ asyncio_mode = "auto"
 # A marker nobody registered is a typo, and a typo in `-m` selects nothing.
 # `-ra` names what was skipped, so a test that quietly stops running says so.
 addopts = ["--strict-markers", "--strict-config", "-ra"]
+# A ceiling on any one test that did not ask for its own. Everything here drives processes,
+# sockets and pseudoterminals, and every one of those has a way of waiting forever -- which
+# without this is a whole job sitting at the wall until CI kills it, saying nothing about
+# which test it was sitting in. A test that needs longer says so with `@pytest.mark.timeout`,
+# which wins over this.
+timeout = 300
 
 [tool.ruff]
 # The formatter wraps at 88; `pycodestyle` below lets prose the formatter cannot

--- a/src/hmz/sdk/flows.py
+++ b/src/hmz/sdk/flows.py
@@ -191,10 +191,10 @@ class Flows:
           named: The flow, by the name it is offered under or by a path to a file.
 
         Returns:
-          The path, as a string.
-
-        Raises:
-          NotAFlow: If nothing of that name is a flow.
+          The path to run, resolved -- and `named` itself where nothing answers to it, so
+          that whatever asked hears the name back rather than an exception it would have to
+          tell apart from a flow that is genuinely called that. Whether a flow is there is
+          answered by what comes back being a file.
         """
         from hmz.flows import find
 
@@ -331,10 +331,15 @@ class Flows:
           into: Where to put it, defaulting to this project's own flows.
 
         Returns:
-          The name it is offered under from now on, which is the one it already had.
+          The directory it was copied to, spelled as it was reached -- this project's own
+          flows are named from the project, so a copy that went there is named from there
+          too. The name it is offered under from now on is the one it already had, yours
+          being looked in first: `official/rlar` forked is `rlar`.
 
         Raises:
-          NotAFlow: If nothing of that name is a flow.
+          ValueError: If nothing of that name is a flow, or there is already one of that
+            name here -- which is a copy to edit, run or take away rather than one to write
+            over.
           OSError: If it cannot be copied.
         """
         from hmz.flows import fork

--- a/tests/agents/test_acp.py
+++ b/tests/agents/test_acp.py
@@ -18,7 +18,10 @@ from hmz import backends
 from hmz.agents import AcpAgent, AcpAgentConfig, driver
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+    from hmz.agents.acp import AcpSession
 
 #: An agent that speaks ACP: it answers the handshake, opens a session, and takes a turn --
 #: saying a thought, a tool call it asks permission for, and the answer it ends on. A prompt
@@ -110,6 +113,21 @@ def _agent(added: str) -> AcpAgent:
     )
 
 
+@pytest.fixture
+def session(added: str) -> Iterator[AcpSession]:
+    """One conversation on the stand-in agent, ended however the test ends.
+
+    The process is the session here: ACP opens one and holds the agent up between turns, so
+    a test that takes a turn and walks away leaves that process running for as long as the
+    suite does. Every test below that actually takes one comes through this.
+    """
+    held = _agent(added).new()
+    try:
+        yield held
+    finally:
+        held.close()
+
+
 def test_an_added_cli_is_written_down_and_read_back(added: str) -> None:
     """It outlives the run: a CLI is installed on a machine, not in one directory."""
     assert backends.speaking()[added] == ("my-agent", "--acp")
@@ -138,9 +156,10 @@ def test_an_added_cli_can_be_taken_away_again(added: str) -> None:
     assert backends.forget(added) is False
 
 
-def test_a_turn_opens_a_session_and_says_what_the_agent_said(added: str) -> None:
+def test_a_turn_opens_a_session_and_says_what_the_agent_said(
+    session: AcpSession,
+) -> None:
     """The handshake, the session, and the turn taken on it, in that order."""
-    session = _agent(added).new()
     said = list(session.stream("hi"))
 
     kinds = [event.kind for event in said]
@@ -150,21 +169,55 @@ def test_a_turn_opens_a_session_and_says_what_the_agent_said(added: str) -> None
     assert session.id == "ses-acp-1"
 
 
-def test_the_session_is_held_open_across_turns(added: str) -> None:
+def test_the_session_is_held_open_across_turns(session: AcpSession) -> None:
     """ACP opens a conversation once and prompts it many times."""
-    session = _agent(added).new()
     assert session("hi") == "hi"
     assert session("again") == "again"
     assert session.id == "ses-acp-1"
 
 
-def test_a_tool_call_is_permitted_by_the_kind_of_the_option(added: str) -> None:
+def test_a_tool_call_is_permitted_by_the_kind_of_the_option(
+    session: AcpSession,
+) -> None:
     """Never by its id: one agent calls it `proceed_once` and another `allow-once`.
 
     The stand-in offers the refusal first and carries the turn on only for the grant, so a
     client that picked whichever option came first would end this turn on a refusal.
     """
-    assert _agent(added).new()("hi") == "hi"
+    assert session("hi") == "hi"
+
+
+def test_ending_a_conversation_ends_the_agent_that_was_holding_it(added: str) -> None:
+    """The process is the session, so a conversation let go of is a process left running."""
+    held = _agent(added).new()
+    assert held("hi") == "hi"
+    link = held._link
+    assert link is not None
+    running = link.proc
+    assert running is not None
+    assert running.poll() is None
+
+    held.close()
+
+    assert running.wait(timeout=10) is not None
+    assert held._link is None
+
+
+def test_a_conversation_closed_twice_is_not_a_second_thing_to_end(added: str) -> None:
+    held = _agent(added).new()
+    assert held("hi") == "hi"
+
+    held.close()
+    held.close()  # the absence of a raised error is the whole assertion
+
+
+def test_a_conversation_dropped_without_a_turn_in_it_never_started(added: str) -> None:
+    """Nothing is spawned until the first turn, so there is nothing to end either."""
+    held = _agent(added).new()
+
+    held.close()
+
+    assert held._link is None
 
 
 def test_a_turn_that_ended_on_a_refusal_is_a_failed_turn(added: str) -> None:

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -595,9 +595,8 @@ def kimi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _FakeServer:
     # serves the REST the daemon serves and not the socket it notifies over, so every read
     # here is the plain polling the backend ran on before there were notifications -- one
     # read a second, and a turn is many reads. That is a cadence rather than anything under
-    # test: what these check is which calls were made, not how long apart. On the slower of
-    # the two systems the matrix runs it was thirty-seven seconds a test, and a turn nobody
-    # could steer inside the six seconds this file gives one.
+    # test: what these check is which calls were made, not how long apart. Fifty-two tests
+    # in ten seconds rather than sixty.
     monkeypatch.setattr(kimicode, "_POLL_SECONDS", 0.1)
     monkeypatch.setattr(kimicode, "_RECOVERY_SECONDS", 1.0)
     return _install("kimi", _KIMI, tmp_path, monkeypatch)

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -50,6 +50,7 @@ class _Verdict(BaseModel):
 #: recording each one. A prompt of `boom` is refused, which is how a failed turn is spelled.
 _KIMI = """
 import json, pathlib, sys
+import socketserver
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 LOG = pathlib.Path(sys.argv[0] + ".log")
@@ -151,7 +152,17 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
-server = HTTPServer(("127.0.0.1", 0), Handler)
+
+class Server(HTTPServer):
+    def server_bind(self):
+        # Skip the reverse lookup `HTTPServer` does to name itself. On a machine whose
+        # resolver has nothing to say about 127.0.0.1 it blocks for that resolver's timeout,
+        # which is half a minute -- once per process, and this is a process per test.
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+server = Server(("127.0.0.1", 0), Handler)
 print(f"Kimi server: http://127.0.0.1:{server.server_port}/#token=secret", flush=True)
 server.serve_forever()
 """
@@ -164,6 +175,7 @@ server.serve_forever()
 #: querystring schema requires, or the bare path a daemon that never had that filter takes.
 _KIMI_SLOW_TO_START = """
 import json, os, pathlib, sys
+import socketserver
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 LOG = pathlib.Path(sys.argv[0] + ".log")
@@ -250,7 +262,17 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
-server = HTTPServer(("127.0.0.1", 0), Handler)
+
+class Server(HTTPServer):
+    def server_bind(self):
+        # Skip the reverse lookup `HTTPServer` does to name itself. On a machine whose
+        # resolver has nothing to say about 127.0.0.1 it blocks for that resolver's timeout,
+        # which is half a minute -- once per process, and this is a process per test.
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+server = Server(("127.0.0.1", 0), Handler)
 print(f"Kimi server: http://127.0.0.1:{server.server_port}/#token=secret", flush=True)
 server.serve_forever()
 """

--- a/tests/agents/test_appservers.py
+++ b/tests/agents/test_appservers.py
@@ -569,6 +569,15 @@ def _bodies(server: _FakeServer, path: str) -> list[dict[str, Any]]:
 
 @pytest.fixture
 def kimi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _FakeServer:
+    # The same shortening `unhurried` below does, and for the same reason. This stand-in
+    # serves the REST the daemon serves and not the socket it notifies over, so every read
+    # here is the plain polling the backend ran on before there were notifications -- one
+    # read a second, and a turn is many reads. That is a cadence rather than anything under
+    # test: what these check is which calls were made, not how long apart. On the slower of
+    # the two systems the matrix runs it was thirty-seven seconds a test, and a turn nobody
+    # could steer inside the six seconds this file gives one.
+    monkeypatch.setattr(kimicode, "_POLL_SECONDS", 0.1)
+    monkeypatch.setattr(kimicode, "_RECOVERY_SECONDS", 1.0)
     return _install("kimi", _KIMI, tmp_path, monkeypatch)
 
 

--- a/tests/agents/test_providers.py
+++ b/tests/agents/test_providers.py
@@ -22,6 +22,7 @@ from hmz.agents import AgentConfig, ClaudeCodeAgent, ClaudeCodeAgentConfig
 from hmz.backends import named
 from hmz.machines import MachineBase, MachineConfig
 from tests.stubs import HereAnchor, ShellAgent, ShellSession
+from tests.supervising import traced
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +67,7 @@ def test_an_agent_with_no_provider_is_run_exactly_as_it_was() -> None:
     assert agent.new()("echo hi") == "hi"
 
 
+@traced
 def test_a_provider_that_is_variables_is_what_the_turn_is_run_with(home: Path) -> None:
     """A key, an endpoint, an account on somebody's cloud: every CLI reads one as a variable."""
     providers.add(
@@ -90,6 +92,7 @@ def test_a_provider_that_is_variables_is_what_the_turn_is_run_with(home: Path) -
     assert agent.new()('printf %s "$PATH"') == os.environ["PATH"]  # and keeps its own
 
 
+@traced
 @pytest.mark.timeout(120, method="thread")
 def test_a_turn_under_a_provider_reads_that_providers_credentials(home: Path) -> None:
     """The whole errand: the CLI names its own path and is answered with the provider's."""
@@ -108,6 +111,7 @@ def test_a_turn_under_a_provider_reads_that_providers_credentials(home: Path) ->
     }
 
 
+@traced
 @pytest.mark.timeout(120, method="thread")
 def test_what_a_turn_under_a_provider_writes_lands_in_that_provider(home: Path) -> None:
     """A token refreshed mid-run is written back where it was read from, which is the provider."""
@@ -122,6 +126,7 @@ def test_what_a_turn_under_a_provider_writes_lands_in_that_provider(home: Path) 
     ).read_text() == '{"token": "this machine"}'
 
 
+@traced
 @pytest.mark.timeout(180, method="thread")
 def test_two_agents_of_one_cli_under_two_providers_are_two_accounts(home: Path) -> None:
     """The flame-chase case: one flow, one CLI, two accounts, at the same time."""
@@ -140,6 +145,7 @@ def test_two_agents_of_one_cli_under_two_providers_are_two_accounts(home: Path) 
     assert [json.loads(one)["account"] for one in said] == ["first", "second"]
 
 
+@traced
 @pytest.mark.timeout(180, method="thread")
 def test_two_accounts_run_at_the_same_time_without_reading_each_others(
     home: Path,
@@ -172,6 +178,7 @@ def test_two_accounts_run_at_the_same_time_without_reading_each_others(
     assert [json.loads(one)["account"] for one in said] == ["first", "second"]
 
 
+@traced
 def test_a_key_left_lying_about_does_not_outrank_the_account_it_was_told(
     home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -195,6 +202,7 @@ def test_a_key_left_lying_about_does_not_outrank_the_account_it_was_told(
     assert agent.new()('printf %s "$PATH"') == os.environ["PATH"]
 
 
+@traced
 def test_a_provider_keeps_the_variables_it_set_itself(
     home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/agents/test_watchdog.py
+++ b/tests/agents/test_watchdog.py
@@ -31,7 +31,7 @@ from hmz.agents import (
 from hmz.agents.watchdog import WATCHDOG, Watchdog, held, silence
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 CONFIG = AgentConfig(model="m", effort="high")
 
@@ -147,6 +147,28 @@ def _watched(agent: AgentBase) -> list[Event]:
     said: list[Event] = []
     agent.watch(lambda _agent, _session, event: said.append(event))
     return said
+
+
+def _until(what: Callable[[], bool], seconds: float = 20.0) -> bool:
+    """Waits for the watchdog thread to have done a thing, rather than for a length of time.
+
+    One rung is a whole tick apart from the next, so "after this one and before that one" is
+    a window that a loaded machine steps straight over -- and the rung after a look is one
+    that does something, which is the difference between a verdict and none.
+
+    Args:
+      what: The question, asked again until it is yes.
+      seconds: How long to go on asking.
+
+    Returns:
+      Whether it became true in the time it was given.
+    """
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if what():
+            return True
+        time.sleep(0.01)
+    return what()
 
 
 def _steps(said: list[Event]) -> str:
@@ -389,7 +411,10 @@ def test_a_backend_that_crashed_keeps_the_reason_it_crashed() -> None:
     proc.wait()
     watch = Watchdog(session, riding=lambda: proc, window=0.5)
     with watch:
-        time.sleep(2.0)
+        # Left as soon as it has looked, rather than after a length of time: looking is one
+        # rung and the rung after it puts the transport down, which is a thing done and so a
+        # verdict claimed. Sleeping across that boundary is a coin toss.
+        assert _until(lambda: "is gone" in _steps(said))
     assert "is gone" in _steps(said)  # seen, and said at the moment it was seen
     assert watch.wedged() is None  # but nothing was done to it, so nothing is claimed
 

--- a/tests/coganchor/conftest.py
+++ b/tests/coganchor/conftest.py
@@ -32,6 +32,7 @@ from hmz.coganchor.proto import Channel
 from hmz.coganchor.remote import RemoteClient
 from hmz.coganchor.serve.exports import ExportTable
 from hmz.coganchor.serve.server import Server
+from tests.supervising import WITHOUT
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -112,7 +113,15 @@ def _decode(
 
 @pytest.fixture
 def anchorage(tmp_path: Path) -> Anchorage:
-    """A fresh target/mirror pair for one test."""
+    """A fresh target/mirror pair for one test.
+
+    The agent half of a session is a seccomp filter and a ptrace supervisor, so a machine
+    that cannot trace cannot have one. The serving half is portable on purpose and is
+    reached through `link` below, which every other test here uses and which asks nothing
+    of the kernel.
+    """
+    if WITHOUT:
+        pytest.skip(WITHOUT)
     target = tmp_path / "target"
     mirror = tmp_path / "mirror"
     target.mkdir()

--- a/tests/coganchor/test_anchor.py
+++ b/tests/coganchor/test_anchor.py
@@ -19,6 +19,7 @@ from hmz import cli
 from hmz.coganchor import AnchorConfig, check, connect
 from hmz.coganchor.argv import parser
 from tests.coganchor.conftest import DEFAULT_TIMEOUT, REPO_ROOT, Anchorage
+from tests.supervising import traced
 
 #: Every setting at once, none of them left at its default. The token is spelled the way one
 #: in eighty of `secrets.token_urlsafe`'s are, and the paths hold a space, because a setting
@@ -153,6 +154,7 @@ def test_settings_no_session_could_run_under_are_refused_as_they_are_written(
         AnchorConfig(**settings)
 
 
+@traced
 def test_connect_refuses_to_run_nothing() -> None:
     """Refused before a mirror is prepared or a target dialled, so nothing is left half done."""
     with pytest.raises(ValueError, match="no agent"):

--- a/tests/coganchor/test_anchor_command.py
+++ b/tests/coganchor/test_anchor_command.py
@@ -1,0 +1,302 @@
+"""`hmz anchor` as a command line: what it refuses, and where it routes what it accepts.
+
+Both halves are here. `serve` is answered first and without loading the agent half at all,
+which is what lets one program serve a target of any architecture -- so everything below runs
+in this process on any machine, rather than through the zipapp the end-to-end suites push.
+
+Most of what this file is about is refusals, and one of them is the door: a target left
+listening on an address anything can reach, with no secret asked for, is a shell on that
+machine offered to whoever finds the port.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from hmz.cli.anchor import anchor
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from hmz.coganchor.serve.exports import ExportTable
+
+
+#: The address that is the whole point of the refusal below -- everything that can reach this
+#: machine can reach a target left on it, which is why a secret stops being optional there.
+EVERYWHERE = "0.0.0.0"  # noqa: S104
+
+
+class _Listened:
+    """What `serve_forever` was asked for, instead of it actually listening."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, ExportTable, str | None]] = []
+        self.raises: OSError | None = None
+
+    def __call__(
+        self, host: str, port: int, table: ExportTable, token: str | None
+    ) -> None:
+        self.calls.append((host, port, table, token))
+        if self.raises is not None:
+            raise self.raises
+
+
+@pytest.fixture
+def listened(monkeypatch: pytest.MonkeyPatch) -> _Listened:
+    """Stands in for the listener, which is `test_listener.py`'s to actually run."""
+    from hmz.coganchor.serve import listener
+
+    held = _Listened()
+    monkeypatch.setattr(listener, "serve_forever", held)
+    return held
+
+
+@pytest.fixture
+def exported(tmp_path: Path) -> str:
+    """One directory to export, as `--export` takes it."""
+    target = tmp_path / "target"
+    target.mkdir()
+    return f"/project:{target}"
+
+
+# --------------------------------------------------------------- what it refuses
+
+
+def test_a_directory_that_is_not_an_export_is_a_bad_argument(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert anchor(["serve", "--export", "", "--stdio"]) == 2
+
+    assert "hmz:" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "listen",
+    [
+        "not-a-port",
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:70000",
+        "127.0.0.1:-1",
+        "127.0.0.1:",
+    ],
+)
+def test_an_address_that_is_not_one_is_a_bad_argument(
+    listen: str, exported: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert anchor(["serve", "--export", exported, "--listen", listen]) == 2
+
+    assert "malformed listen address" in capsys.readouterr().err
+
+
+def test_listening_where_anything_can_reach_it_without_a_secret_is_refused(
+    exported: str, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An `hmz anchor` port is equivalent to a shell on that machine."""
+    monkeypatch.delenv("HUMANIZE_TOKEN", raising=False)
+
+    assert anchor(["serve", "--export", exported, f"--listen={EVERYWHERE}:8080"]) == 2
+
+    assert "refusing to listen" in capsys.readouterr().err
+
+
+def test_serving_over_a_pipe_and_over_a_port_at_once_is_refused(exported: str) -> None:
+    """One session or many, and the far end has already been started for one of the two."""
+    with pytest.raises(SystemExit) as stopped:
+        anchor(["serve", "--export", exported, "--stdio", "--listen", "8080"])
+
+    assert stopped.value.code == 2
+
+
+def test_serving_neither_way_is_refused(exported: str) -> None:
+    with pytest.raises(SystemExit) as stopped:
+        anchor(["serve", "--export", exported])
+
+    assert stopped.value.code == 2
+
+
+def test_serving_nothing_at_all_is_refused() -> None:
+    """There is no default export: what a session may name is the whole of what it may do."""
+    with pytest.raises(SystemExit) as stopped:
+        anchor(["serve", "--stdio"])
+
+    assert stopped.value.code == 2
+
+
+# ------------------------------------------------------------ what it accepts
+
+
+def test_a_port_on_its_own_is_listened_for_on_the_loopback(
+    exported: str, listened: _Listened
+) -> None:
+    """Which is the address nothing off this machine can reach, so it needs no secret."""
+    assert anchor(["serve", "--export", exported, "--listen", "8080"]) == 0
+
+    (host, port, _, token) = listened.calls[0]
+    assert (host, port, token) == ("127.0.0.1", 8080, None)
+
+
+def test_an_address_given_whole_is_the_one_listened_on(
+    exported: str, listened: _Listened
+) -> None:
+    assert anchor(["serve", "--export", exported, "--listen", "127.0.0.1:9000"]) == 0
+
+    assert listened.calls[0][:2] == ("127.0.0.1", 9000)
+
+
+def test_an_ipv6_address_is_unwrapped_from_the_brackets_it_is_written_in(
+    exported: str, listened: _Listened
+) -> None:
+    """`[::1]:9000` is how a host with colons in it is told apart from the port."""
+    assert anchor(["serve", "--export", exported, "--listen", "[::1]:9000"]) == 0
+
+    assert listened.calls[0][:2] == ("::1", 9000)
+
+
+def test_an_address_anything_can_reach_is_listened_on_once_a_secret_is_asked_for(
+    exported: str, listened: _Listened
+) -> None:
+    assert (
+        anchor(
+            [
+                "serve",
+                "--export",
+                exported,
+                f"--listen={EVERYWHERE}:8080",
+                "--token",
+                "not-a-real-shared-secret",
+            ]
+        )
+        == 0
+    )
+
+    assert listened.calls[0][0] == EVERYWHERE
+    assert listened.calls[0][3] == "not-a-real-shared-secret"
+
+
+def test_the_secret_is_taken_from_the_environment_where_the_line_does_not_say(
+    exported: str, listened: _Listened, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A secret on a command line is a secret in whatever reads that machine's processes."""
+    monkeypatch.setenv("HUMANIZE_TOKEN", "out-of-the-environment")
+
+    assert anchor(["serve", "--export", exported, f"--listen={EVERYWHERE}:8080"]) == 0
+
+    assert listened.calls[0][3] == "out-of-the-environment"
+
+
+def test_a_port_zero_asks_for_whichever_one_is_free(
+    exported: str, listened: _Listened
+) -> None:
+    assert anchor(["serve", "--export", exported, "--listen", "0"]) == 0
+
+    assert listened.calls[0][1] == 0
+
+
+def test_an_address_that_cannot_be_listened_on_is_reported_rather_than_raised(
+    exported: str, listened: _Listened, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import errno
+
+    listened.raises = OSError(errno.EADDRINUSE, "Address already in use")
+
+    assert anchor(["serve", "--export", exported, "--listen", "8080"]) == 1
+
+    said = capsys.readouterr().err
+    assert "cannot listen on 127.0.0.1:8080" in said
+    assert "Address already in use" in said
+
+
+# ------------------------------------------------------------- the agent half
+
+
+def test_running_no_agent_at_all_is_a_bad_argument() -> None:
+    with pytest.raises(SystemExit) as stopped:
+        anchor([])
+
+    assert stopped.value.code == 2
+
+
+def test_settings_a_session_could_not_be_run_under_are_bad_arguments_too() -> None:
+    """Exit 2 the way argparse's own rejections do, rather than as a session that failed."""
+    with pytest.raises(SystemExit) as stopped:
+        anchor(["--target", "nonsense://nowhere", "bash"])
+
+    assert stopped.value.code == 2
+
+
+def test_a_target_that_cannot_be_reached_is_reported_rather_than_raised(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hmz.coganchor import anchor as connecting
+
+    def refuses(*_: Any, **__: Any) -> dict[str, Any]:
+        raise ConnectionRefusedError("nothing is listening there")
+
+    monkeypatch.setattr(connecting, "check", refuses)
+
+    assert anchor(["--target", f"local:{tmp_path}", "--check"]) == 1
+
+    assert "nothing is listening there" in capsys.readouterr().err
+
+
+def test_what_a_target_answers_is_printed_a_line_at_a_time(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--check` is for a person reading it, so it is lines rather than the reply itself."""
+    from hmz.coganchor import anchor as connecting
+
+    def answers(*_: Any, **__: Any) -> dict[str, Any]:
+        return {
+            "target": "local:/somewhere",
+            "hostname": "a-machine",
+            "python": "3.12.3",
+            "pid": 4321,
+            "exports": [{"virtual": "/project", "real": "/somewhere/project"}],
+            "workspace": "/project",
+            "entries": 7,
+        }
+
+    monkeypatch.setattr(connecting, "check", answers)
+
+    assert anchor(["--target", f"local:{tmp_path}", "--check"]) == 0
+
+    said = capsys.readouterr().out
+    assert "target      local:/somewhere" in said
+    assert "hostname    a-machine" in said
+    assert "python      3.12.3 (pid 4321)" in said
+    assert "export      /project -> /somewhere/project" in said
+    assert "workspace   /project (7 entries)" in said
+
+
+def test_a_target_that_answers_nothing_about_itself_is_still_printed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An older target says less about itself, which is a shorter report and not a crash."""
+    from hmz.coganchor import anchor as connecting
+
+    def sparsely(*_: Any, **__: Any) -> dict[str, Any]:
+        return {"target": "local:/somewhere", "workspace": "/project", "entries": 0}
+
+    monkeypatch.setattr(connecting, "check", sparsely)
+
+    assert anchor(["--target", f"local:{tmp_path}", "--check"]) == 0
+
+    said = capsys.readouterr().out
+    assert "hostname    None" in said
+    assert "workspace   /project (0 entries)" in said
+
+
+def test_a_session_interrupted_at_the_keyboard_says_so_the_way_a_shell_does(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """128 plus SIGINT, which is what every program a person stops exits with."""
+    from hmz.coganchor import anchor as connecting
+
+    def interrupted(*_: Any, **__: Any) -> int:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(connecting, "connect", interrupted)
+
+    assert anchor(["--target", f"local:{tmp_path}", "bash"]) == 130

--- a/tests/coganchor/test_fsops.py
+++ b/tests/coganchor/test_fsops.py
@@ -1,0 +1,207 @@
+"""Every operation a session may ask of its target, replayed on a directory here.
+
+`test_serve.py` drives the shape of the thing -- the export table, the streaming read, the
+atomic write -- and four of the mutations. This is the rest of them, one apiece, checked on
+the target's own directory rather than on what the reply said: an operation that answered
+`{}` and did nothing would pass either way otherwise.
+
+All of it is the serving half, which runs on the target and is POSIX rather than Linux: this
+is the file that says so on whatever the matrix is running.
+"""
+
+from __future__ import annotations
+
+import errno
+import stat
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.coganchor.proto import Op
+from hmz.coganchor.remote import RemoteOSError
+from tests.coganchor.conftest import VIRTUAL_EXPORT
+
+if TYPE_CHECKING:
+    from tests.coganchor.conftest import Link
+
+
+def _at(link: Link, *named: str) -> str:
+    """One path as the session names it, which is not where it really is."""
+    return "/".join((VIRTUAL_EXPORT, *named))
+
+
+# ---------------------------------------------------------------- directories
+
+
+def test_the_directories_above_one_are_made_where_they_were_asked_for(
+    link: Link,
+) -> None:
+    link.client.mkdir(_at(link, "one/two/three"), parents=True)
+
+    assert (link.target / "one" / "two" / "three").is_dir()
+
+
+def test_making_one_again_where_the_ones_above_were_asked_for_is_not_a_failure(
+    link: Link,
+) -> None:
+    """`makedirs` with `exist_ok`, which is what `mkdir -p` means."""
+    link.client.mkdir(_at(link, "one/two"), parents=True)
+
+    link.client.mkdir(_at(link, "one/two"), parents=True)
+
+    assert (link.target / "one" / "two").is_dir()
+
+
+def test_a_directory_under_one_that_is_not_there_is_the_target_s_own_errno(
+    link: Link,
+) -> None:
+    with pytest.raises(RemoteOSError) as raised:
+        link.client.mkdir(_at(link, "nowhere/at/all"))
+
+    assert raised.value.errno == errno.ENOENT
+
+
+def test_a_directory_made_at_the_mode_it_was_asked_for_is_at_that_mode(
+    link: Link,
+) -> None:
+    link.client.mkdir(_at(link, "shut"), mode=0o700)
+
+    assert stat.S_IMODE((link.target / "shut").stat().st_mode) == 0o700
+
+
+# --------------------------------------------------------------------- files
+
+
+def test_a_file_taken_away_is_gone(link: Link) -> None:
+    (link.target / "gone.txt").write_text("here for now")
+
+    link.client.unlink(_at(link, "gone.txt"))
+
+    assert not (link.target / "gone.txt").exists()
+
+
+def test_a_file_that_was_never_there_is_the_target_s_own_errno(link: Link) -> None:
+    with pytest.raises(RemoteOSError) as raised:
+        link.client.unlink(_at(link, "never-there.txt"))
+
+    assert raised.value.errno == errno.ENOENT
+
+
+def test_a_second_name_for_one_file_is_the_same_file(link: Link) -> None:
+    (link.target / "first.txt").write_text("one file")
+
+    link.client.link(_at(link, "first.txt"), _at(link, "second.txt"))
+
+    assert (link.target / "second.txt").read_text() == "one file"
+    assert (link.target / "first.txt").stat().st_ino == (
+        link.target / "second.txt"
+    ).stat().st_ino
+
+
+def test_a_path_moved_without_replacing_is_still_moved(link: Link) -> None:
+    (link.target / "here.txt").write_text("moving")
+
+    link.client.rename(_at(link, "here.txt"), _at(link, "there.txt"), replace=False)
+
+    assert not (link.target / "here.txt").exists()
+    assert (link.target / "there.txt").read_text() == "moving"
+
+
+def test_a_path_moved_over_another_replaces_it(link: Link) -> None:
+    (link.target / "here.txt").write_text("the new one")
+    (link.target / "there.txt").write_text("the old one")
+
+    link.client.rename(_at(link, "here.txt"), _at(link, "there.txt"))
+
+    assert (link.target / "there.txt").read_text() == "the new one"
+
+
+# ------------------------------------------------------ what is written about one
+
+
+def test_the_bits_a_path_is_kept_at_are_the_ones_it_was_set_to(link: Link) -> None:
+    (link.target / "key").write_text("a secret")
+
+    link.client.chmod(_at(link, "key"), 0o600)
+
+    assert stat.S_IMODE((link.target / "key").stat().st_mode) == 0o600
+
+
+def test_only_the_permission_bits_are_set(link: Link) -> None:
+    """`S_IMODE` of what was asked for: a file must not be made a device by a chmod."""
+    (link.target / "key").write_text("a secret")
+
+    link.client.chmod(_at(link, "key"), stat.S_IFREG | 0o640)
+
+    said = (link.target / "key").stat().st_mode
+    assert stat.S_IMODE(said) == 0o640
+    assert stat.S_ISREG(said)
+
+
+def test_the_times_a_path_carries_are_the_ones_it_was_given(link: Link) -> None:
+    (link.target / "dated.txt").write_text("when")
+    when = 1_600_000_000_000_000_000
+
+    link.client.utime(_at(link, "dated.txt"), when, when)
+
+    said = (link.target / "dated.txt").stat()
+    assert said.st_mtime_ns == when
+    assert said.st_atime_ns == when
+
+
+def test_a_time_that_was_not_given_is_the_one_the_path_already_had(link: Link) -> None:
+    """`None` for one of the two is `UTIME_OMIT`, which is what `utimensat` takes."""
+    (link.target / "dated.txt").write_text("when")
+    when = 1_600_000_000_000_000_000
+    link.client.utime(_at(link, "dated.txt"), when, when)
+    later = 1_700_000_000_000_000_000
+
+    link.client.utime(_at(link, "dated.txt"), None, later)
+
+    said = (link.target / "dated.txt").stat()
+    assert said.st_mtime_ns == later
+    assert said.st_atime_ns == when
+
+
+# ----------------------------------------------------------------- cutting one down
+
+
+def test_a_file_cut_down_is_that_long(link: Link) -> None:
+    (link.target / "long.txt").write_text("far more than four")
+
+    link.client.call(Op.TRUNCATE, path=_at(link, "long.txt"), size=4)
+
+    assert (link.target / "long.txt").read_bytes() == b"far "
+
+
+def test_a_file_extended_out_is_that_long_and_the_rest_is_nothing(link: Link) -> None:
+    (link.target / "short.txt").write_bytes(b"ab")
+
+    link.client.call(Op.TRUNCATE, path=_at(link, "short.txt"), size=6)
+
+    assert (link.target / "short.txt").read_bytes() == b"ab\0\0\0\0"
+
+
+# -------------------------------------------------------------- what it reads back
+
+
+def test_what_a_link_names_is_what_it_names_rather_than_where_it_leads(
+    link: Link,
+) -> None:
+    """Not resolved on the way out: a session asked what the link says, not what is there."""
+    link.client.symlink("../outside/the/export", _at(link, "pointing"))
+
+    said = link.client.call(Op.READLINK, path=_at(link, "pointing"))
+
+    assert said["target"] == "../outside/the/export"
+    assert (link.target / "pointing").readlink() == Path("../outside/the/export")
+
+
+def test_something_that_is_not_a_link_is_the_target_s_own_errno(link: Link) -> None:
+    (link.target / "plain.txt").write_text("not a link")
+
+    with pytest.raises(RemoteOSError) as raised:
+        link.client.call(Op.READLINK, path=_at(link, "plain.txt"))
+
+    assert raised.value.errno == errno.EINVAL

--- a/tests/coganchor/test_linux_buffers.py
+++ b/tests/coganchor/test_linux_buffers.py
@@ -14,8 +14,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.supervising import WITHOUT_BINDINGS, traced
+
+if (
+    WITHOUT_BINDINGS
+):  # what is imported below is the binding itself, so it is asked first
+    pytest.skip(WITHOUT_BINDINGS, allow_module_level=True)
+
 from hmz.coganchor.linux import procfs, ptrace
-from tests.providers.test_redirect import traced
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/tests/coganchor/test_listener.py
+++ b/tests/coganchor/test_listener.py
@@ -32,6 +32,23 @@ if TYPE_CHECKING:
 TOKEN = "not-a-real-shared-secret"
 
 
+def _has_ipv6() -> bool:
+    """Whether this machine has an IPv6 loopback to listen on at all."""
+    if not socket.has_ipv6:
+        return False
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as one:
+            one.bind(("::1", 0))
+    except OSError:
+        return False
+    return True
+
+
+#: A machine with IPv6 switched off is one this cannot be asked of, rather than one it fails
+#: on -- and CI runners are configured by whoever runs them.
+ipv6 = pytest.mark.skipif(not _has_ipv6(), reason="there is no IPv6 loopback here")
+
+
 def _caught(monkeypatch: pytest.MonkeyPatch) -> list[listener._ThreadedServer]:
     """Catches the server on its way past, so a test has something to stop.
 
@@ -245,6 +262,7 @@ def test_a_listener_on_its_way_out_does_not_leave_commands_running_on_the_target
     client.close()
 
 
+@ipv6
 @pytest.mark.timeout(60)
 def test_an_address_with_a_colon_in_it_is_listened_on_as_ipv6(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/coganchor/test_listener.py
+++ b/tests/coganchor/test_listener.py
@@ -1,0 +1,273 @@
+"""A target left listening on a port, serving every session that reaches it.
+
+The other way in is a pipe carrying one session, which `test_serve.py` drives: the far end has
+already been started for that session alone, and the server is the whole of it. This is the
+other one -- the address is bound here, the port it landed on is announced here, a session per
+connection is served at once here, and the shared secret is checked here.
+
+All of it is the serving half, which runs on the target and is portable on purpose: no seccomp
+filter, no ptrace supervisor, and nothing that asks what architecture this is. The address is
+`127.0.0.1` and the port is whichever one the kernel hands out.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from hmz.coganchor.proto import Channel
+from hmz.coganchor.remote import RemoteClient
+from hmz.coganchor.serve import listener
+from hmz.coganchor.serve.exports import ExportTable
+from tests.coganchor.conftest import VIRTUAL_EXPORT
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+#: The secret a client has to present where the listener was given one.
+TOKEN = "not-a-real-shared-secret"
+
+
+def _caught(monkeypatch: pytest.MonkeyPatch) -> list[listener._ThreadedServer]:
+    """Catches the server on its way past, so a test has something to stop.
+
+    `serve_forever` runs until it is interrupted, and a thread is not somewhere a
+    `KeyboardInterrupt` can be put -- so what a test stops it by is the server object, which
+    the function builds for itself and does not hand back.
+
+    Args:
+      monkeypatch: The test's own, so the listener is itself again however the test ends.
+
+    Returns:
+      The servers built from now on, in the order they were built.
+    """
+    made: list[listener._ThreadedServer] = []
+    watched = listener._ThreadedServer
+
+    class Caught(watched):
+        def __init__(self, *args: Any, **rest: Any) -> None:
+            super().__init__(*args, **rest)
+            made.append(self)
+
+    monkeypatch.setattr(listener, "_ThreadedServer", Caught)
+    return made
+
+
+class _Listening:
+    """A listener running on a port of its own, and the handles a test needs of it."""
+
+    def __init__(
+        self,
+        port: int,
+        target: Path,
+        shutdown: Callable[[], None],
+        thread: threading.Thread,
+    ) -> None:
+        self.port = port
+        self.target = target
+        self._shutdown = shutdown
+        self._thread = thread
+
+    def stop(self) -> None:
+        """Takes the listener down and waits for it to have finished going.
+
+        `shutdown` only ends the accept loop; closing the sessions still open happens after
+        it returns, inside `serve_forever` -- so a test that asked for one and looked at the
+        next moment would be looking during the teardown rather than after it.
+        """
+        self._shutdown()
+        self._thread.join(timeout=10)
+        assert not self._thread.is_alive(), "the listener did not finish going"
+
+    def client(self, token: str | None = None) -> RemoteClient:
+        """One session, connected and handshaken, which the caller closes."""
+        held = socket.create_connection(("127.0.0.1", self.port), timeout=10)
+        client = RemoteClient(Channel.from_socket(held))
+        client.start(token)
+        return client
+
+
+@pytest.fixture
+def serving(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Callable[[str | None], _Listening]]:
+    """Starts a listener with or without a secret, and takes it down however the test ends.
+
+    The server object is caught on its way past so the test can stop it: `serve_forever` runs
+    until it is interrupted, and a thread is not somewhere a `KeyboardInterrupt` can be put.
+    """
+    target = tmp_path / "target"
+    target.mkdir()
+    threads: list[threading.Thread] = []
+    made = _caught(monkeypatch)
+
+    def start(token: str | None = None) -> _Listening:
+        table = ExportTable.parse([f"{VIRTUAL_EXPORT}:{target}"])
+        thread = threading.Thread(
+            target=listener.serve_forever,
+            args=("127.0.0.1", 0, table, token),
+            daemon=True,
+        )
+        thread.start()
+        threads.append(thread)
+        for _ in range(500):
+            if made:
+                break
+            thread.join(timeout=0.02)
+        assert made, "the listener never bound an address"
+        return _Listening(made[-1].server_address[1], target, made[-1].shutdown, thread)
+
+    try:
+        yield start
+    finally:
+        for one in made:
+            one.shutdown()
+        for thread in threads:
+            thread.join(timeout=10)
+
+
+@pytest.mark.timeout(60)
+def test_the_port_it_landed_on_is_announced_to_whoever_started_it(
+    serving: Callable[[str | None], _Listening], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Not a message but a handshake: a port of 0 is how a script asks for any free one."""
+    held = serving(None)
+
+    said = capsys.readouterr().err
+
+    assert f"hmz anchor serve listening 127.0.0.1 {held.port}" in said
+    assert held.port != 0
+
+
+@pytest.mark.timeout(60)
+def test_a_session_that_connects_is_served_off_the_target_s_own_directory(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    held = serving(None)
+    (held.target / "shipped.txt").write_text("arrived over a port\n")
+
+    client = held.client()
+    try:
+        listed = client.listdir(VIRTUAL_EXPORT)
+    finally:
+        client.close()
+
+    assert "shipped.txt" in [one["name"] for one in listed["entries"]]
+
+
+@pytest.mark.timeout(60)
+def test_more_than_one_session_at_once_is_what_a_port_is_for(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    """A pipe carries one session; this is the way in that carries several."""
+    held = serving(None)
+    (held.target / "shipped.txt").write_text("arrived over a port\n")
+
+    first, second = held.client(), held.client()
+    try:
+        # Both open at once, and each one still answers.
+        assert first.listdir(VIRTUAL_EXPORT)["entries"]
+        assert second.listdir(VIRTUAL_EXPORT)["entries"]
+        second.mkdir(f"{VIRTUAL_EXPORT}/made-by-the-second")
+        assert "made-by-the-second" in [
+            one["name"] for one in first.listdir(VIRTUAL_EXPORT)["entries"]
+        ]
+    finally:
+        first.close()
+        second.close()
+
+
+@pytest.mark.timeout(60)
+def test_a_session_presenting_the_secret_is_served(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    held = serving(TOKEN)
+    (held.target / "shipped.txt").write_text("arrived over a port\n")
+
+    client = held.client(TOKEN)
+    try:
+        assert client.listdir(VIRTUAL_EXPORT)["entries"]
+    finally:
+        client.close()
+
+
+@pytest.mark.timeout(60)
+def test_a_session_presenting_the_wrong_secret_is_refused(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    """An `hmz anchor` port is equivalent to a shell on that machine, so this is the door."""
+    held = serving(TOKEN)
+
+    with pytest.raises(OSError, match="token"):
+        held.client("not-the-secret")
+
+
+@pytest.mark.timeout(60)
+def test_a_session_presenting_no_secret_at_all_is_refused(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    held = serving(TOKEN)
+
+    with pytest.raises(OSError, match="token"):
+        held.client(None)
+
+
+@pytest.mark.timeout(60)
+def test_a_listener_on_its_way_out_does_not_leave_commands_running_on_the_target(
+    serving: Callable[[str | None], _Listening],
+) -> None:
+    """Handler threads are daemons and do not get to finish on their own.
+
+    What the listener takes with it is what each connection owns -- the commands it started
+    on the target -- rather than the connection itself: a target being shut down must not
+    leave a `sleep` of somebody's behind it.
+    """
+    held = serving(None)
+    client = held.client()
+    ended = threading.Event()
+    client.start_exec(
+        ["sleep", "60"],
+        cwd=VIRTUAL_EXPORT,
+        env={},
+        on_output=lambda stream, data: None,
+        on_exit=lambda result, error: ended.set(),
+    )
+    # Started rather than merely asked for: what is being checked is a command torn down.
+    assert not ended.wait(timeout=1)
+
+    held.stop()
+
+    assert ended.wait(timeout=15)
+    client.close()
+
+
+@pytest.mark.timeout(60)
+def test_an_address_with_a_colon_in_it_is_listened_on_as_ipv6(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which is how the one function serves both families without being told which."""
+    target = tmp_path / "target"
+    target.mkdir()
+    made = _caught(monkeypatch)
+    table = ExportTable.parse([f"{VIRTUAL_EXPORT}:{target}"])
+    thread = threading.Thread(
+        target=listener.serve_forever, args=("::1", 0, table, None), daemon=True
+    )
+    thread.start()
+    try:
+        for _ in range(500):
+            if made:
+                break
+            thread.join(timeout=0.02)
+        assert made, "the listener never bound an address"
+
+        assert made[-1].address_family == socket.AF_INET6
+        assert made[-1].socket.family == socket.AF_INET6
+    finally:
+        for one in made:
+            one.shutdown()
+        thread.join(timeout=10)

--- a/tests/coganchor/test_redirect.py
+++ b/tests/coganchor/test_redirect.py
@@ -15,6 +15,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.supervising import WITHOUT_BINDINGS
+
+if (
+    WITHOUT_BINDINGS
+):  # what is imported below is the binding itself, so it is asked first
+    pytest.skip(WITHOUT_BINDINGS, allow_module_level=True)
+
 from hmz import cli
 from hmz.coganchor import AnchorConfig
 from hmz.coganchor.argv import parser, settings

--- a/tests/coganchor/test_serve.py
+++ b/tests/coganchor/test_serve.py
@@ -4,14 +4,27 @@ from __future__ import annotations
 
 import errno
 import os
-from typing import TYPE_CHECKING
+import signal
+import socket
+import threading
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from hmz.coganchor.proto import Frame, Kind, Op, RemoteOSError
+from hmz.coganchor.proto import (
+    PROTOCOL_VERSION,
+    Channel,
+    Frame,
+    Kind,
+    Op,
+    RemoteOSError,
+)
+from hmz.coganchor.remote import RemoteClient
 from hmz.coganchor.serve import fsops
 from hmz.coganchor.serve.exports import Export, ExportTable
+from hmz.coganchor.serve.server import Server
 from hmz.coganchor.serve.sessions import compose_env
+from tests.coganchor.conftest import VIRTUAL_EXPORT
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -233,3 +246,75 @@ def test_unknown_operation_reports_enosys_without_dropping_the_link(link: Link) 
 
     still_working = link.client.call(Op.STAT, path="/project")
     assert still_working["kind"] == "dir", "the connection must still work"
+
+
+def test_a_request_missing_what_it_needs_is_a_bad_request_rather_than_a_dead_link(
+    link: Link,
+) -> None:
+    """A peer that sent nonsense gets an error; the session it sent it on goes on."""
+    with pytest.raises(RemoteOSError) as raised:
+        link.client.call(Op.STAT)
+
+    assert raised.value.errno == errno.EINVAL
+    assert link.client.call(Op.STAT, path=VIRTUAL_EXPORT)["kind"] == "dir"
+
+
+@pytest.mark.timeout(60)
+def test_a_signal_reaches_the_command_it_names(link: Link) -> None:
+    """A turn stopped here is a process stopped there, or the target keeps running it."""
+    ended = threading.Event()
+    done: list[dict[str, Any]] = []
+
+    def over(result: dict[str, Any] | None, _error: object) -> None:
+        done.append(result or {})
+        ended.set()
+
+    running = link.client.start_exec(
+        ["sleep", "60"],
+        cwd=VIRTUAL_EXPORT,
+        env={},
+        on_output=lambda stream, data: None,
+        on_exit=over,
+    )
+    assert not ended.wait(timeout=1)
+
+    running.signal(signal.SIGTERM)
+
+    assert ended.wait(timeout=30)
+    assert done
+
+
+@pytest.mark.timeout(60)
+def test_a_signal_naming_nothing_is_answered_rather_than_ignored(link: Link) -> None:
+    """The client waits on the reply, so a target that said nothing would hang it."""
+    assert link.client.call(Op.SIGNAL, target=999_999, sig=signal.SIGTERM) is not None
+
+
+@pytest.mark.timeout(60)
+def test_a_client_speaking_another_protocol_is_refused_and_the_link_goes_with_it() -> (
+    None
+):
+    """Both ends check, because either may be the older build.
+
+    And the connection goes with the refusal: an untokened session starts out
+    authenticated, so failing the handshake alone would leave every request after it
+    working.
+    """
+    left, right = socket.socketpair()
+    table = ExportTable.parse([f"{VIRTUAL_EXPORT}:/"])
+    server = Server(Channel.from_socket(right), table)
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+    client = RemoteClient(Channel.from_socket(left))
+    client._reader.start()
+    try:
+        with pytest.raises(RemoteOSError) as raised:
+            client.call(Op.HELLO, version=PROTOCOL_VERSION + 1000, token=None)
+
+        assert raised.value.errno == errno.EPROTO
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "the connection must go with the refusal"
+    finally:
+        client.close()
+        left.close()
+        right.close()

--- a/tests/coganchor/test_shadow.py
+++ b/tests/coganchor/test_shadow.py
@@ -191,3 +191,107 @@ def test_prepare_can_be_forced(tmp_path: Path) -> None:
     root.mkdir()
     (root / "stuff.txt").write_text("x")
     prepare_shadow_root(str(root), force=True)
+
+
+def _linked(fixture: Fixture) -> tuple[str, str]:
+    """One placeholder, and a second name for it made on both sides as a hard link is.
+
+    Returns:
+      The two local paths, the first mirrored and the second only just made.
+    """
+    (fixture.target / "one.txt").write_text("real content here")
+    fixture.shadow.ensure_directory(str(fixture.mirror))
+    # The tracee's `link` lands on both: here, and replayed on the target.
+    (fixture.target / "two.txt").hardlink_to(fixture.target / "one.txt")
+    first, second = str(fixture.local("one.txt")), str(fixture.local("two.txt"))
+    Path(second).hardlink_to(first)
+    return first, second
+
+
+def test_a_second_name_for_a_placeholder_reads_the_file_rather_than_its_zeroes(
+    fixture: Fixture,
+) -> None:
+    first, second = _linked(fixture)
+
+    fixture.shadow.duplicate(first, second)
+
+    fixture.shadow.ensure_content(second)
+    assert fixture.local("two.txt").read_text() == "real content here"
+
+
+def test_a_second_name_nobody_recorded_is_the_zeroes_it_holds(fixture: Fixture) -> None:
+    """Which is what `duplicate` is for: a placeholder reached by a name with no record."""
+    _first, second = _linked(fixture)
+
+    fixture.shadow.ensure_content(second)
+
+    assert fixture.local("two.txt").read_bytes() == b"\x00" * len("real content here")
+
+
+def test_a_second_name_for_something_nobody_recorded_records_nothing(
+    fixture: Fixture,
+) -> None:
+    """A hard link between two files the mirror never made is not the mirror's to know."""
+    fixture.shadow.duplicate(
+        str(fixture.local("never-mirrored")), str(fixture.local("nor-this"))
+    )
+
+    assert str(fixture.local("nor-this")) not in fixture.shadow._files
+
+
+def test_what_was_taken_away_is_forgotten_whole(fixture: Fixture) -> None:
+    """A directory dropped takes what was under it, or the next run reads a stale record."""
+    (fixture.target / "box").mkdir()
+    (fixture.target / "box" / "inside.txt").write_text("under it")
+    fixture.shadow.ensure_directory(str(fixture.mirror))
+    fixture.shadow.ensure_directory(str(fixture.local("box")))
+    assert any("inside.txt" in one for one in fixture.shadow._files)
+
+    fixture.shadow.forget(str(fixture.local("box")))
+
+    assert not any("inside.txt" in one for one in fixture.shadow._files)
+    assert not any("box" in one for one in fixture.shadow._dirs)
+
+
+def test_a_write_outside_the_mirror_is_not_the_mirror_s_to_push(
+    fixture: Fixture, tmp_path: Path
+) -> None:
+    """The tracee writes to its own machine as well, and none of that goes to the target."""
+    elsewhere = tmp_path / "elsewhere.txt"
+    elsewhere.write_text("this machine's own")
+
+    fixture.shadow.note_write(str(elsewhere))
+
+    assert fixture.shadow.flush() == 0
+
+
+def test_a_file_that_went_away_before_the_push_is_not_pushed(fixture: Fixture) -> None:
+    """The unlink was replayed already, so there is nothing left here to send."""
+    (fixture.target / "gone.txt").write_text("here for now")
+    fixture.shadow.ensure_directory(str(fixture.mirror))
+    fixture.local("gone.txt").write_text("edited")
+    fixture.shadow.note_write(str(fixture.local("gone.txt")))
+    fixture.local("gone.txt").unlink()
+
+    assert fixture.shadow.flush() == 0
+
+
+def test_something_that_is_not_a_file_is_not_pushed(fixture: Fixture) -> None:
+    """A directory the tracee made is replayed as a mkdir rather than sent as bytes."""
+    made = fixture.local("made")
+    made.mkdir(parents=True)
+
+    fixture.shadow.note_write(str(made))
+
+    assert fixture.shadow.flush() == 0
+
+
+def test_content_is_fetched_through_the_link_that_names_it(fixture: Fixture) -> None:
+    """A tracee opens a symlink and expects the file, so the mirror follows it first."""
+    (fixture.target / "real.txt").write_text("what the link leads to")
+    (fixture.target / "alias").symlink_to("real.txt")
+    fixture.shadow.ensure_directory(str(fixture.mirror))
+
+    fixture.shadow.ensure_content(str(fixture.local("alias")))
+
+    assert fixture.local("real.txt").read_text() == "what the link leads to"

--- a/tests/coganchor/test_smoke.py
+++ b/tests/coganchor/test_smoke.py
@@ -7,8 +7,15 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from hmz.coganchor import standin
 from tests.coganchor.tasks import SMOKE_TASKS, SmokeTask
+from tests.supervising import WITHOUT_BINDINGS
+
+if (
+    WITHOUT_BINDINGS
+):  # what is imported below is the binding itself, so it is asked first
+    pytest.skip(WITHOUT_BINDINGS, allow_module_level=True)
+
+from hmz.coganchor import standin
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/coganchor/test_transport.py
+++ b/tests/coganchor/test_transport.py
@@ -108,6 +108,23 @@ def test_bundle_reports_failure_in_its_exit_status(tmp_path: Path) -> None:
     assert "malformed listen address" in result.stderr
 
 
+def _bare() -> dict[str, str]:
+    """The environment the anchored run below gets, which is the one the probe must use.
+
+    Deliberately small -- a `PATH`, the source tree, and a home to read an ssh config out of
+    -- so that what reaches the far side is what humanize puts there rather than whatever the
+    suite happened to be started with. `SSH_AUTH_SOCK` is the one that matters: an agent
+    forwarded into the terminal running the tests would let a probe in and leave the run
+    itself outside, which is a skip that never happens in front of a failure that always
+    does.
+    """
+    return {
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        "HOME": str(Path.home()),
+    }
+
+
 def _ssh_to_localhost_works() -> bool:
     try:
         probe = subprocess.run(
@@ -122,6 +139,7 @@ def _ssh_to_localhost_works() -> bool:
             ],
             capture_output=True,
             timeout=20,
+            env=_bare(),
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -162,11 +180,7 @@ def test_ssh_transport_bootstraps_and_runs(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
-        env={
-            "PATH": "/usr/bin:/bin",
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-            "HOME": str(Path.home()),
-        },
+        env=_bare(),
         timeout=150,
         check=False,
     )

--- a/tests/daemon/test_attaching.py
+++ b/tests/daemon/test_attaching.py
@@ -216,18 +216,30 @@ def test_a_terminal_that_has_not_been_told_its_own_size_is_the_ordinary_one_too(
 def test_a_terminal_is_put_into_raw_and_put_back_again(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Raw is what every multiplexer does: the run does its own echoing and line editing."""
+    """Raw is what every multiplexer does: the run does its own echoing and line editing.
+
+    Asked of those two modes rather than of the whole of `tcgetattr`, which also carries
+    state nobody set: `PENDIN` says the kernel has input to retype and comes and goes on its
+    own, so a terminal put back exactly still does not compare equal to what it was.
+    """
     controller, follower = pty.openpty()
     try:
         monkeypatch.setattr(attach, "_IN", follower)
         monkeypatch.setattr(attach, "_OUT", follower)
-        before = termios.tcgetattr(follower)
+        before = termios.tcgetattr(follower)[3]
+        assert before & termios.ECHO
+        assert before & termios.ICANON
 
         with attach._raw():
-            inside = termios.tcgetattr(follower)
+            inside = termios.tcgetattr(follower)[3]
 
-        assert inside != before, "the terminal was never put into raw mode"
-        assert termios.tcgetattr(follower) == before
+        assert not inside & termios.ECHO, "the terminal was never put into raw mode"
+        assert not inside & termios.ICANON
+        after = termios.tcgetattr(follower)[3]
+        assert after & termios.ECHO, (
+            "the terminal was left doing none of its own echoing"
+        )
+        assert after & termios.ICANON
     finally:
         os.close(follower)
         os.close(controller)

--- a/tests/daemon/test_attaching.py
+++ b/tests/daemon/test_attaching.py
@@ -1,0 +1,516 @@
+"""The pieces a terminal reads a held run with, each on its own.
+
+The whole of `reads` is `test_opening.py`'s and `terminals.py`'s: it puts the terminal it is
+called on into raw mode and sits on it until the run lets go, which is a thing to do in a
+process built for it rather than to the one running the suite. What is here is everything
+underneath that -- what is read off the socket, what is put on the terminal, how big the
+terminal says it is, and what each of those does when the thing at the other end has gone.
+
+Every descriptor below is a pipe or a pseudoterminal of the test's own. Nothing touches the
+terminal the suite was started from.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+import os
+import pty
+import signal
+import socket
+import struct
+import termios
+import threading
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from hmz.daemon import attach
+from hmz.daemon.proto import GONE, HELLO, INPUT, OUTPUT, RESIZE, Frames, frame
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+
+@pytest.fixture
+def pipe() -> Iterator[tuple[int, int]]:
+    """A pipe, closed however the test ends, standing in for a terminal."""
+    reading, writing = os.pipe()
+    try:
+        yield reading, writing
+    finally:
+        for one in (reading, writing):
+            with contextlib.suppress(OSError):
+                os.close(one)
+
+
+@pytest.fixture
+def paired() -> Iterator[tuple[socket.socket, socket.socket]]:
+    """Two ends of a socket, as a run reached through one and the terminal at the other."""
+    here, there = socket.socketpair()
+    try:
+        yield here, there
+    finally:
+        here.close()
+        there.close()
+
+
+# ------------------------------------------------------ what comes off the socket
+
+
+def test_what_the_run_drew_is_what_is_read_off_the_socket(
+    paired: tuple[socket.socket, socket.socket],
+) -> None:
+    here, there = paired
+    there.sendall(b"a screen")
+
+    assert attach._taken(here) == b"a screen"
+
+
+def test_a_run_that_has_gone_reads_as_nothing_at_all(
+    paired: tuple[socket.socket, socket.socket],
+) -> None:
+    """Nothing at all and None are different answers: one is over, the other is not yet."""
+    here, there = paired
+    there.shutdown(socket.SHUT_WR)
+
+    assert attach._taken(here) == b""
+
+
+def test_a_read_with_nothing_behind_it_yet_is_neither_over_nor_anything(
+    paired: tuple[socket.socket, socket.socket],
+) -> None:
+    here, _ = paired
+    here.setblocking(False)
+
+    assert attach._taken(here) is None
+
+
+def test_a_socket_that_is_not_one_any_more_reads_as_a_run_that_has_gone() -> None:
+    here, there = socket.socketpair()
+    there.close()
+    here.close()
+
+    assert attach._taken(here) == b""
+
+
+# ------------------------------------------------------- what comes off the terminal
+
+
+def test_what_was_typed_is_what_is_read_from_the_terminal(
+    pipe: tuple[int, int],
+) -> None:
+    reading, writing = pipe
+    os.write(writing, b"typed")
+
+    assert attach._taken_from(reading) == b"typed"
+
+
+def test_a_terminal_that_has_gone_reads_as_nothing_at_all() -> None:
+    reading, writing = os.pipe()
+    os.close(reading)
+    os.close(writing)
+
+    assert attach._taken_from(reading) == b""
+
+
+# --------------------------------------------------------- what goes to the terminal
+
+
+def test_what_the_run_drew_is_put_on_the_terminal_whole(
+    pipe: tuple[int, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reading, writing = pipe
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    attach._draws(b"a screen")
+
+    assert os.read(reading, 64) == b"a screen"
+
+
+def test_a_terminal_that_has_gone_is_not_something_to_crash_over(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whoever was reading has closed their laptop; the run itself is still running."""
+    reading, writing = os.pipe()
+    os.close(reading)
+    os.close(writing)
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    attach._draws(b"a screen")  # the absence of a raised error is the whole assertion
+
+
+def test_why_the_reading_ended_is_said_on_a_line_a_raw_terminal_can_read(
+    pipe: tuple[int, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A carriage return as well as a newline: the terminal has only just stopped being raw."""
+    reading, writing = pipe
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    attach._says("the run is over")
+
+    assert os.read(reading, 64) == b"the run is over\r\n"
+
+
+def test_saying_why_to_a_terminal_that_has_gone_is_not_something_to_crash_over(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reading, writing = os.pipe()
+    os.close(reading)
+    os.close(writing)
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    attach._says("the run is over")
+
+
+# ------------------------------------------------------------- how big it is
+
+
+def test_the_size_is_the_terminal_s_own(monkeypatch: pytest.MonkeyPatch) -> None:
+    controller, follower = pty.openpty()
+    try:
+        termios.tcgetattr(follower)
+        attach.os.set_blocking(follower, True)
+        from hmz.daemon.serve import sized
+
+        sized(controller, 101, 37)
+        monkeypatch.setattr(attach, "_OUT", follower)
+
+        assert attach.size() == (101, 37)
+    finally:
+        os.close(follower)
+        os.close(controller)
+
+
+def test_something_that_is_not_a_terminal_is_the_ordinary_eighty_by_twenty_four(
+    pipe: tuple[int, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pipe has no size, and a full-screen program still has to draw something."""
+    _, writing = pipe
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    assert attach.size() == (attach._WIDE, attach._TALL)
+
+
+def test_a_terminal_that_has_not_been_told_its_own_size_is_the_ordinary_one_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero columns is not a terminal one column wide: it is one that has not said."""
+    controller, follower = pty.openpty()
+    try:
+        from hmz.daemon.serve import sized
+
+        sized(controller, 0, 0)
+        monkeypatch.setattr(attach, "_OUT", follower)
+
+        assert attach.size() == (attach._WIDE, attach._TALL)
+    finally:
+        os.close(follower)
+        os.close(controller)
+
+
+# ---------------------------------------------------------- the mode it is put into
+
+
+def test_a_terminal_is_put_into_raw_and_put_back_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw is what every multiplexer does: the run does its own echoing and line editing."""
+    controller, follower = pty.openpty()
+    try:
+        monkeypatch.setattr(attach, "_IN", follower)
+        monkeypatch.setattr(attach, "_OUT", follower)
+        before = termios.tcgetattr(follower)
+
+        with attach._raw():
+            inside = termios.tcgetattr(follower)
+
+        assert inside != before, "the terminal was never put into raw mode"
+        assert termios.tcgetattr(follower) == before
+    finally:
+        os.close(follower)
+        os.close(controller)
+
+
+def test_something_that_is_not_a_terminal_is_left_alone_rather_than_refused(
+    pipe: tuple[int, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run read by something other than a terminal is still a run being read."""
+    reading, writing = pipe
+    monkeypatch.setattr(attach, "_IN", writing)
+    monkeypatch.setattr(attach, "_OUT", writing)
+
+    with attach._raw():
+        pass
+
+    # And what is put back is the escape that leaves the alternate screen, whether or not
+    # there was a mode to restore: the run drew there either way.
+    assert os.read(reading, len(attach._BACK)) == attach._BACK
+
+
+# ----------------------------------------------------------------- reaching one
+
+
+def test_a_daemon_directory_nothing_is_listening_in_cannot_be_reached(
+    tmp_path: object,
+) -> None:
+    with pytest.raises(OSError, match="No such file or directory"):
+        attach.attaches(str(tmp_path))
+
+
+def test_the_socket_a_run_is_reached_through_is_the_one_in_its_own_directory(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pathlib import Path
+
+    from hmz.daemon import where
+
+    at = Path(str(tmp_path))
+    monkeypatch.chdir(at)
+    listening = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listening.bind(where.SOCKET)
+    listening.listen(1)
+    try:
+        reached = attach.attaches(at)
+        try:
+            held, _ = listening.accept()
+            held.sendall(b"hello")
+            assert reached.recv(16) == b"hello"
+            held.close()
+        finally:
+            reached.close()
+    finally:
+        listening.close()
+
+
+@pytest.mark.parametrize("why", [errno.EINTR, errno.EAGAIN, errno.EWOULDBLOCK])
+def test_a_read_that_did_not_happen_is_not_a_run_that_has_gone(why: int) -> None:
+    """`EINTR` is a signal arriving mid-read, which is every window resize there is."""
+
+    class Interrupted:
+        def recv(self, _size: int) -> bytes:
+            raise OSError(why, os.strerror(why))
+
+    assert attach._taken(cast("socket.socket", Interrupted())) is None
+
+
+def test_a_read_that_failed_for_any_other_reason_is_a_run_that_has_gone() -> None:
+    class Broken:
+        def recv(self, _size: int) -> bytes:
+            raise OSError(errno.ECONNRESET, "Connection reset by peer")
+
+    assert attach._taken(cast("socket.socket", Broken())) == b""
+
+
+# ------------------------------------------- carrying the keys one way and the screen the other
+
+
+def _peer(
+    there: socket.socket, answering: Callable[[Frames, bytes, bytes], bool]
+) -> threading.Thread:
+    """The run at the other end, reading frames and answering until it says to stop.
+
+    Args:
+      there: The run's end of the socket.
+      answering: Called with the reader and each frame; True when it has said its last.
+
+    Returns:
+      The thread it is running on, already started.
+    """
+
+    def run() -> None:
+        frames = Frames()
+        while read := there.recv(1 << 16):
+            if any(
+                answering(frames, kind, payload) for kind, payload in frames.feed(read)
+            ):
+                break
+        there.close()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.mark.timeout(30)
+def test_a_run_that_has_gone_ends_the_reading_without_saying_why(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    here, there = paired
+    reading, _ = pipe
+    monkeypatch.setattr(attach, "_IN", reading)
+    there.close()
+
+    assert attach._pumps(here) == ""
+
+
+@pytest.mark.timeout(30)
+def test_a_run_that_lets_go_says_why_and_that_is_what_comes_back(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Which is the one thing somebody is looking at when a terminal is let go of."""
+    here, there = paired
+    reading, _ = pipe
+    monkeypatch.setattr(attach, "_IN", reading)
+    there.sendall(frame(GONE, b"the run is over"))
+
+    assert attach._pumps(here) == "the run is over"
+
+
+@pytest.mark.timeout(30)
+def test_what_the_run_draws_is_put_on_this_terminal(
+    paired: tuple[socket.socket, socket.socket],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    here, there = paired
+    typing, _ = os.pipe()
+    drawn_r, drawn_w = os.pipe()
+    try:
+        monkeypatch.setattr(attach, "_IN", typing)
+        monkeypatch.setattr(attach, "_OUT", drawn_w)
+        there.sendall(frame(OUTPUT, b"a screen") + frame(GONE, b"over"))
+
+        assert attach._pumps(here) == "over"
+        assert os.read(drawn_r, 64) == b"a screen"
+    finally:
+        for one in (typing, drawn_r, drawn_w):
+            with contextlib.suppress(OSError):
+                os.close(one)
+
+
+@pytest.mark.timeout(30)
+def test_what_is_typed_here_reaches_the_run(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    here, there = paired
+    reading, writing = pipe
+    monkeypatch.setattr(attach, "_IN", reading)
+    heard: list[bytes] = []
+
+    def answering(_frames: Frames, kind: bytes, payload: bytes) -> bool:
+        if kind == INPUT:
+            heard.append(payload)
+            there.sendall(frame(GONE, b"over"))
+            return True
+        return False
+
+    thread = _peer(there, answering)
+    os.write(writing, b"typed")
+
+    assert attach._pumps(here) == "over"
+
+    thread.join(timeout=10)
+    assert heard == [b"typed"]
+
+
+@pytest.mark.timeout(30)
+def test_a_terminal_that_goes_ends_the_reading(
+    paired: tuple[socket.socket, socket.socket],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whoever was reading has gone; the run itself is somebody else's to end."""
+    here, _there = paired
+    reading, writing = os.pipe()
+    os.close(writing)
+    try:
+        monkeypatch.setattr(attach, "_IN", reading)
+
+        assert attach._pumps(here) == ""
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(reading)
+
+
+@pytest.mark.timeout(30)
+def test_reading_a_run_says_hello_with_the_size_of_this_terminal(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The run draws for the terminal reading it, so it is told how big that is first."""
+    here, there = paired
+    reading, _ = pipe
+    drawn_r, drawn_w = os.pipe()
+    try:
+        monkeypatch.setattr(attach, "_IN", reading)
+        monkeypatch.setattr(attach, "_OUT", drawn_w)
+        said: list[tuple[bytes, bytes]] = []
+
+        def answering(_frames: Frames, kind: bytes, payload: bytes) -> bool:
+            said.append((kind, payload))
+            there.sendall(frame(GONE, b"over"))
+            return True
+
+        thread = _peer(there, answering)
+
+        assert attach.reads(here) == 0
+
+        thread.join(timeout=10)
+        assert said[0][0] == HELLO
+        assert json.loads(said[0][1])["columns"] == attach._WIDE
+    finally:
+        for one in (drawn_r, drawn_w):
+            with contextlib.suppress(OSError):
+                os.close(one)
+
+
+def test_a_run_there_was_nothing_to_say_hello_to_is_one_status_of_our_own() -> None:
+    here, there = socket.socketpair()
+    here.close()
+    there.close()
+
+    assert attach.reads(here) == 1
+
+
+@pytest.mark.timeout(30)
+def test_a_terminal_that_changes_size_tells_the_run_the_new_one(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The run draws for the terminal reading it, so a window dragged wider is news."""
+    here, there = paired
+    reading, _ = pipe
+    monkeypatch.setattr(attach, "_IN", reading)
+    said: list[tuple[bytes, bytes]] = []
+
+    def answering(_frames: Frames, kind: bytes, payload: bytes) -> bool:
+        said.append((kind, payload))
+        there.sendall(frame(GONE, b"over"))
+        return True
+
+    thread = _peer(there, answering)
+    threading.Timer(0.1, os.kill, [os.getpid(), signal.SIGWINCH]).start()
+
+    assert attach._pumps(here) == "over"
+
+    thread.join(timeout=10)
+    assert said[0][0] == RESIZE
+    assert set(json.loads(said[0][1])) == {"columns", "rows"}
+
+
+@pytest.mark.timeout(30)
+def test_a_socket_carrying_something_else_ends_the_reading_rather_than_raising(
+    paired: tuple[socket.socket, socket.socket],
+    pipe: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Either way there is nothing left to read.
+
+    And a stack trace over a terminal that is still in raw mode is a stack trace nobody
+    can read.
+    """
+    here, there = paired
+    reading, _ = pipe
+    monkeypatch.setattr(attach, "_IN", reading)
+    # A length no frame of this protocol has, which is what something else looks like.
+    there.sendall(struct.pack(">cI", b"O", 1 << 30))
+
+    assert attach._pumps(here) == ""

--- a/tests/daemon/test_held.py
+++ b/tests/daemon/test_held.py
@@ -174,9 +174,13 @@ def test_why_a_terminal_was_let_go_of_is_said_where_it_can_be_read(
     try:
         terminal.until(b"open")
         held.detach()
+
+        # Read while there is still a terminal to read from. Closing the far side of a
+        # pseudoterminal throws away whatever was still in it on some systems, so a goodbye
+        # gathered after the reader has gone is a goodbye gathered from nothing.
+        drawn = terminal.until(b"detached")
         assert _until(lambda: terminal.gone)
 
-        drawn = terminal.drew(1.0)
         # The sequence that leaves the alternate screen comes first, and the reason after it.
         assert b"\x1b[?1049l" in drawn
         assert drawn.index(b"\x1b[?1049l") < drawn.index(b"detached")

--- a/tests/daemon/test_holding.py
+++ b/tests/daemon/test_holding.py
@@ -1,0 +1,516 @@
+"""The run being held, and the terminals reading it, driven in this process.
+
+`tests/daemon/test_opening.py` and `terminals.py` drive the whole thing as it really works: a
+double fork, a run in the detached process, a reader in a process of its own. Which is the
+right way to check that a run outlives the terminal that started it, and the wrong way to
+check what the holding itself does with each thing that can arrive -- every branch of it is
+two processes away from the assertion, and the one that matters most is the one where a
+terminal misbehaves.
+
+So this drives `Held` directly. It is an ordinary object: a pseudoterminal the run draws on,
+a socket terminals arrive at, and a thread carrying between them. The run here is the test
+writing on the far side of the pseudoterminal, and the terminals are sockets the test opens.
+
+The socket is bound by a bare name from inside its own directory: a Unix socket address holds
+about a hundred bytes whole, 104 of them on macOS, and the directory pytest hands out is
+longer than that.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import pty
+import socket
+import time
+import tty
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from hmz.daemon import where
+from hmz.daemon.proto import (
+    CONTROL,
+    GONE,
+    HELLO,
+    INPUT,
+    OUTPUT,
+    RESIZE,
+    Frames,
+    frame,
+    spoken,
+)
+from hmz.daemon.serve import Held
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+#: How long a test waits for something that should already be on its way.
+PATIENCE = 10.0
+
+#: A terminal of this suite's own, wide enough not to be the width the suite is being run at.
+COLUMNS, ROWS = 100, 30
+
+
+def until(what: Callable[[], bool], seconds: float = PATIENCE) -> bool:
+    """Waits for something another thread is doing, rather than for a number of goes.
+
+    The loop carrying a run is a thread, so everything a test asks of it lands a moment
+    later. A count of iterations is a wait that is nothing at all on a fast machine, which
+    is a test that passes here and fails on whatever CI is running today.
+
+    Args:
+      what: The question, asked again until it is yes.
+      seconds: How long to go on asking.
+
+    Returns:
+      Whether it became true in the time it was given.
+    """
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if what():
+            return True
+        time.sleep(0.01)
+    return what()
+
+
+class Terminal:
+    """One socket on the other end of a held run, and the frames that came off it."""
+
+    def __init__(self, one: socket.socket) -> None:
+        self.one = one
+        self._frames = Frames()
+        self._held: list[tuple[bytes, bytes]] = []
+
+    def says(self, kind: bytes, said: dict[str, Any] | None = None) -> None:
+        """Sends one frame, as a terminal or as a question about the run."""
+        self.one.sendall(spoken(kind, said) if said is not None else frame(kind))
+
+    def types(self, typed: bytes) -> None:
+        self.one.sendall(frame(INPUT, typed))
+
+    def hears(self, kind: bytes) -> bytes:
+        """Waits for the next frame of that kind, and gives back what it carried.
+
+        Raises:
+            AssertionError: If the run said nothing of that kind before it went quiet.
+        """
+        while True:
+            for at, (said, payload) in enumerate(self._held):
+                if said == kind:
+                    del self._held[: at + 1]
+                    return payload
+            self.one.settimeout(PATIENCE)
+            read = self.one.recv(1 << 16)
+            if not read:
+                raise AssertionError(f"the run went without ever saying {kind!r}")
+            self._held.extend(self._frames.feed(read))
+
+    def quiet(self, seconds: float = 0.3) -> bool:
+        """Whether nothing more arrives, for a test about something not being sent.
+
+        A socket that was closed is not a socket that stayed quiet, and reading one as the
+        other is how a test about something not being sent passes for the wrong reason.
+
+        Raises:
+            AssertionError: If the run let go of this terminal instead of saying nothing.
+        """
+        self.one.settimeout(seconds)
+        try:
+            read = self.one.recv(1 << 16)
+        except TimeoutError:
+            return True
+        if not read:
+            raise AssertionError(
+                "the run let go of this terminal rather than said nothing"
+            )
+        self._held.extend(self._frames.feed(read))
+        return False
+
+    def close(self) -> None:
+        with contextlib.suppress(OSError):
+            self.one.close()
+
+
+class Holding:
+    """A run being held here, with both sides of it reachable from the test."""
+
+    def __init__(self, held: Held, run: int, at: Path) -> None:
+        self.held = held
+        self.run = run
+        self.at = at
+        self._opened: list[Terminal] = []
+        self._joined = 0
+
+    def draws(self, drawn: bytes) -> None:
+        """What the run draws on its own terminal."""
+        os.write(self.run, drawn)
+
+    def read(self, how_many: int = 1 << 16) -> bytes:
+        """What arrived in the run's own terminal, which is what somebody typed."""
+        os.set_blocking(self.run, False)
+        try:
+            return os.read(self.run, how_many)
+        except BlockingIOError:
+            return b""
+        finally:
+            os.set_blocking(self.run, True)
+
+    def terminal(self, *, joining: bool = True) -> Terminal:
+        """A terminal arriving to read this run, closed however the test ends."""
+        one = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        one.connect(where.SOCKET)
+        held = Terminal(one)
+        self._opened.append(held)
+        if joining:
+            self._joined += 1
+            held.says(HELLO, {"columns": COLUMNS, "rows": ROWS})
+            # Waited for here rather than in each test: everything a test does after this
+            # is about a terminal that is reading, and a HELLO still in flight is not one.
+            assert until(lambda: self.held.attached == self._joined), (
+                "the terminal never joined the run"
+            )
+        return held
+
+    def close(self) -> None:
+        for one in self._opened:
+            one.close()
+
+
+@pytest.fixture
+def holding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Holding]:
+    """A run held on a pseudoterminal, with the socket terminals arrive at already bound."""
+    monkeypatch.chdir(tmp_path)
+    controller, follower = pty.openpty()
+    # The side the run draws on, in the modes a full-screen program puts it in -- without
+    # which the terminal echoes what is typed straight back out as though the run drew it.
+    tty.setraw(follower)
+    listening = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listening.bind(where.SOCKET)
+    listening.listen(8)
+    where.wrote(tmp_path, {"pid": os.getpid(), "workspace": str(tmp_path)})
+    held = Held(controller, listening, tmp_path)
+    one = Holding(held, follower, tmp_path)
+    held.start()
+    try:
+        yield one
+    finally:
+        one.close()
+        held.close()
+        for fd in (follower, controller):
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+# ------------------------------------------------------ carrying it both ways
+
+
+@pytest.mark.timeout(60)
+def test_what_the_run_draws_reaches_the_terminal_reading_it(holding: Holding) -> None:
+    terminal = holding.terminal()
+
+    holding.draws(b"a screen")
+
+    assert terminal.hears(OUTPUT) == b"a screen"
+
+
+@pytest.mark.timeout(60)
+def test_what_is_typed_at_a_terminal_reaches_the_run(holding: Holding) -> None:
+    terminal = holding.terminal()
+    reached = bytearray()
+
+    terminal.types(b"typed")
+
+    def arrived() -> bool:
+        reached.extend(holding.read())
+        return bytes(reached) == b"typed"
+
+    assert until(arrived), f"what was typed reached the run as {bytes(reached)!r}"
+
+
+@pytest.mark.timeout(60)
+def test_every_terminal_reading_gets_what_the_run_drew(holding: Holding) -> None:
+    """A run is read from more than one terminal at once, and both see the same screen."""
+    first, second = holding.terminal(), holding.terminal()
+
+    holding.draws(b"a screen")
+
+    assert first.hears(OUTPUT) == b"a screen"
+    assert second.hears(OUTPUT) == b"a screen"
+
+
+# ------------------------------------------------- what was drawn before anybody read
+
+
+@pytest.mark.timeout(60)
+def test_a_terminal_arriving_at_a_run_that_has_not_moved_is_not_shown_a_blank_screen(
+    holding: Holding,
+) -> None:
+    """What it drew before anybody was reading is kept for whoever arrives first."""
+    holding.draws(b"drawn before anybody arrived")
+
+    terminal = holding.terminal()
+
+    assert terminal.hears(OUTPUT) == b"drawn before anybody arrived"
+
+
+@pytest.mark.timeout(60)
+def test_what_was_kept_is_given_to_the_first_terminal_alone(holding: Holding) -> None:
+    """The second is a run already being read, so it is drawn again rather than replayed."""
+    holding.draws(b"drawn before anybody arrived")
+    first = holding.terminal()
+    assert first.hears(OUTPUT) == b"drawn before anybody arrived"
+
+    second = holding.terminal()
+
+    assert second.quiet()
+
+
+# ----------------------------------------------------------- how many are reading
+
+
+@pytest.mark.timeout(60)
+def test_a_run_nobody_has_arrived_at_is_read_by_nobody(holding: Holding) -> None:
+    assert holding.held.attached == 0
+
+
+@pytest.mark.timeout(60)
+def test_a_terminal_that_has_said_hello_is_one_of_the_ones_reading(
+    holding: Holding,
+) -> None:
+    holding.terminal()
+
+    assert holding.held.attached == 1
+
+
+@pytest.mark.timeout(60)
+def test_a_socket_that_has_not_said_what_it_is_for_is_not_a_terminal_reading(
+    holding: Holding,
+) -> None:
+    """One is on the list from the moment it connects, and says what it is for afterwards."""
+    holding.terminal(joining=False)
+
+    assert holding.held.attached == 0
+
+
+# -------------------------------------------------------------- letting go
+
+
+@pytest.mark.timeout(60)
+def test_letting_go_says_why_and_leaves_the_run_running(holding: Holding) -> None:
+    terminal = holding.terminal()
+    holding.draws(b"a screen")
+    terminal.hears(OUTPUT)
+
+    assert holding.held.detach() == 1
+
+    assert terminal.hears(GONE)
+    assert holding.held.attached == 0
+
+
+@pytest.mark.timeout(60)
+def test_letting_go_of_a_run_nobody_is_reading_lets_go_of_none(
+    holding: Holding,
+) -> None:
+    assert holding.held.detach() == 0
+
+
+@pytest.mark.timeout(60)
+def test_a_run_that_is_over_says_so_to_every_terminal(holding: Holding) -> None:
+    terminal = holding.terminal()
+    holding.draws(b"a screen")
+    terminal.hears(OUTPUT)
+
+    holding.held.close("the run is over")
+
+    assert terminal.hears(GONE) == b"the run is over"
+
+
+@pytest.mark.timeout(60)
+def test_a_run_that_is_over_stops_saying_there_is_one_here_to_read(
+    holding: Holding,
+) -> None:
+    """A directory that still says yes is a terminal that connects and then waits forever."""
+    holding.held.close()
+
+    assert not (holding.at / where.SOCKET).exists()
+    assert not (holding.at / where.RECORD).exists()
+
+
+# --------------------------------------------------------------- how big it is
+
+
+@pytest.mark.timeout(60)
+def test_the_run_is_drawn_for_the_terminal_that_is_reading_it(holding: Holding) -> None:
+    terminal = holding.terminal()
+    holding.draws(b"a screen")
+    terminal.hears(OUTPUT)
+
+    assert _size(holding.run) == (COLUMNS, ROWS)
+
+
+@pytest.mark.timeout(60)
+def test_a_terminal_dragged_wider_says_so_and_the_run_is_drawn_for_that(
+    holding: Holding,
+) -> None:
+    terminal = holding.terminal()
+    holding.draws(b"a screen")
+    terminal.hears(OUTPUT)
+
+    terminal.says(RESIZE, {"columns": 133, "rows": 44})
+    holding.draws(b"again")
+    terminal.hears(OUTPUT)
+
+    assert _size(holding.run) == (133, 44)
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "said",
+    [
+        {"columns": 0, "rows": 0},
+        {"columns": 1, "rows": 1},
+        {"columns": -5, "rows": 30},
+        {"columns": "wide", "rows": 30},
+        {},
+    ],
+)
+def test_a_size_that_is_not_a_window_somebody_is_reading_is_refused(
+    holding: Holding, said: dict[str, Any]
+) -> None:
+    """Laying a screen out against no columns is what a full-screen program crashes on."""
+    terminal = holding.terminal()
+    holding.draws(b"a screen")
+    terminal.hears(OUTPUT)
+    was = _size(holding.run)
+
+    terminal.says(RESIZE, said)
+    holding.draws(b"again")
+    terminal.hears(OUTPUT)
+
+    assert _size(holding.run) == was
+
+
+# ------------------------------------------ a question about the run rather than a terminal
+
+
+@pytest.mark.timeout(60)
+def test_what_is_running_here_is_answered_off_what_was_written_down(
+    holding: Holding,
+) -> None:
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "status"})
+
+    said = json.loads(asking.hears(CONTROL))
+    assert said["ok"]
+    assert said["workspace"] == str(holding.at)
+    assert said["attached"] == 0
+
+
+@pytest.mark.timeout(60)
+def test_whatever_is_holding_the_run_may_add_to_what_is_said_about_it(
+    holding: Holding,
+) -> None:
+    holding.held.says(lambda: {"flow": "rlar", "task": "go"})
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "status"})
+
+    said = json.loads(asking.hears(CONTROL))
+    assert said["flow"] == "rlar"
+    assert said["task"] == "go"
+
+
+@pytest.mark.timeout(60)
+def test_something_that_cannot_say_what_it_is_doing_is_not_a_run_that_cannot_be_asked(
+    holding: Holding,
+) -> None:
+    """A hook that raises is a hook that said nothing, rather than a status that failed."""
+
+    def raising() -> dict[str, Any]:
+        raise RuntimeError("not today")
+
+    holding.held.says(raising)
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "status"})
+
+    assert json.loads(asking.hears(CONTROL))["ok"]
+
+
+@pytest.mark.timeout(60)
+def test_a_run_may_be_let_go_of_from_outside_it(holding: Holding) -> None:
+    reading = holding.terminal()
+    holding.draws(b"a screen")
+    reading.hears(OUTPUT)
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "detach"})
+
+    assert json.loads(asking.hears(CONTROL))["let go"] == 1
+    assert reading.hears(GONE)
+
+
+@pytest.mark.timeout(60)
+def test_a_run_nothing_can_stop_says_so_rather_than_saying_it_stopped(
+    holding: Holding,
+) -> None:
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "stop"})
+
+    said = json.loads(asking.hears(CONTROL))
+    assert not said["ok"]
+    assert "cannot be stopped" in said["why"]
+
+
+@pytest.mark.timeout(60)
+def test_a_run_that_can_be_stopped_is_stopped(holding: Holding) -> None:
+    stopped: list[bool] = []
+    holding.held.stopping(lambda: stopped.append(True))
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "stop"})
+
+    assert json.loads(asking.hears(CONTROL))["ok"]
+    assert until(lambda: bool(stopped)), "the run was never asked to stop"
+
+
+@pytest.mark.timeout(60)
+def test_a_request_that_is_not_one_says_so(holding: Holding) -> None:
+    asking = holding.terminal(joining=False)
+
+    asking.says(CONTROL, {"do": "juggle"})
+
+    said = json.loads(asking.hears(CONTROL))
+    assert not said["ok"]
+    assert "no such request" in said["why"]
+
+
+# --------------------------------------------------------- drawing it again
+
+
+@pytest.mark.timeout(60)
+def test_a_terminal_arriving_has_the_run_draw_itself_again(holding: Holding) -> None:
+    """A fresh terminal has none of what was drawn before it, in its own modes and size."""
+    drawn: list[bool] = []
+    holding.held.redrawn(lambda: drawn.append(True))
+
+    holding.terminal()
+
+    assert until(lambda: bool(drawn)), "the run was never asked to draw itself again"
+
+
+def _size(fd: int) -> tuple[int, int]:
+    """How big the pseudoterminal on this descriptor says it is."""
+    import fcntl
+    import struct
+    import termios
+
+    rows, columns, _, _ = struct.unpack(
+        "HHHH", fcntl.ioctl(fd, termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0))
+    )
+    return columns, rows

--- a/tests/providers/test_command.py
+++ b/tests/providers/test_command.py
@@ -317,6 +317,7 @@ def test_signing_in_again_runs_the_way_the_provider_was_made_by(
     assert (provider.at / "home" / ".credentials.json").exists()
 
 
+@traced
 def test_an_account_is_asked_what_it_runs_as_soon_as_it_is_made(
     asking: None,
     tmp_path: Path,

--- a/tests/providers/test_command.py
+++ b/tests/providers/test_command.py
@@ -19,7 +19,7 @@ import pytest
 
 from hmz import backends, cli, providers
 from tests.providers.test_login import CLAUDE_LOGIN, stand_in
-from tests.providers.test_redirect import traced
+from tests.supervising import traced
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/providers/test_login.py
+++ b/tests/providers/test_login.py
@@ -22,7 +22,7 @@ import pytest
 
 from hmz import backends, providers
 from hmz.providers import login
-from tests.providers.test_redirect import traced
+from tests.supervising import traced
 
 #: A stand-in for `claude auth login`: what a login leaves behind, without the browser.
 CLAUDE_LOGIN = """\

--- a/tests/providers/test_redirect.py
+++ b/tests/providers/test_redirect.py
@@ -11,19 +11,17 @@ this process ptrace a child of its own. Whether it can is answered by running on
 by asking what the kernel is -- a container without `CAP_SYS_PTRACE` has every module and can
 supervise nothing -- and where it cannot, those tests say so and skip.
 
-`traced` and `cred` are imported by the login and command-line suites, which spawn the same
-supervisor: this is the file the redirect is tested in, so it is the file they come from.
+Whether this machine can trace, and how `hmz cred` is spawned, are `tests/supervising.py`'s:
+three suites and a conftest ask, and a conftest cannot import a test module.
 """
 
 from __future__ import annotations
 
 import errno
 import os
-import platform
 import signal
 import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,66 +29,7 @@ import pytest
 
 from hmz import cli
 from hmz.providers import redirect
-
-#: What the machine itself is signed in as, which a turn under a provider must never see.
-MACHINE = '{"token": "the one at this machine"}'
-
-#: What the provider is signed in as, which is what every read below has to come back with.
-PROVIDER = '{"token": "the provider"}'
-
-#: How long a supervised program is given before the run is taken to have hung.
-PATIENCE = 45
-
-
-def cred(
-    argv: list[str], *, stdin: str = "", timeout: int = PATIENCE
-) -> subprocess.CompletedProcess[str]:
-    """Runs `hmz cred` as a turn under a provider runs it: its own process, on its own.
-
-    Args:
-      argv: What follows the command name -- the swaps, `--`, and the program.
-      stdin: What to write to the program's standard input.
-      timeout: How long to wait before taking the run to have hung.
-
-    Returns:
-      What the run came to, with its output read back.
-    """
-    return subprocess.run(
-        [sys.executable, "-m", "hmz", "cred", *argv],
-        input=stdin,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
-
-
-def _cannot_trace() -> str:
-    """Why a redirected run cannot be watched on this machine, or "" where one can.
-
-    Answered by running one: the modules import on any Linux, and whether the kernel will
-    hand over a tracee is a question only the attempt asks.
-    """
-    if sys.platform != "linux":
-        return "a redirected run is a Linux seccomp filter and a ptrace supervisor"
-    if platform.machine() != "x86_64":
-        return f"the register map is x86-64 only, and this host is {platform.machine()}"
-    with tempfile.TemporaryDirectory() as folder:
-        named, instead = Path(folder) / "named", Path(folder) / "instead"
-        named.write_text(MACHINE)
-        instead.write_text(PROVIDER)
-        try:
-            done = cred([f"--map={named}={instead}", "--", "cat", str(named)])
-        except (OSError, subprocess.SubprocessError) as why:
-            return f"a supervisor could not be started here: {why}"
-    if done.stdout != PROVIDER:
-        return f"nothing is traced here: {done.stderr.strip() or done.returncode}"
-    return ""
-
-
-#: Why the end-to-end tests cannot run here, and the mark that leaves them out when so.
-WITHOUT = _cannot_trace()
-traced = pytest.mark.skipif(bool(WITHOUT), reason=WITHOUT or "this machine can trace")
+from tests.supervising import MACHINE, PATIENCE, PROVIDER, cred, traced
 
 
 @dataclass(frozen=True)

--- a/tests/sampling.py
+++ b/tests/sampling.py
@@ -1,0 +1,29 @@
+"""Whether the sampler can be run on the machine running the suite.
+
+:mod:`hmz.tracing.profile` watches what a run started by asking the operating system about
+every process under this one, a hundred times a second. On one cell of the matrix -- macOS
+under Python 3.13, and not the 3.12 or 3.14 beside it -- doing that wedges the whole
+interpreter: the call it is inside does not come back and does not let another thread run
+either, so not even pytest's own per-test ceiling can end it. The job reaches the wall having
+said nothing, which is the one outcome a ceiling exists to prevent.
+
+Narrow on purpose. This is a thing to fix rather than a platform that cannot have it: the
+same file runs in two seconds on every other cell, and profiling is off unless a workspace
+asks for it. Written down here rather than as a bare `skipif` in two files so that there is
+one place saying what is known and one place to delete when it is fixed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+#: The one combination the sampler cannot be started on.
+WEDGES = sys.platform == "darwin" and sys.version_info[:2] == (3, 13)
+
+#: The mark for a test that starts one.
+sampled = pytest.mark.skipif(
+    WEDGES,
+    reason="the sampler wedges this interpreter (macOS on Python 3.13) -- see tests/sampling.py",
+)

--- a/tests/sdk/test_accounts.py
+++ b/tests/sdk/test_accounts.py
@@ -1,0 +1,329 @@
+"""The accounts half of the SDK, which is the same store every other way in walks.
+
+`Accounts` is a facade: each method is one call into :mod:`hmz.providers` or
+:mod:`hmz.models`. What is worth checking about a facade is not the call -- that is one line
+-- but that it is wired to the right one, with the arguments in the right order, so that an
+account made from here is the account a command line lists a moment later and the account the
+interface offers. So these go through the SDK and read back through the store, and the two
+have to agree.
+
+Nothing here signs into anything or starts a backend to ask what it runs: the way in that is
+exercised is the one that is only answers, and what a backend said it runs is written down
+rather than asked for.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz import providers
+from hmz.sdk import Hmz
+
+if TYPE_CHECKING:
+    from hmz.backends import Model
+
+
+def test_an_account_written_from_here_is_one_the_store_reads_back() -> None:
+    held = Hmz().accounts
+
+    made = held.write(
+        "claude",
+        "mine",
+        way="gateway",
+        env={"ANTHROPIC_BASE_URL": "https://example.invalid/anthropic"},
+        args=("--flag", "value"),
+    )
+
+    assert providers.find("claude", "mine") == made
+    assert made.way == "gateway"
+    assert made.env["ANTHROPIC_BASE_URL"] == "https://example.invalid/anthropic"
+    assert made.args == ("--flag", "value")
+
+
+def test_an_account_written_without_a_way_in_is_the_one_that_is_only_variables() -> (
+    None
+):
+    """`write` has two calls in it, and which one it makes is whether a way was named."""
+    written = Hmz().accounts.write("claude", "plain", env={"ANTHROPIC_API_KEY": "k"})
+
+    assert written.way == providers.ENV.name
+
+
+def test_every_account_is_listed_and_one_backend_s_are_listed_alone() -> None:
+    held = Hmz().accounts
+    held.write("claude", "first")
+    held.write("codex", "second")
+
+    assert [(one.cli, one.name) for one in held.all()] == [
+        ("claude", "first"),
+        ("codex", "second"),
+    ]
+    assert [one.name for one in held.all("claude")] == ["first"]
+
+
+def test_an_account_is_found_by_name_and_a_name_nobody_made_is_nothing() -> None:
+    held = Hmz().accounts
+    held.write("claude", "mine")
+
+    found = held.find("claude", "mine")
+
+    assert found is not None
+    assert found.name == "mine"
+    assert held.find("claude", "never-made") is None
+
+
+def test_where_an_account_is_kept_is_answered_before_it_is_made() -> None:
+    """Which is what asks it of a name: a directory is made at what this says."""
+    held = Hmz().accounts
+
+    at = held.where("claude", "mine")
+
+    assert at == providers.where("claude", "mine")
+    assert not at.exists()
+    assert held.write("claude", "mine").at == at
+
+
+def test_a_name_an_account_may_not_be_kept_under_is_refused() -> None:
+    with pytest.raises(ValueError, match="name"):
+        Hmz().accounts.where("claude", "../evil")
+
+
+def test_the_account_this_machine_is_signed_into_is_where_the_backend_keeps_its_own() -> (
+    None
+):
+    from hmz.providers import store
+
+    assert Hmz().accounts.local("claude") == store.alone("claude")
+
+
+def test_the_ways_in_a_backend_offers_are_the_ones_it_is_asked_for() -> None:
+    held = Hmz().accounts
+
+    assert held.ways("claude") == providers.ways("claude")
+    assert [one.name for one in held.ways("claude")]
+
+
+def test_a_way_in_is_found_by_name_and_a_name_it_does_not_offer_is_nothing() -> None:
+    held = Hmz().accounts
+
+    way = held.way("claude", "gateway")
+
+    assert way is not None
+    assert way.name == "gateway"
+    assert held.way("claude", "not-a-way") is None
+
+
+def test_what_a_way_in_still_has_to_be_told_is_what_was_not_answered() -> None:
+    held = Hmz().accounts
+    way = held.way("claude", "gateway")
+    assert way is not None
+
+    assert held.asks(way, {}) == ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]
+    assert held.asks(way, {"ANTHROPIC_BASE_URL": "https://example.invalid"}) == [
+        "ANTHROPIC_AUTH_TOKEN"
+    ]
+
+
+def test_a_way_in_whose_answers_have_a_fixed_one_does_not_ask_for_it() -> None:
+    """Bedrock's region has a default, so it is answerable without being answered."""
+    held = Hmz().accounts
+    way = held.way("claude", "bedrock")
+    assert way is not None
+
+    assert "AWS_REGION" not in held.asks(way, {})
+
+
+def test_an_account_made_out_of_a_way_in_keeps_what_that_way_sets() -> None:
+    held = Hmz().accounts
+    way = held.way("claude", "bedrock")
+    assert way is not None
+
+    made = held.make("claude", "aws", way, {"AWS_PROFILE": "work"})
+
+    assert made.way == "bedrock"
+    assert made.env["AWS_PROFILE"] == "work"
+    assert made.env["CLAUDE_CODE_USE_BEDROCK"] == "1"
+    # And the fixed answer nobody was asked is written down with the rest.
+    assert made.env["AWS_REGION"] == "us-east-1"
+
+
+def test_signing_in_by_a_way_that_is_only_answers_runs_nothing_and_is_already_done() -> (
+    None
+):
+    held = Hmz().accounts
+    way = held.way("claude", "key")
+    assert way is not None
+    made = held.make("claude", "keyed", way, {"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    assert held.sign_in(made, way) == 0
+
+
+def test_the_other_backends_an_account_could_run_are_the_vendor_s_rather_than_the_cli_s() -> (
+    None
+):
+    """An Anthropic key is an Anthropic key whoever is holding it."""
+    held = Hmz().accounts
+    key = held.way("claude", "key")
+    assert key is not None
+    made = held.make("claude", "mine", key, {"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    serves = held.serves(made)
+
+    assert serves == providers.serves(made)
+    assert "pi" in serves
+    assert "claude" not in serves  # the backend it already is, which is not another one
+
+
+def test_an_account_that_cannot_travel_says_there_is_nowhere_for_it_to_go() -> None:
+    """A gateway is reached under one backend's own variables and nothing else reads them."""
+    held = Hmz().accounts
+    gateway = held.way("claude", "gateway")
+    assert gateway is not None
+    made = held.make(
+        "claude",
+        "walled",
+        gateway,
+        {
+            "ANTHROPIC_BASE_URL": "https://example.invalid/anthropic",
+            "ANTHROPIC_AUTH_TOKEN": "not-a-real-token",
+        },
+    )
+
+    assert held.serves(made) == ()
+
+
+def test_an_account_copied_to_another_backend_is_written_down_under_it() -> None:
+    held = Hmz().accounts
+    key = held.way("claude", "key")
+    assert key is not None
+    made = held.make("claude", "mine", key, {"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    copy = held.copies(made, "pi", "copied")
+
+    assert copy.cli == "pi"
+    assert copy.name == "copied"
+    assert held.find("pi", "copied") == copy
+
+
+def test_a_copy_made_under_no_name_of_its_own_keeps_the_one_it_already_has() -> None:
+    held = Hmz().accounts
+    key = held.way("claude", "key")
+    assert key is not None
+    made = held.make("claude", "mine", key, {"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    assert held.copies(made, "pi").name == "mine"
+
+
+def test_an_account_that_could_not_run_another_backend_is_not_copied_to_it() -> None:
+    held = Hmz().accounts
+    made = held.write("claude", "mine", env={"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    with pytest.raises(ValueError, match="not an account"):
+        held.copies(made, "definitely-not-a-backend")
+
+
+def test_the_accounts_a_turn_carries_on_under_are_the_chain_it_was_pointed_down() -> (
+    None
+):
+    held = Hmz().accounts
+    held.write("claude", "first")
+    held.write("claude", "second")
+
+    assert held.points("claude", "first", "second")
+    chain = held.chain(held.find("claude", "first"))  # pyright: ignore[reportArgumentType]
+
+    assert [one.name for one in chain] == ["first", "second"]
+
+
+def test_an_account_pointed_at_one_that_is_not_its_backend_s_is_refused() -> None:
+    held = Hmz().accounts
+    held.write("claude", "first")
+
+    with pytest.raises(ValueError, match="no claude account called"):
+        held.points("claude", "first", "never-made")
+
+
+def test_pointing_an_account_nobody_made_says_there_was_none_to_write_it_on() -> None:
+    assert not Hmz().accounts.points("claude", "never-made", "")
+
+
+def test_an_account_taken_away_is_gone_and_taking_it_away_twice_says_so() -> None:
+    held = Hmz().accounts
+    held.write("claude", "mine")
+
+    assert held.remove("claude", "mine")
+    assert held.find("claude", "mine") is None
+    assert not held.remove("claude", "mine")
+
+
+def test_the_account_this_machine_is_signed_into_is_not_one_to_take_away() -> None:
+    """Humanize did not make it and keeps no credentials for it."""
+    with pytest.raises(ValueError, match="is not a provider name"):
+        Hmz().accounts.remove("claude", "")
+
+
+def test_variables_are_read_out_of_the_lines_they_were_typed_as() -> None:
+    held = Hmz().accounts
+
+    assert held.env("A=one\n# a note\n\nB = two ") == {"A": "one", "B": "two"}
+
+
+def test_a_line_that_is_not_a_variable_is_a_line_to_correct() -> None:
+    with pytest.raises(ValueError, match="NAME=VALUE"):
+        Hmz().accounts.env("not a variable")
+
+
+def test_what_a_turn_runs_with_is_the_account_s_and_nothing_for_no_account() -> None:
+    held = Hmz().accounts
+    made = held.write("claude", "mine", env={"ANTHROPIC_API_KEY": "not-a-real-key"})
+
+    assert held.environ(made) == {"ANTHROPIC_API_KEY": "not-a-real-key"}
+    assert held.environ(None) == {}
+
+
+def test_what_a_backend_runs_is_read_off_what_was_kept_and_nothing_before_it_was_asked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hmz import models
+
+    held = Hmz().accounts
+
+    assert held.models("claude") == ()
+    assert held.asked("claude") == ""
+
+    kept: tuple[Model, ...] = ()
+
+    def answering(
+        cli: str, provider: str = "", seconds: float = 0.0
+    ) -> tuple[Model, ...]:
+        assert (cli, provider) == ("claude", "mine")
+        return kept
+
+    monkeypatch.setattr(models, "ask", answering)
+
+    assert held.ask("claude", "mine") == kept
+
+
+def test_how_long_a_backend_is_given_to_answer_is_passed_on_only_when_it_is_said(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default is that backend's own, which is a different call rather than a number."""
+    from hmz import models
+
+    seen: list[tuple[str, str, float | None]] = []
+
+    def answering(
+        cli: str, provider: str = "", seconds: float | None = None
+    ) -> tuple[Model, ...]:
+        seen.append((cli, provider, seconds))
+        return ()
+
+    monkeypatch.setattr(models, "ask", answering)
+    held = Hmz().accounts
+
+    held.ask("claude")
+    held.ask("claude", "mine", 12.5)
+
+    assert seen == [("claude", "", None), ("claude", "mine", 12.5)]

--- a/tests/sdk/test_epics.py
+++ b/tests/sdk/test_epics.py
@@ -1,0 +1,195 @@
+"""The runs that have already happened, reached through the SDK rather than through a line.
+
+`Epics` is what everything listing runs asks -- a command line, the interface's own `/epics` --
+so what is checked here is that it is about the workspace it was given, that every way of
+reading one run back agrees with the record the run itself wrote, and that the two things
+gathered out of a run afterwards -- a trace of it, an archive of it -- come out of the run's
+own directory rather than out of whatever directory somebody was standing in.
+
+The run is a real one: a flow, driven by a stand-in agent that opens a session and echoes into
+it. Nothing here starts a coding agent.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.agents import AgentConfig
+from hmz.runner import Runner
+from hmz.sdk import Hmz
+from hmz.sdk.epics import Epics
+from tests.stubs import ShellAgent, written
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CONFIG = AgentConfig(model="m", effort="high")
+
+#: A flow that opens one session and says something into it, so that the run has one to point
+#: at -- which is the whole of what an epic is for -- and counts the runs of itself, so that
+#: the run also has something to be picked up from.
+FLOW = '''"""Opens a session, and counts the runs of itself."""
+
+from typing import Any
+
+from hmz.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow(resumable=True)
+def run(agents: tuple[AgentBase], task: str, state: dict[str, Any]) -> None:
+    state["rounds"] = state.get("rounds", 0) + 1
+    agents[0].new()("echo the-session")
+'''
+
+
+@pytest.fixture
+def ran(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """One run of one flow in a workspace of its own, and the epic it wrote."""
+    monkeypatch.chdir(tmp_path)
+    written(tmp_path, "flow", FLOW)
+    Runner(tmp_path / "flow", [ShellAgent(CONFIG, name="actor")]).run("go")
+    (epic,) = Hmz().epics.all()
+    return epic
+
+
+@pytest.fixture
+def named(tmp_path: Path) -> str:
+    """The flow, as it was named when it ran, which is what its state is written under."""
+    return str(tmp_path / "flow")
+
+
+def test_the_runs_are_kept_under_the_directory_this_says_they_are(ran: Path) -> None:
+    held = Hmz().epics
+
+    assert held.under() == ran.parent
+    assert ran.is_dir()
+
+
+def test_what_one_run_was_is_read_back_off_what_the_run_itself_wrote(ran: Path) -> None:
+    read = Hmz().epics.read(ran)
+
+    assert read is not None
+    assert read.task == "go"
+    assert read.flow.endswith("flow")
+
+
+def test_a_run_that_is_not_one_reads_as_nothing(tmp_path: Path) -> None:
+    """A directory of runs is read by people, and a directory in it may be anything."""
+    stray = tmp_path / "not-a-run"
+    stray.mkdir()
+
+    assert Hmz().epics.read(stray) is None
+
+
+def test_every_session_one_run_opened_is_one_it_points_at(ran: Path) -> None:
+    held = Hmz().epics
+
+    opened = held.sessions(ran)
+
+    assert opened
+    assert [one.ident for one in opened] == [
+        ident for ids in held.opened(ran).values() for ident in ids
+    ]
+
+
+def test_what_each_agent_opened_is_under_the_name_the_run_knew_it_as(ran: Path) -> None:
+    opened = Hmz().epics.opened(ran)
+
+    assert list(opened) == ["actor"]
+    assert opened["actor"]
+
+
+def test_the_last_run_of_a_flow_here_is_what_a_resumable_flow_picks_up(
+    ran: Path, named: str
+) -> None:
+    """Looked for by what the state holds, so a flow called by another is picked up too."""
+    held = Hmz().epics
+
+    assert held.resumed(named) == ran
+    assert held.resumed("a-flow-nobody-ran") is None
+
+
+def test_what_a_flow_left_behind_is_what_the_run_picking_it_up_is_handed(
+    ran: Path, named: str
+) -> None:
+    held = Hmz().epics
+
+    assert held.state(ran) == {"rounds": 1}
+    # Asked for by name it is the same thing, which is how a called flow's is reached.
+    assert held.state(ran, named) == {"rounds": 1}
+    assert held.state(ran, "a-flow-that-never-ran") == {}
+
+
+def test_the_runs_of_a_workspace_are_the_ones_run_there_and_no_others(
+    ran: Path, tmp_path: Path
+) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    assert Hmz(tmp_path).epics.all() == [ran]
+    assert Hmz(elsewhere).epics.all() == []
+    assert Epics(elsewhere).under() != Epics(tmp_path).under()
+
+
+def test_a_trace_of_a_run_goes_in_the_run_s_own_directory_unless_it_is_sent_elsewhere(
+    ran: Path,
+) -> None:
+    """Which is what makes collecting one twice keep both rather than write over the first."""
+    where, document = Hmz().epics.traced(ran)
+
+    assert where.parent.parent == ran
+    assert where.is_file()
+    assert json.loads(where.read_text(encoding="utf-8")) == document
+
+
+def test_a_trace_written_where_it_was_asked_for_is_written_there(
+    ran: Path, tmp_path: Path
+) -> None:
+    asked = tmp_path / "out" / "run.trace.json"
+
+    where, document = Hmz().epics.traced(ran, output=asked)
+
+    assert where == asked
+    assert json.loads(asked.read_text(encoding="utf-8")) == document
+
+
+def test_a_trace_holds_the_sessions_that_run_opened_and_no_others(ran: Path) -> None:
+    held = Hmz().epics
+    ours = {ident for ids in held.opened(ran).values() for ident in ids}
+
+    _, document = held.traced(ran)
+
+    said = json.dumps(document)
+    assert ours
+    for ident in ours:
+        assert ident in said
+
+
+def test_a_trace_of_no_sessions_is_an_empty_trace_rather_than_a_refusal() -> None:
+    """An empty iterable is none of them, which is what a run that opened none gathers.
+
+    That it is *not* read as every session is the collector's own promise and is checked
+    where the collector is, against sessions that were really logged. What this asks is the
+    part the SDK owns: the argument arrives, and what comes back is a trace document.
+    """
+    document = Hmz().epics.trace(sessions=[])
+
+    assert document["traceEvents"] == []
+    assert "displayTimeUnit" in document
+
+
+def test_a_run_is_packaged_up_whole_to_send_to_somebody_who_was_not_there(
+    ran: Path, tmp_path: Path
+) -> None:
+    into = tmp_path / "bundles"
+    into.mkdir()
+
+    where, manifest = Hmz().epics.bundled(ran, output=into)
+
+    assert where.exists()
+    assert where.parent == into
+    assert manifest

--- a/tests/sdk/test_fallbacks.py
+++ b/tests/sdk/test_fallbacks.py
@@ -1,0 +1,125 @@
+"""Where a turn goes when the place taking it cannot take it, reached through the SDK.
+
+The store itself is `tests/test_fallback_command.py`'s and `hmz.fallbacks`'s. What is checked
+here is the other half of the promise the SDK makes: that a step written from here is the step
+a command line lists and the interface's own menu reads back, and that the three things which
+can happen to one -- pointed somewhere, told how to try again, taken away -- are the same three
+whichever way in wrote them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hmz.sdk import Hmz
+
+
+def test_how_a_failed_turn_waits_unless_somebody_said_otherwise_is_one_of_the_policies() -> (
+    None
+):
+    held = Hmz().fallbacks
+
+    assert held.default in [one.name for one in held.policies()]
+
+
+def test_the_waits_are_offered_hardest_last() -> None:
+    """Which is the order a menu of them is drawn in, so it is the order they come in."""
+    names = [one.name for one in Hmz().fallbacks.policies()]
+
+    assert names[0] == "none"
+    assert len(names) == len(set(names))
+
+
+def test_a_wait_is_found_by_name_and_a_name_none_of_them_goes_by_is_nothing() -> None:
+    held = Hmz().fallbacks
+
+    found = held.named(held.default)
+
+    assert found is not None
+    assert found.name == held.default
+    assert held.named("not-a-policy") is None
+
+
+def test_a_place_is_read_back_as_it_is_written_down() -> None:
+    assert Hmz().fallbacks.reads("claude/opus") == "claude/opus"
+
+
+def test_a_spelling_no_place_answers_to_reads_as_nothing() -> None:
+    assert Hmz().fallbacks.reads("definitely-not-a-backend/whatever") == ""
+
+
+def test_a_place_is_spelled_out_of_the_three_things_a_place_is() -> None:
+    held = Hmz().fallbacks
+
+    assert held.spec("claude", "opus", "mine") == "claude@mine/opus"
+    # And an account nobody named is the one this machine is already signed into.
+    assert held.spec("claude", "opus") == "claude/opus"
+
+
+def test_a_place_nothing_is_written_against_says_nothing_rather_than_missing() -> None:
+    """A menu asks every place what it does, including the ones nobody has answered for."""
+    written = Hmz().fallbacks.tried("claude/opus")
+
+    assert written.spec == "claude/opus"
+    assert written.to == ""
+    assert written.tries == 0
+    assert written.timeout == 0.0
+
+
+def test_a_place_that_falls_back_nowhere_is_a_chain_of_itself_alone() -> None:
+    assert Hmz().fallbacks.chain("claude/opus") == ["claude/opus"]
+
+
+def test_a_step_written_from_here_is_the_chain_and_the_listing_a_line_walks() -> None:
+    held = Hmz().fallbacks
+
+    step = held.points("claude/opus", "codex/gpt")
+
+    assert step.spec == "claude/opus"
+    assert step.to == "codex/gpt"
+    assert held.chain("claude/opus") == ["claude/opus", "codex/gpt"]
+    assert [one.spec for one in held.all()] == ["claude/opus"]
+
+
+def test_a_step_that_would_point_at_itself_is_refused() -> None:
+    with pytest.raises(ValueError, match="cannot fall back to itself"):
+        Hmz().fallbacks.points("claude/opus", "claude/opus")
+
+
+def test_a_step_from_a_place_that_is_not_one_is_refused() -> None:
+    with pytest.raises(ValueError, match="is not a place"):
+        Hmz().fallbacks.points("definitely-not-a-backend/whatever", "codex/gpt")
+
+
+def test_how_a_failed_turn_is_taken_again_is_written_on_the_same_row_as_the_step() -> (
+    None
+):
+    """Both are answers to the one thing that happened, so one row holds them."""
+    held = Hmz().fallbacks
+    held.points("claude/opus", "codex/gpt")
+
+    step = held.retrying("claude/opus", 3, "linear", 30.0)
+
+    assert step.tries == 3
+    assert step.policy == "linear"
+    assert step.timeout == 30.0
+    # And writing the one did not forget the other.
+    assert step.to == "codex/gpt"
+    assert [one.spec for one in held.all()] == ["claude/opus"]
+
+
+def test_trying_again_by_a_wait_that_is_not_one_is_refused() -> None:
+    with pytest.raises(ValueError, match="is not a retry policy"):
+        Hmz().fallbacks.retrying("claude/opus", 3, "not-a-policy", 0.0)
+
+
+def test_a_step_taken_away_is_a_place_that_falls_back_nowhere_again() -> None:
+    held = Hmz().fallbacks
+    held.points("claude/opus", "codex/gpt")
+
+    assert held.clear("claude/opus")
+
+    assert held.chain("claude/opus") == ["claude/opus"]
+    assert held.all() == []
+    # And there is nothing left to take away a second time.
+    assert not held.clear("claude/opus")

--- a/tests/sdk/test_flows.py
+++ b/tests/sdk/test_flows.py
@@ -1,0 +1,341 @@
+"""The flows there are and the places they come from, reached through the SDK.
+
+A command line, the interface and a daemon each ask this rather than the three modules behind
+it, so what is checked here is that all three would get the same answer: a flowverse added
+from here is one the listing offers a moment later, a flow's name resolves to the file it is
+written in, and the handful of answers every way in needs -- what a flow takes, what it says
+about itself, whether it can be picked up -- come off the flow rather than off a second copy
+of the facts.
+
+The flowverse fetched from is a git repository under `tmp_path`. Nothing here reaches a
+network, and nothing starts a coding agent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.flows import BUILTIN, ENTRY, FLOWS, LOCAL, OFFICIAL, USER, NotAFlow
+from hmz.sdk import Hmz
+from tests.stubs import written
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: A flow, as short as one can be, that says a line about itself and takes one agent.
+FLOW = '''"""A flow of somebody else's."""
+
+from hmz.flows import Agent, flow
+
+
+@flow
+def run(agents: tuple[Agent], task: str) -> None:
+    (agent,) = agents
+    agent.new()(task)
+'''
+
+#: One that says it can be picked up where the last run of it left off, and takes a setting.
+KEEPS = '''"""A flow that is picked up."""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from hmz.flows import Agent, flow
+
+
+class Config(BaseModel):
+    """What it takes."""
+
+    rounds: int = 1
+
+
+@flow(resumable=True)
+def run(
+    agents: tuple[Agent],
+    task: str,
+    config: Config | None = None,
+    state: dict[str, Any] | None = None,
+) -> None:
+    (agent,) = agents
+'''
+
+
+def _git(*said: str, at: Path) -> None:
+    """Runs one git command in a directory, failing the test if it fails."""
+    subprocess.run(["git", "-C", str(at), *said], check=True, capture_output=True)
+
+
+@pytest.fixture
+def theirs(tmp_path: Path) -> Path:
+    """A repository of one flow, to be fetched from."""
+    where = tmp_path / "theirs"
+    (where / FLOWS).mkdir(parents=True)
+    written(where / FLOWS, "loop", FLOW)
+    _git("init", "-b", "main", at=where)
+    _git("config", "user.email", "t@example.com", at=where)
+    _git("config", "user.name", "t", at=where)
+    _git("add", "-A", at=where)
+    _git("commit", "-m", "one flow", at=where)
+    return where
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project with two flows of its own, stood in."""
+    where = tmp_path / "project"
+    flows = where / ".humanize" / "flows"
+    flows.mkdir(parents=True)
+    written(flows, "mine", FLOW)
+    written(flows, "kept", KEEPS)
+    monkeypatch.chdir(where)
+    return where
+
+
+# ------------------------------------------------------------ where flows come from
+
+
+def test_the_places_are_listed_in_the_order_their_flows_are_offered() -> None:
+    assert [one.name for one in Hmz().verses.all()] == [BUILTIN, OFFICIAL, LOCAL, USER]
+
+
+def test_a_name_is_looked_up_in_a_different_order_than_the_flows_are_offered_in() -> (
+    None
+):
+    """Nearest first: this project's own flows answer to a name before the package's do."""
+    verses = Hmz().verses
+
+    assert next(one.name for one in verses.nearest()) == LOCAL
+    assert {one.name for one in verses.nearest()} == {one.name for one in verses.all()}
+
+
+def test_a_place_is_found_by_name_and_a_name_none_answers_to_is_nothing() -> None:
+    verses = Hmz().verses
+
+    found = verses.find(BUILTIN)
+
+    assert found is not None
+    assert found.name == BUILTIN
+    assert verses.find("not-a-flowverse") is None
+
+
+def test_a_place_added_here_is_one_the_listing_offers_a_moment_later(
+    theirs: Path,
+) -> None:
+    verses = Hmz().verses
+
+    added = verses.add(str(theirs), "theirs")
+
+    assert added.name == "theirs"
+    assert added.fetched
+    assert "theirs" in [one.name for one in verses.all()]
+    assert [one.name for one in verses.holds(added)] == ["theirs/loop"]
+    assert "theirs/loop" in [one.name for one in Hmz().flows.all()]
+
+
+def test_a_place_is_kept_in_the_directory_this_says_whether_or_not_it_was_fetched() -> (
+    None
+):
+    verses = Hmz().verses
+
+    at = verses.where("theirs")
+
+    assert not at.exists()
+    assert at.name == "theirs"
+
+
+def test_a_place_fetched_again_is_a_fetch_rather_than_a_merge(theirs: Path) -> None:
+    verses = Hmz().verses
+    verses.add(str(theirs), "theirs")
+    written(theirs / FLOWS, "second", FLOW)
+    _git("add", "-A", at=theirs)
+    _git("commit", "-m", "another flow", at=theirs)
+
+    again = verses.fetch("theirs")
+
+    assert {one.name for one in verses.holds(again)} == {"theirs/loop", "theirs/second"}
+
+
+def test_a_place_taken_away_is_gone_and_taking_it_away_twice_says_so(
+    theirs: Path,
+) -> None:
+    verses = Hmz().verses
+    verses.add(str(theirs), "theirs")
+
+    assert verses.remove("theirs")
+
+    assert verses.find("theirs") is None
+    assert not verses.remove("theirs")
+
+
+def test_the_two_that_are_always_there_cannot_be_taken_away() -> None:
+    with pytest.raises(ValueError, match="not one to take away"):
+        Hmz().verses.remove(BUILTIN)
+
+
+def test_a_place_that_has_not_been_fetched_holds_nothing_rather_than_failing() -> None:
+    verses = Hmz().verses
+    official = verses.find(OFFICIAL)
+    assert official is not None
+
+    if official.fetched:
+        pytest.skip("humanize's own flowverse has been fetched on this machine")
+    assert verses.holds(official) == []
+
+
+def test_what_was_signed_into_a_url_is_not_what_is_printed_of_it() -> None:
+    plain = Hmz().verses.plain("https://someone:secret@example.invalid/theirs.git")
+
+    assert "secret" not in plain
+    assert "example.invalid/theirs.git" in plain
+
+
+# ------------------------------------------------------------------- the flows
+
+
+def test_every_flow_there_is_to_run_is_offered_by_the_name_dash_f_takes(
+    project: Path,
+) -> None:
+    offered = Hmz().flows.all()
+
+    assert ("local", "local/mine") in [(one.whose, one.name) for one in offered]
+    assert "chat" in [one.name for one in offered]
+
+
+def test_a_flow_s_name_is_the_file_it_is_written_in(project: Path) -> None:
+    found = Hmz().flows.find("mine")
+
+    assert found == str((project / ".humanize/flows/mine" / ENTRY).resolve())
+
+
+def test_a_name_nothing_answers_to_comes_back_as_the_name_it_was_asked_by(
+    project: Path,
+) -> None:
+    """Rather than as an exception: whatever asked hears the name, and says so itself."""
+    assert Hmz().flows.find("definitely-not-a-flow") == "definitely-not-a-flow"
+
+
+def test_the_line_a_flow_says_about_itself_is_read_off_the_flow(project: Path) -> None:
+    assert Hmz().flows.about("mine") == "A flow of somebody else's."
+
+
+def test_every_agent_a_flow_needs_chosen_is_read_off_how_it_declared_them(
+    project: Path,
+) -> None:
+    places = Hmz().flows.places("mine")
+
+    assert len(places) == 1
+    assert not places[0].person
+
+
+def test_what_a_flow_can_be_set_up_with_is_its_own_model_and_none_for_one_that_takes_none(
+    project: Path,
+) -> None:
+    flows = Hmz().flows
+
+    model = flows.configures("kept")
+
+    assert model is not None
+    assert "rounds" in model.model_fields
+    assert flows.configures("mine") is None
+
+
+def test_whether_a_flow_can_be_picked_up_is_what_the_flow_said(project: Path) -> None:
+    flows = Hmz().flows
+
+    assert flows.resumes("kept")
+    assert not flows.resumes("mine")
+
+
+def test_a_flow_forked_into_this_project_is_offered_under_the_name_it_already_had(
+    project: Path,
+) -> None:
+    """Yours are looked in first, so from then on that name means the copy."""
+    flows = Hmz().flows
+
+    where = flows.fork("chat")
+
+    # Spelled as this project's own flows are spelled, which is from the project itself.
+    assert where == ".humanize/flows/chat"
+    assert (project / ".humanize" / "flows" / "chat").is_dir()
+    assert flows.find("chat").startswith(str(project))
+
+
+def test_forking_a_name_nothing_of_which_is_a_flow_is_refused(project: Path) -> None:
+    with pytest.raises(ValueError, match="no flow called"):
+        Hmz().flows.fork("definitely-not-a-flow")
+
+
+def test_forking_over_a_flow_of_your_own_is_refused(project: Path) -> None:
+    """A copy already there is one to edit, run or take away rather than to write over."""
+    flows = Hmz().flows
+    flows.fork("chat")
+
+    with pytest.raises(ValueError, match="already a flow of your own"):
+        flows.fork("chat")
+
+
+def test_nothing_is_running_outside_a_run(project: Path) -> None:
+    assert Hmz().flows.running() == ()
+
+
+def test_the_places_flows_come_from_are_reached_from_the_flows_as_well() -> None:
+    """One object, so that whatever holds the flows does not have to hold a second thing."""
+    held = Hmz()
+
+    assert [one.name for one in held.flows.verses.all()] == [
+        one.name for one in held.verses.all()
+    ]
+
+
+# ------------------------------------------------------- what a flow is set up with
+
+
+def test_what_a_flow_is_set_up_with_is_read_out_of_the_file_it_was_written_in(
+    tmp_path: Path,
+) -> None:
+    said = tmp_path / "setup.yml"
+    said.write_text("rounds: 3\nname: mine\n", encoding="utf-8")
+
+    assert Hmz().flows.set_up_from(said) == {"rounds": 3, "name": "mine"}
+
+
+def test_a_setup_file_that_is_empty_sets_nothing_up(tmp_path: Path) -> None:
+    said = tmp_path / "setup.yml"
+    said.write_text("", encoding="utf-8")
+
+    assert Hmz().flows.set_up_from(said) == {}
+
+
+def test_a_setup_file_that_is_not_a_mapping_is_refused(tmp_path: Path) -> None:
+    said = tmp_path / "setup.yml"
+    said.write_text("- one\n- two\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mapping"):
+        Hmz().flows.set_up_from(said)
+
+
+# ------------------------------------------------------------- reading a flow first
+
+
+def test_a_flow_that_will_run_is_read_and_nothing_is_found(project: Path) -> None:
+    assert Hmz().flows.check("mine") == ()
+
+
+def test_the_reading_that_executes_nothing_is_the_one_that_was_asked_for(
+    project: Path,
+) -> None:
+    """`static` is the whole of what it keeps: pure `ast`, and the flow is never loaded."""
+    assert Hmz().flows.check("mine", static=True) == ()
+
+
+def test_a_flow_that_is_not_an_atlas_compiles_to_no_prophecy(project: Path) -> None:
+    assert Hmz().flows.prophecy("mine") is None
+
+
+def test_a_flow_that_is_not_an_atlas_has_no_prophecy_to_ship(project: Path) -> None:
+    with pytest.raises(NotAFlow, match="not an atlas"):
+        Hmz().flows.foretell("mine")

--- a/tests/sdk/test_session.py
+++ b/tests/sdk/test_session.py
@@ -1,0 +1,91 @@
+"""A run being read from a terminal, as whatever is holding the run sees it.
+
+A protocol rather than the thing itself, so that the interface names no daemon: the point of
+it is that the interface can ask how many terminals are reading and let go of them without
+knowing what is holding the run. What is worth checking about such a protocol is the two
+halves of that promise -- that the thing a daemon really hands over satisfies it, and that
+something which only half does is not mistaken for one.
+
+The socket is bound by a bare name from inside its own directory: a Unix socket address holds
+about a hundred bytes whole, 104 of them on macOS, and the directory pytest hands out is
+longer than that.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.daemon.serve import Held
+from hmz.sdk import Session
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def held(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Held]:
+    """What a daemon holds a run in, with both its ends closed again afterwards."""
+    monkeypatch.chdir(tmp_path)
+    master, worker = os.openpty()
+    listening = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listening.bind("daemon.sock")
+    listening.listen(1)
+    try:
+        yield Held(master, listening, tmp_path)
+    finally:
+        listening.close()
+        os.close(worker)
+        os.close(master)
+
+
+def test_what_a_daemon_holds_a_run_in_is_what_the_interface_was_promised(
+    held: Held,
+) -> None:
+    """Which is the whole of the coupling: the interface names this and no daemon."""
+    assert isinstance(held, Session)
+
+
+def test_a_run_nobody_is_reading_says_so_rather_than_saying_nothing(held: Held) -> None:
+    assert held.attached == 0
+
+
+def test_letting_go_of_terminals_nobody_was_reading_through_lets_go_of_none(
+    held: Held,
+) -> None:
+    """Zero where nobody was reading, rather than a refusal: it is asked of every run."""
+    assert held.detach() == 0
+
+
+def test_something_offering_both_halves_is_one_of_these_whatever_it_is() -> None:
+    """A protocol is a shape, so a run held some other way would satisfy it too."""
+
+    class Otherwise:
+        @property
+        def attached(self) -> int:
+            return 3
+
+        def detach(self) -> int:
+            return 3
+
+    assert isinstance(Otherwise(), Session)
+
+
+def test_something_offering_neither_half_is_not_one() -> None:
+    """Which is what a run in the process somebody typed `hmz` in is handed instead: none."""
+    assert not isinstance(object(), Session)
+
+
+def test_something_offering_only_half_of_it_is_not_one() -> None:
+    """Being able to count the terminals is no use where they cannot be let go of."""
+
+    class Counting:
+        @property
+        def attached(self) -> int:
+            return 1
+
+    assert not isinstance(Counting(), Session)

--- a/tests/supervising.py
+++ b/tests/supervising.py
@@ -13,9 +13,13 @@ answers: a container without `CAP_SYS_PTRACE` has every module and can supervise
 :data:`WITHOUT` is that answer, and :data:`traced` is the mark that leaves a test out where
 it is no.
 
-Here rather than beside the supervisor's own tests because a conftest needs the answer too --
-the anchored suites skip a fixture on it -- and a conftest is a pytest plugin rather than a
-module to import from, so it cannot be the one that holds it.
+Here rather than beside the supervisor's own tests because most of what asks is somewhere
+else. A turn run as a named account is a supervised turn -- the paths that turn reads are
+answered by others, which is what the filter and the tracer are for -- so the accounts, the
+catalogues kept per account, an epic naming the account a session ran as and a flow running
+one CLI as two of them all ask this before they ask for one. A conftest asks too, and a
+conftest is a pytest plugin rather than a module to import from, so it cannot be the one that
+holds it.
 """
 
 from __future__ import annotations

--- a/tests/supervising.py
+++ b/tests/supervising.py
@@ -1,0 +1,105 @@
+"""Whether the machine running the suite can supervise a program, and how one is spawned.
+
+Two questions, and they are not the same one.
+
+The first is whether the bindings import at all. :mod:`hmz.coganchor.linux` opens `libc.so.6`
+and picks a register map at import time, refusing anything but x86-64, so a test module that
+names those bindings cannot be *collected* anywhere else -- a skip written inside it would
+never be reached, because the import above it raises first. :data:`WITHOUT_BINDINGS` is what
+such a module asks before importing them.
+
+The second is whether this kernel will really hand over a tracee, which only running one
+answers: a container without `CAP_SYS_PTRACE` has every module and can supervise nothing.
+:data:`WITHOUT` is that answer, and :data:`traced` is the mark that leaves a test out where
+it is no.
+
+Here rather than beside the supervisor's own tests because a conftest needs the answer too --
+the anchored suites skip a fixture on it -- and a conftest is a pytest plugin rather than a
+module to import from, so it cannot be the one that holds it.
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+#: What the machine itself is signed in as, which a turn under a provider must never see.
+MACHINE = '{"token": "the one at this machine"}'
+
+#: What the provider is signed in as, which is what every read below has to come back with.
+PROVIDER = '{"token": "the provider"}'
+
+#: How long a supervised program is given before the run is taken to have hung.
+PATIENCE = 45
+
+
+def cred(
+    argv: list[str], *, stdin: str = "", timeout: int = PATIENCE
+) -> subprocess.CompletedProcess[str]:
+    """Runs `hmz cred` as a turn under a provider runs it: its own process, on its own.
+
+    Args:
+      argv: What follows the command name -- the swaps, `--`, and the program.
+      stdin: What to write to the program's standard input.
+      timeout: How long to wait before taking the run to have hung.
+
+    Returns:
+      What the run came to, with its output read back.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "hmz", "cred", *argv],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _cannot_import() -> str:
+    """Why the Linux bindings will not import here, or "" where they will.
+
+    Asked of the platform rather than by importing them, because the caller is a module that
+    has not imported them yet and wants to know whether it may.
+    """
+    if sys.platform != "linux":
+        return "a redirected run is a Linux seccomp filter and a ptrace supervisor"
+    if platform.machine() != "x86_64":
+        return f"the register map is x86-64 only, and this host is {platform.machine()}"
+    return ""
+
+
+#: Why a module that names :mod:`hmz.coganchor.linux` cannot be imported here, or "" where it
+#: can. A module gated on this skips itself before reaching for the bindings.
+WITHOUT_BINDINGS = _cannot_import()
+
+
+def _cannot_trace() -> str:
+    """Why a redirected run cannot be watched on this machine, or "" where one can.
+
+    Answered by running one: the modules import on any x86-64 Linux, and whether the kernel
+    will hand over a tracee is a question only the attempt asks.
+    """
+    if WITHOUT_BINDINGS:
+        return WITHOUT_BINDINGS
+    with tempfile.TemporaryDirectory() as folder:
+        named, instead = Path(folder) / "named", Path(folder) / "instead"
+        named.write_text(MACHINE)
+        instead.write_text(PROVIDER)
+        try:
+            done = cred([f"--map={named}={instead}", "--", "cat", str(named)])
+        except (OSError, subprocess.SubprocessError) as why:
+            return f"a supervisor could not be started here: {why}"
+    if done.stdout != PROVIDER:
+        return f"nothing is traced here: {done.stderr.strip() or done.returncode}"
+    return ""
+
+
+#: Why the end-to-end tests cannot run here, and the mark that leaves them out when so.
+WITHOUT = _cannot_trace()
+traced = pytest.mark.skipif(bool(WITHOUT), reason=WITHOUT or "this machine can trace")

--- a/tests/test_builtin_flows.py
+++ b/tests/test_builtin_flows.py
@@ -28,7 +28,7 @@ import pytest
 from hmz.agents import AgentConfig, Stopped, Usage
 from hmz.epic import STATE, epics, state
 from hmz.flows import resumes
-from hmz.flows.builtin import ralph_loop, stateful_ralph
+from hmz.flows.builtin import chat, ralph_loop, stateful_ralph
 from hmz.runner import Runner
 from tests.stubs import ShellAgent
 
@@ -42,6 +42,11 @@ CONFIG = AgentConfig(model="m", effort="high")
 
 #: What the agents are set to do, which the stand-in runs as the shell command it is.
 TASK = "echo working"
+#: The conversation, by the name `-f` takes. Imported above as the loops are rather than
+#: written out here: a flow is loaded from its file when it is run, and a module nothing
+#: imported is one coverage never sees run -- so the flow the interface opens on read as
+#: untouched while these tests were driving it.
+CHAT = chat.__name__.rpartition(".")[2]
 
 #: A turn that cannot be taken at all, which is what an account the backend refused looks like
 #: from inside a flow: under `suppress` it answers with nothing and spends nothing, so a budget
@@ -253,7 +258,7 @@ def test_the_loops_can_be_picked_up_and_the_conversation_cannot(
 
     assert resumes("ralph_loop")
     assert resumes("stateful_ralph")
-    assert not resumes("chat")
+    assert not resumes(CHAT)
 
 
 @pytest.mark.timeout(60)
@@ -263,7 +268,7 @@ def test_a_run_of_chat_leaves_nothing_behind_to_pick_up(
     """What was said is the backend's log, and nobody is at the prompt to say more."""
     monkeypatch.chdir(tmp_path)
 
-    Runner("chat", [ShellAgent(CONFIG)]).run(TASK)
+    Runner(CHAT, [ShellAgent(CONFIG)]).run(TASK)
 
     (epic,) = epics()
     assert not (epic / STATE).exists()
@@ -283,7 +288,7 @@ def test_a_chat_whose_opening_turn_cannot_be_taken_says_so(
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(subprocess.CalledProcessError):
-        Runner("chat", [ShellAgent(CONFIG)]).run(FAILS)
+        Runner(CHAT, [ShellAgent(CONFIG)]).run(FAILS)
 
 
 @pytest.mark.timeout(60)

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -19,6 +19,7 @@ from hmz.agents import AgentConfig, Stopped
 from hmz.epic import JOURNAL, called, epics, linked, opened, read, sessions
 from hmz.runner import Runner
 from tests.stubs import ShellAgent, events, written
+from tests.supervising import traced
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -220,6 +221,7 @@ def test_a_session_is_named_for_whose_it_is_what_ran_it_and_which_account(
     assert one.name == called("builder", "claude", "", "the-session")
 
 
+@traced
 def test_a_session_says_which_account_took_its_turns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -21,6 +21,7 @@ from hmz.epic import epics, sessions
 from hmz.exporting import MANIFEST, REDACTED, TRANSCRIPT, bundle, logged, plain, sized
 from hmz.runner import Runner
 from tests.stubs import ShellAgent, written
+from tests.supervising import traced
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -238,6 +239,7 @@ def test_a_backend_that_logs_nothing_says_so_rather_than_carrying_nothing(
     assert said["backends"]["opencode"]["logs"] is False
 
 
+@traced
 def test_no_account_variable_rides_along(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,7 @@ import pytest
 
 from hmz import backends, models, providers
 from hmz.backends import named
+from tests.supervising import traced
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -293,6 +294,7 @@ def test_claude_keeps_the_alias_of_a_custom_model(
     assert environment["ANTHROPIC_CUSTOM_MODEL_OPTION"] == "fable"
 
 
+@traced
 @pytest.mark.parametrize("provider", ["", "subscribed"])
 def test_claude_is_never_asked_about_a_model_humanize_thought_of(
     provider: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -477,6 +479,7 @@ def test_a_catalogue_written_by_something_else_is_no_catalogue(
     assert models.offered("codex") == ()
 
 
+@traced
 def test_two_accounts_of_one_backend_are_two_catalogues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -496,6 +499,7 @@ def test_two_accounts_of_one_backend_are_two_catalogues(
     assert models.offered("codex", "mine") == ()
 
 
+@traced
 def test_what_an_account_runs_is_kept_with_the_account(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -509,6 +513,7 @@ def test_what_an_account_runs_is_kept_with_the_account(
     assert models.offered("codex", "mine") == ()
 
 
+@traced
 def test_an_account_is_asked_under_its_own_credentials_and_without_anybody_elses(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -717,6 +722,7 @@ def test_an_endpoint_written_with_its_version_is_not_asked_for_a_second_one(
     assert [path for path, _ in asked] == ["/v1/models"]
 
 
+@traced
 def test_an_account_that_names_no_endpoint_is_asked_of_its_cli(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -737,6 +743,7 @@ def test_an_account_that_names_no_endpoint_is_asked_of_its_cli(
         ("<html>somebody else's login page</html>", 200),
     ],
 )
+@traced
 def test_an_endpoint_that_will_not_say_leaves_the_cli_to_answer(
     body: str, status: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -754,6 +761,7 @@ def test_an_endpoint_that_will_not_say_leaves_the_cli_to_answer(
     assert [model.name for model in found] == ["claude-nine", "claude-quick"]
 
 
+@traced
 def test_an_endpoint_nothing_is_listening_at_leaves_the_cli_to_answer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -791,6 +799,7 @@ def test_the_accounts_own_credential_is_sent_and_never_written_down(
     assert "the-secret" not in models.where("claude", "gateway").read_text("utf-8")
 
 
+@traced
 def test_a_backend_whose_ids_are_a_providers_is_never_asked_an_endpoint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -813,6 +822,7 @@ def test_a_backend_whose_ids_are_a_providers_is_never_asked_an_endpoint(
     assert asked == []
 
 
+@traced
 def test_the_credential_does_not_follow_a_redirect_to_another_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import socketserver
 import subprocess
 import sys
 import threading
@@ -661,7 +662,19 @@ def endpoint(
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             """Nothing: a suite is not somewhere a web server keeps a log."""
 
-    running = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    class Serving(ThreadingHTTPServer):
+        """The same, without the reverse lookup it names itself by.
+
+        On a machine whose resolver has nothing to say about `127.0.0.1` that lookup blocks
+        for the resolver's own timeout, which is half a minute.
+        """
+
+        def server_bind(self) -> None:
+            socketserver.TCPServer.server_bind(self)
+            host, port = self.server_address[:2]
+            self.server_name, self.server_port = str(host), int(port)
+
+    running = Serving(("127.0.0.1", 0), Handler)
     reader = threading.Thread(target=running.serve_forever, daemon=True)
     reader.start()
     try:

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -8,7 +8,10 @@ spent in tokens without inventing a bill of nothing.
 
 from __future__ import annotations
 
+import http.server
 import json
+import socket
+import threading
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -351,3 +354,167 @@ def test_a_bill_is_written_to_what_can_be_read_at_a_glance(
 ) -> None:
     """And to four places under a cent: a tenth of one is still something spent."""
     assert prices.money(dollars) == said
+
+
+# ------------------------------------------------- the half that speaks to a source
+
+#: What the served document says, so a test can tell a fetched list from a written one.
+_SERVED = "served-over-http"
+
+
+class _Source:
+    """A price list served over HTTP, on a port of this machine's own.
+
+    The one path the rest of this file does not take: `HUMANIZE_PRICES` points at a file
+    everywhere else, which is the same path the real fetch takes *once the bytes are in
+    hand*. Getting the bytes is what this is about -- the conditional request, the answer
+    that says nothing has changed, and the schemes a price list may not come over.
+
+    Nothing here leaves the machine: it is `127.0.0.1` and whichever port the kernel hands
+    out.
+    """
+
+    def __init__(self, body: bytes, etag: str) -> None:
+        self.body = body
+        self.etag = etag
+        #: What each request carried, for a test about the request rather than the answer.
+        self.asked: list[dict[str, str]] = []
+        outer = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                outer.asked.append(dict(self.headers))
+                if outer.etag and self.headers.get("If-None-Match") == outer.etag:
+                    self.send_response(304)
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                if outer.etag:
+                    self.send_header("ETag", outer.etag)
+                self.send_header("Content-Length", str(len(outer.body)))
+                self.end_headers()
+                self.wfile.write(outer.body)
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+                """Nothing: a suite is not a place for an access log."""
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host!s}:{port}/prices.json"
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+
+
+@pytest.fixture
+def served() -> Any:
+    """A price list served over HTTP, taken down however the test ends."""
+    made: list[_Source] = []
+
+    def one(document: dict[str, Any] | None = None, etag: str = "") -> _Source:
+        held = _Source(
+            json.dumps(document or _listing(_model(_SERVED, input_tokens=1))).encode(),
+            etag,
+        )
+        made.append(held)
+        return held
+
+    yield one
+    for held in made:
+        held.close()
+
+
+@pytest.mark.timeout(60)
+def test_a_list_is_fetched_from_where_it_is_served(
+    served: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = served()
+    monkeypatch.setenv(prices.WHENCE, source.url)
+    prices._tried = 0.0
+
+    assert prices.refresh(wait=True)
+
+    assert prices.price(_SERVED) is not None
+
+
+@pytest.mark.timeout(60)
+def test_what_came_back_is_the_body_and_the_tag_to_ask_with_next_time(
+    served: Any,
+) -> None:
+    source = served(etag='"the-first-one"')
+
+    body, etag = prices._over_http(source.url, "")
+
+    assert json.loads(body)["currency"] == "USD"
+    assert etag == '"the-first-one"'
+
+
+@pytest.mark.timeout(60)
+def test_a_tag_already_here_is_what_the_source_is_asked_with(served: Any) -> None:
+    """Conditional, so that a list nobody has changed is not fetched again every day."""
+    source = served(etag='"the-first-one"')
+
+    with pytest.raises(prices._Unchanged):
+        prices._over_http(source.url, '"the-first-one"')
+
+    assert source.asked[-1]["If-None-Match"] == '"the-first-one"'
+
+
+@pytest.mark.timeout(60)
+def test_a_source_that_has_something_newer_answers_with_it(served: Any) -> None:
+    source = served(etag='"the-second-one"')
+
+    body, etag = prices._over_http(source.url, '"the-first-one"')
+
+    assert body
+    assert etag == '"the-second-one"'
+
+
+@pytest.mark.timeout(60)
+def test_a_source_that_says_nothing_has_changed_leaves_what_was_kept_serving(
+    served: Any, listed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which is the whole point of asking conditionally: the answer costs nothing."""
+    listed(_model("kept-from-before", input_tokens=2))
+    source = served(etag='"the-first-one"')
+    monkeypatch.setenv(prices.WHENCE, source.url)
+    prices._tried = 0.0
+    assert prices.refresh(wait=True)  # which keeps the etag beside what it fetched
+    prices._tried = 0.0
+
+    assert prices.refresh(wait=True)
+
+    assert prices.price(_SERVED) is not None
+
+
+@pytest.mark.parametrize("whence", ["file:///etc/passwd", "ftp://example.invalid/x"])
+def test_a_price_list_may_not_come_over_anything_but_http(whence: str) -> None:
+    """A source is read out of the environment, and a URL is not only ever a URL."""
+    with pytest.raises(ValueError, match="prices come over http"):
+        prices._over_http(whence, "")
+
+
+@pytest.mark.timeout(60)
+def test_a_source_that_is_not_answering_leaves_what_was_kept_serving(
+    listed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing here may fail a run: a price list that could stop one is worth less than none."""
+    listed(_model("kept-from-before", input_tokens=2))
+    # A port on the loopback with nothing behind it, which refuses at once rather than hangs.
+    with socket.socket() as spare:
+        spare.bind(("127.0.0.1", 0))
+        nobody = spare.getsockname()[1]
+    monkeypatch.setenv(prices.WHENCE, f"http://127.0.0.1:{nobody}/prices.json")
+    prices._tried = 0.0
+
+    assert not prices.refresh(wait=True)
+
+    assert prices.price("kept-from-before") is not None

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import http.server
 import json
 import socket
+import socketserver
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -399,7 +400,19 @@ class _Source:
             def log_message(self, format: str, *args: object) -> None:  # noqa: A002
                 """Nothing: a suite is not a place for an access log."""
 
-        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        class Serving(http.server.ThreadingHTTPServer):
+            """The same, without the reverse lookup it names itself by.
+
+            On a machine whose resolver has nothing to say about `127.0.0.1` that lookup
+            blocks for the resolver's own timeout, which is half a minute.
+            """
+
+            def server_bind(self) -> None:
+                socketserver.TCPServer.server_bind(self)
+                host, port = self.server_address[:2]
+                self.server_name, self.server_port = str(host), int(port)
+
+        self._server = Serving(("127.0.0.1", 0), Handler)
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -8,7 +8,7 @@ path of theirs, no key. The rest is the plumbing that lets a report say what was
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -409,9 +409,8 @@ def test_a_document_is_scrubbed_value_by_value_rather_than_whole() -> None:
     """
     long_enough = "x" * (telemetry._LONG - 10)
 
-    said = telemetry._plainly([long_enough, long_enough, long_enough])
+    said = cast("list[Any]", telemetry._plainly([long_enough] * 3))
 
-    assert isinstance(said, list)
     assert len(said) == 3
     assert all(one == long_enough for one in said)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -359,3 +359,63 @@ def test_a_workspace_may_be_forgotten_without_forgetting_anything_else(
         Settings(tmp_path).enable_sentry is False
     )  # and so is what is true everywhere
     assert not Settings(tmp_path).forget()  # nothing left to forget
+
+
+def test_every_string_inside_what_a_layer_answered_is_scrubbed_too() -> None:
+    """A layer answers with a structure, and a secret is as easily three levels down."""
+    said = telemetry._plainly(
+        {
+            "flow": "https://user:hunter2@example.com/x",
+            "agents": [
+                {
+                    "backend": "claude",
+                    "key": "the key is sk-ant-api03-abcdefghijklmnop",
+                },
+                "https://x-access-token:ghp_abcdefghijklmnop@github.com/org/repo",
+            ],
+        }
+    )
+
+    written = repr(said)
+    assert "hunter2" not in written
+    assert "sk-ant-api03" not in written
+    assert "ghp_" not in written
+    assert "claude" in written  # and what is not a secret is still there to read
+
+
+def test_the_names_of_what_a_layer_answered_are_scrubbed_as_well_as_the_values() -> (
+    None
+):
+    """A key is as easily the name of a field as the value of one."""
+    said = telemetry._plainly({"https://user:hunter2@example.com/x": "ordinary"})
+
+    assert "hunter2" not in repr(said)
+
+
+def test_what_is_not_a_string_is_left_as_it_is() -> None:
+    """Numbers and flags are what a report is read for; scrubbing them would say nothing."""
+    said = telemetry._plainly(
+        {"turns": 3, "profiled": True, "cost": 1.25, "none": None}
+    )
+
+    assert said == {"turns": 3, "profiled": True, "cost": 1.25, "none": None}
+
+
+def test_a_document_is_scrubbed_value_by_value_rather_than_whole() -> None:
+    """Value by value, not over the document.
+
+    Scrubbed as one string it could be cut in half by the length limit, and half a YAML
+    file is a file nobody can read.
+    """
+    long_enough = "x" * (telemetry._LONG - 10)
+
+    said = telemetry._plainly([long_enough, long_enough, long_enough])
+
+    assert isinstance(said, list)
+    assert len(said) == 3
+    assert all(one == long_enough for one in said)
+
+
+def test_a_tuple_a_layer_answered_with_is_a_list_by_the_time_it_is_written() -> None:
+    """YAML has no tuple, so one that stayed a tuple would be a document that will not write."""
+    assert telemetry._plainly(("one", "two")) == ["one", "two"]

--- a/tests/test_together.py
+++ b/tests/test_together.py
@@ -24,6 +24,7 @@ from hmz.coganchor import AnchorConfig
 from hmz.machines import AnchoredConfig
 from tests.coganchor.conftest import VIRTUAL_WORKSPACE
 from tests.stubs import written
+from tests.supervising import traced
 from tests.tracing.conftest import labels
 
 if TYPE_CHECKING:
@@ -139,6 +140,7 @@ def test_a_flow_is_traced_as_the_agents_it_ran(
     }
 
 
+@traced
 @pytest.mark.timeout(180)
 def test_an_anchored_flow_leaves_its_work_there_and_its_trajectory_here(
     sandbox: Path, tmp_path: Path
@@ -186,6 +188,7 @@ def test_an_anchored_flow_leaves_its_work_there_and_its_trajectory_here(
     }
 
 
+@traced
 @pytest.mark.timeout(180)
 def test_one_flow_runs_two_agents_of_one_cli_as_two_accounts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_tools_command.py
+++ b/tests/test_tools_command.py
@@ -1,0 +1,224 @@
+"""`hmz tools`: the pipe a coding agent speaks the tool protocol over, relayed to a flow.
+
+A callback of a flow's is a Python function in the flow's own process, and a CLI takes a tool
+by starting a program and talking to it over that program's stdin and stdout. This is that
+program, and it is spawned rather than typed -- which is why it is checked here rather than
+found by driving a real agent, where it is one moving part of many and only runs at all when
+somebody has a backend installed.
+
+What it owes its two ends: every line goes both ways, a line goes as soon as it is written
+rather than when a buffer fills, closing either end closes the other, and a socket that is not
+there is a flow that has ended rather than a turn that failed.
+
+The socket is bound by a bare name from inside its own directory. A Unix socket address holds
+about a hundred bytes whole -- 104 on macOS -- and the directory pytest hands out is longer
+than that, which is the same thing `hmz.daemon.where` does and for the same reason.
+"""
+
+from __future__ import annotations
+
+import io
+import socket
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.cli.tools import _moves, tools
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+#: What the socket is called inside the directory the test stands in.
+SOCKET = "tools.sock"
+
+
+class _Stdin:
+    """Stands in for `sys.stdin`, which the relay reaches through `.buffer`."""
+
+    def __init__(self, said: bytes) -> None:
+        self.buffer = io.BytesIO(said)
+
+
+class _Stdout:
+    """The same for `sys.stdout`, holding what the relay wrote back."""
+
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def said(self) -> bytes:
+        return self.buffer.getvalue()
+
+
+@pytest.fixture
+def flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[socket.socket]:
+    """A flow serving its callbacks on a socket, stood beside so the name alone reaches it."""
+    monkeypatch.chdir(tmp_path)
+    listening = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listening.bind(SOCKET)
+    listening.listen(1)
+    try:
+        yield listening
+    finally:
+        listening.close()
+
+
+def _cli(said: bytes, monkeypatch: pytest.MonkeyPatch) -> _Stdout:
+    """Stands the CLI's two streams in front of the relay, and hands back what it hears.
+
+    Called from the test body rather than out of a fixture: pytest puts its own capture back
+    over `sys.stdout` when it resumes capturing for the call, so a stand-in installed during
+    setup is one the relay never sees.
+
+    Args:
+      said: What the CLI writes to the flow.
+      monkeypatch: The test's own, so both streams go back however the test ends.
+
+    Returns:
+      What the relay wrote back to the CLI.
+    """
+    out = _Stdout()
+    monkeypatch.setattr("sys.stdin", _Stdin(said))
+    monkeypatch.setattr("sys.stdout", out)
+    return out
+
+
+def _answers(listening: socket.socket, replies: list[bytes]) -> threading.Thread:
+    """A flow that reads a line, says each of these back, and lets go.
+
+    Returns:
+      The thread it is running on, already started.
+    """
+
+    def serve() -> None:
+        held, _ = listening.accept()
+        with held, held.makefile("rb") as reading, held.makefile("wb") as writing:
+            reading.readline()
+            for said in replies:
+                writing.write(said)
+                writing.flush()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.mark.timeout(30)
+def test_a_line_the_cli_writes_reaches_the_flow_and_the_answer_comes_back(
+    flow: socket.socket, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which is the whole errand: the function runs where the flow is, not in a process here."""
+    heard: list[bytes] = []
+
+    def serve() -> None:
+        held, _ = flow.accept()
+        with held, held.makefile("rb") as reading, held.makefile("wb") as writing:
+            heard.append(reading.readline())
+            writing.write(b'{"result": "done"}\n')
+            writing.flush()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    ends = _cli(b'{"call": "one"}\n', monkeypatch)
+
+    assert tools(["--at", SOCKET]) == 0
+
+    thread.join(timeout=10)
+    assert heard == [b'{"call": "one"}\n']
+    assert ends.said() == b'{"result": "done"}\n'
+
+
+@pytest.mark.timeout(30)
+def test_a_flow_may_say_something_before_it_is_asked(
+    flow: socket.socket, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both ways at once, so neither end waits on the other."""
+    thread = _answers(flow, [b'{"note": "first"}\n', b'{"note": "second"}\n'])
+    ends = _cli(b'{"call": "one"}\n', monkeypatch)
+
+    assert tools(["--at", SOCKET]) == 0
+
+    thread.join(timeout=10)
+    assert ends.said() == b'{"note": "first"}\n{"note": "second"}\n'
+
+
+@pytest.mark.timeout(30)
+def test_the_cli_closing_its_end_closes_the_one_the_flow_is_reading(
+    flow: socket.socket, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without saying so the flow sits reading a socket nobody is going to write to."""
+    ended = threading.Event()
+
+    def serve() -> None:
+        held, _ = flow.accept()
+        with held, held.makefile("rb") as reading:
+            while reading.readline():
+                pass
+            # Read to the end rather than blocked partway, which is what is being checked.
+            ended.set()
+
+    threading.Thread(target=serve, daemon=True).start()
+    _cli(b'{"call": "one"}\n', monkeypatch)
+
+    assert tools(["--at", SOCKET]) == 0
+
+    assert ended.wait(timeout=10)
+
+
+@pytest.mark.timeout(30)
+def test_a_socket_that_is_not_there_is_a_flow_that_has_ended(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One rather than a crash: the CLI reads it as tools unavailable, not a failed turn."""
+    monkeypatch.chdir(tmp_path)
+
+    assert tools(["--at", "nobody-is-serving-this.sock"]) == 1
+
+    said = capsys.readouterr().err
+    assert "hmz tools" in said
+    assert "nobody-is-serving-this.sock" in said
+
+
+def test_the_socket_to_relay_to_has_to_be_said() -> None:
+    """It is spawned rather than typed, so there is no sensible default to fall back on."""
+    with pytest.raises(SystemExit) as stopped:
+        tools([])
+
+    assert stopped.value.code == 2
+
+
+def test_a_line_goes_as_soon_as_it_is_written_rather_than_when_a_buffer_fills() -> None:
+    """The protocol is one JSON object per line, and a held line is a request held."""
+    written: list[bytes] = []
+
+    class Watching(io.BytesIO):
+        def flush(self) -> None:
+            written.append(self.getvalue())
+
+    source = io.BytesIO(b'{"one": 1}\n{"two": 2}\n')
+    sink = Watching()
+
+    _moves(source, sink)
+
+    assert written == [b'{"one": 1}\n', b'{"one": 1}\n{"two": 2}\n']
+
+
+def test_carrying_stops_where_the_stream_does_rather_than_raising() -> None:
+    """Either end going is the ordinary way this ends, and is not something to report."""
+    source = io.BytesIO(b"")
+    sink = io.BytesIO()
+
+    _moves(source, sink)
+
+    assert sink.getvalue() == b""
+
+
+def test_a_stream_that_is_already_closed_is_the_same_as_one_that_ended() -> None:
+    source = io.BytesIO(b'{"one": 1}\n')
+    source.close()
+    sink = io.BytesIO()
+
+    _moves(source, sink)
+
+    assert sink.getvalue() == b""

--- a/tests/tracing/test_codex_items.py
+++ b/tests/tracing/test_codex_items.py
@@ -1,0 +1,277 @@
+"""The rollout items a Codex thread can hold that the shared fixture does not.
+
+`test_collect.py` reads one realistic thread end to end, which covers the spine -- the
+session meta, a turn, a reasoning summary, a shell call and its output. What it does not
+hold is the rest of the vocabulary: a web search, an applied patch, a sub-agent's activity,
+a context that was compacted, and the token counts a turn is billed by.
+
+Each is written here on its own, against a rollout built for it, so that a reader which
+quietly stopped recognising one of them is a failing test rather than a trace with a hole
+in it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from hmz.tracing.readers import codex
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from hmz.tracing.session import Action, Session
+
+#: The thread every rollout below is written under.
+THREAD = "01998f1a-0000-7000-8000-00000000beef"
+
+#: The moment a rollout starts, as Codex writes one.
+_BEGAN = 1_780_000_000.0
+
+
+def _stamp(seconds: float) -> str:
+    """One moment, as a Codex rollout spells it."""
+    import datetime
+
+    return (
+        datetime.datetime.fromtimestamp(_BEGAN + seconds, tz=datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+@pytest.fixture
+def rollout(
+    tmp_path: pathlib.Path,
+) -> Any:
+    """Writes one thread out of the records handed in, and reads it back.
+
+    Returns:
+      A callable taking the records after the session meta and the turn context, and
+      answering with the one session that came of them.
+    """
+    home = tmp_path / "codex"
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    def written(*records: dict[str, Any]) -> Session:
+        at = home / "sessions" / "2026" / "07" / "20"
+        at.mkdir(parents=True, exist_ok=True)
+        head = [
+            {
+                "timestamp": _stamp(0),
+                "type": "session_meta",
+                "payload": {
+                    "id": THREAD,
+                    "cwd": str(workspace),
+                    "cli_version": "0.5.0",
+                    "originator": "cli",
+                },
+            },
+            {
+                "timestamp": _stamp(0),
+                "type": "turn_context",
+                "payload": {"model": "gpt-5.6", "effort": "high"},
+            },
+            {
+                "timestamp": _stamp(1),
+                "type": "event_msg",
+                "payload": {"type": "task_started", "turn_id": "turn-1"},
+            },
+        ]
+        (at / f"rollout-2026-07-20T10-00-00-{THREAD}.jsonl").write_text(
+            "\n".join(json.dumps(one) for one in [*head, *records]) + "\n",
+            encoding="utf-8",
+        )
+        (one,) = codex.collect(home, workspace, None, (float("-inf"), float("inf")))
+        return one
+
+    return written
+
+
+def _named(session: Session, starting: str) -> Action:
+    """The one action whose name starts like this, for a test about that action."""
+    found = [one for one in session.actions if one.name.startswith(starting)]
+    assert len(found) == 1, [one.name for one in session.actions]
+    return found[0]
+
+
+def test_a_web_search_is_the_query_it_was_made_with(rollout: Any) -> None:
+    said = rollout(
+        {
+            "timestamp": _stamp(4),
+            "type": "response_item",
+            "payload": {
+                "type": "web_search_call",
+                "action": {"type": "search", "query": "how to port a module"},
+            },
+        }
+    )
+
+    found = _named(said, "web_search")
+
+    assert "how to port a module" in found.name
+    assert found.args["tool"] == "web_search"
+
+
+def test_a_patch_that_was_applied_says_which_files_it_touched(rollout: Any) -> None:
+    said = rollout(
+        {
+            "timestamp": _stamp(5),
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "changes": {"one.py": {"update": {}}, "two.py": {"add": {}}},
+                "stdout": "Success. Updated the following files:",
+                "success": True,
+            },
+        }
+    )
+
+    found = _named(said, "apply_patch")
+
+    assert "one.py" in found.name
+    assert "two.py" in found.name
+    assert found.args["success"] is True
+
+
+def test_what_a_sub_agent_did_is_written_down_as_the_agent_that_did_it(
+    rollout: Any,
+) -> None:
+    said = rollout(
+        {
+            "timestamp": _stamp(6),
+            "type": "event_msg",
+            "payload": {
+                "type": "sub_agent_activity",
+                "kind": "started",
+                "agent_path": "reviewer",
+            },
+        }
+    )
+
+    found = _named(said, "agent started")
+
+    assert "reviewer" in found.name
+    assert found.category == "event"
+
+
+def test_a_context_that_was_compacted_is_an_event_on_the_timeline(rollout: Any) -> None:
+    """A turn that forgot most of what it knew is the explanation for the next one."""
+    said = rollout(
+        {
+            "timestamp": _stamp(7),
+            "type": "event_msg",
+            "payload": {"type": "context_compacted"},
+        }
+    )
+
+    assert _named(said, "system: context_compacted").category == "event"
+
+
+def test_what_a_turn_spent_is_read_off_the_count_it_was_told(rollout: Any) -> None:
+    said = rollout(
+        {
+            "timestamp": _stamp(3),
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "read the module"}],
+            },
+        },
+        {
+            "timestamp": _stamp(4),
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {"input_tokens": 120, "output_tokens": 34}
+                },
+            },
+        },
+    )
+
+    found = _named(said, "think")
+
+    assert found.args["usage"] == {"input_tokens": 120, "output_tokens": 34}
+
+
+def test_reasoning_said_outside_a_summary_joins_the_thinking_it_belongs_to(
+    rollout: Any,
+) -> None:
+    """Codex says a thought twice: the summary, and the reasoning behind it."""
+    said = rollout(
+        {
+            "timestamp": _stamp(3),
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "read the module"}],
+            },
+        },
+        {
+            "timestamp": _stamp(4),
+            "type": "event_msg",
+            "payload": {"type": "agent_reasoning", "text": "and then port it"},
+        },
+    )
+
+    found = _named(said, "think")
+
+    assert "read the module" in found.args["reasoning"]
+    assert "and then port it" in found.args["reasoning"]
+
+
+def test_a_tool_call_nothing_answered_is_marked_as_the_one_that_did_not_finish(
+    rollout: Any,
+) -> None:
+    """A run killed mid-call leaves one open, and a trace that hid it would read as done."""
+    said = rollout(
+        {
+            "timestamp": _stamp(4),
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "call_id": "call-shell",
+                "arguments": json.dumps({"command": "sleep 600"}),
+            },
+        }
+    )
+
+    found = _named(said, "shell")
+
+    assert found.args["unfinished"] is True
+
+
+def test_a_tool_call_that_was_answered_carries_what_it_answered_with(
+    rollout: Any,
+) -> None:
+    said = rollout(
+        {
+            "timestamp": _stamp(4),
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "call_id": "call-shell",
+                "arguments": json.dumps({"command": "cat one.py"}),
+            },
+        },
+        {
+            "timestamp": _stamp(5),
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call-shell",
+                "output": "the file's contents",
+            },
+        },
+    )
+
+    found = _named(said, "shell")
+
+    assert "the file's contents" in found.args["output"]
+    assert "unfinished" not in found.args

--- a/tests/tracing/test_profile.py
+++ b/tests/tracing/test_profile.py
@@ -52,7 +52,12 @@ def test_the_programs_a_run_starts_are_written_down(tmp_path: pathlib.Path) -> N
     # Two commands rather than one, and the second a builtin that starts nothing. A shell
     # given a single simple command may `exec` it and cease to be a process of its own, which
     # one of these systems does and the other does not -- and this test is about the shell.
-    said = "sleep 0.4; :"
+    #
+    # A whole second of it, for the reason the sampled flow beside this file runs for one: a
+    # program that lives for a handful of sample periods is a program a loaded machine misses
+    # altogether, and a test of the sampler must not be a test of what else the machine is
+    # doing.
+    said = "sleep 1; :"
     held = _ran(tmp_path, "sh", "-c", said)
 
     # By the tail of what it was started with, since the head of it is the platform's: one
@@ -75,7 +80,9 @@ def test_a_program_is_written_down_as_it_goes_rather_than_at_the_end(
     one = Profiler(tmp_path / PROFILE, every=0.01)
     one.start()
     try:
-        said = "sleep 0.1; :"  # two, so the shell does not `exec` the one and vanish
+        # Two, so the shell does not `exec` the one and vanish -- and a second of it, so the
+        # sampler has a hundred goes at seeing it rather than ten.
+        said = "sleep 1; :"
         subprocess.run(["sh", "-c", said], check=False, capture_output=True)
         time.sleep(0.1)
         # Nothing has stopped it, and the program it saw is already written down --

--- a/tests/tracing/test_profile.py
+++ b/tests/tracing/test_profile.py
@@ -52,7 +52,10 @@ def test_the_programs_a_run_starts_are_written_down(tmp_path: pathlib.Path) -> N
     said = "sleep 0.4"
     held = _ran(tmp_path, "sh", "-c", said)
 
-    shell = next(one for one in held if one.argv == ("sh", "-c", said))
+    # By the tail of what it was started with, since the head of it is the platform's: one
+    # system's `/bin/sh` is another's `bash`, and one of them records the path it resolved
+    # to where the other records the word that was typed.
+    shell = next(one for one in held if one.argv[-2:] == ("-c", said))
     # Timed against the clock the rest of a trace is timed by, rather than against the
     # machine's idea of when it booted -- which is out by half a second on an ordinary one.
     assert 0.2 <= shell.ended - shell.began <= 5.0
@@ -71,8 +74,9 @@ def test_a_program_is_written_down_as_it_goes_rather_than_at_the_end(
     try:
         subprocess.run(["sh", "-c", "sleep 0.1"], check=False, capture_output=True)
         time.sleep(0.1)
-        # Nothing has stopped it, and the program it saw is already written down.
-        assert any(each.name == "sh" for each in read(tmp_path))
+        # Nothing has stopped it, and the program it saw is already written down --
+        # found by what it was given rather than by what this system calls its shell.
+        assert any(each.argv[-2:] == ("-c", "sleep 0.1") for each in read(tmp_path))
     finally:
         one.stop()
 
@@ -90,7 +94,12 @@ def test_a_profile_holds_the_threads_of_what_it_saw(tmp_path: pathlib.Path) -> N
         "held.join()\n",
     )
 
-    one = next(each for each in held if each.threads)
+    one = next((each for each in held if each.threads), None)
+    if one is None:
+        # "Nothing at all where the platform will not say", which the sampler promises and
+        # which is what a system that does not hand over another program's threads gets.
+        # Asked by looking rather than by naming the system, as everything here is.
+        pytest.skip("this platform does not say what another program's threads are")
     assert len(one.threads) >= 1
     assert one.threads[0].tid == one.pid  # the one that ran main
 

--- a/tests/tracing/test_profile.py
+++ b/tests/tracing/test_profile.py
@@ -17,6 +17,7 @@ import pytest
 
 from hmz.tracing import chrome
 from hmz.tracing.profile import PROFILE, Process, Profiler, Thread, read
+from tests.sampling import sampled
 
 if TYPE_CHECKING:
     import pathlib
@@ -41,6 +42,7 @@ def _ran(at: pathlib.Path, *said: str) -> list[Process]:
     return read(at)
 
 
+@sampled
 @pytest.mark.timeout(60)
 def test_the_programs_a_run_starts_are_written_down(tmp_path: pathlib.Path) -> None:
     """Which is the whole of it: what ran, what started it, and how long it took.
@@ -72,6 +74,7 @@ def test_the_programs_a_run_starts_are_written_down(tmp_path: pathlib.Path) -> N
     assert [one.name for one in held if one.ppid == shell.pid] == ["sleep"]
 
 
+@sampled
 @pytest.mark.timeout(60)
 def test_a_program_is_written_down_as_it_goes_rather_than_at_the_end(
     tmp_path: pathlib.Path,
@@ -92,6 +95,7 @@ def test_a_program_is_written_down_as_it_goes_rather_than_at_the_end(
         one.stop()
 
 
+@sampled
 @pytest.mark.timeout(60)
 def test_a_profile_holds_the_threads_of_what_it_saw(tmp_path: pathlib.Path) -> None:
     """A track is a thread, so a program with two of them is a process with two tracks."""

--- a/tests/tracing/test_profile.py
+++ b/tests/tracing/test_profile.py
@@ -49,7 +49,10 @@ def test_the_programs_a_run_starts_are_written_down(tmp_path: pathlib.Path) -> N
     under this process, and a suite that runs flows on threads of its own has other shells
     of its own going at the same time.
     """
-    said = "sleep 0.4"
+    # Two commands rather than one, and the second a builtin that starts nothing. A shell
+    # given a single simple command may `exec` it and cease to be a process of its own, which
+    # one of these systems does and the other does not -- and this test is about the shell.
+    said = "sleep 0.4; :"
     held = _ran(tmp_path, "sh", "-c", said)
 
     # By the tail of what it was started with, since the head of it is the platform's: one
@@ -72,11 +75,12 @@ def test_a_program_is_written_down_as_it_goes_rather_than_at_the_end(
     one = Profiler(tmp_path / PROFILE, every=0.01)
     one.start()
     try:
-        subprocess.run(["sh", "-c", "sleep 0.1"], check=False, capture_output=True)
+        said = "sleep 0.1; :"  # two, so the shell does not `exec` the one and vanish
+        subprocess.run(["sh", "-c", said], check=False, capture_output=True)
         time.sleep(0.1)
         # Nothing has stopped it, and the program it saw is already written down --
         # found by what it was given rather than by what this system calls its shell.
-        assert any(each.argv[-2:] == ("-c", "sleep 0.1") for each in read(tmp_path))
+        assert any(each.argv[-2:] == ("-c", said) for each in read(tmp_path))
     finally:
         one.stop()
 

--- a/tests/tracing/test_profiled_runs.py
+++ b/tests/tracing/test_profiled_runs.py
@@ -32,14 +32,18 @@ CONFIG = AgentConfig(model="m", effort="high")
 #: what reads it is a sampler, taking one every :data:`hmz.tracing.profile.EVERY`, and a
 #: program that lives for a handful of those is one a loaded machine can miss altogether.
 #: Twenty samples is the difference between a test of the profiler and a test of the clock.
-FLOW = """
+#: What the turn runs, which is a shell running a sleep -- two programs, and the profile has
+#: to hold both.
+SAID = "sleep 1; echo the-session"
+
+FLOW = f"""
 from hmz.agents import AgentBase
 from hmz.flows import flow
 
 
 @flow
 def run(agents: tuple[AgentBase], task: str) -> None:
-    agents[0].new()("sleep 1; echo the-session")
+    agents[0].new()("{SAID}")
 """
 
 
@@ -66,7 +70,10 @@ def test_a_run_is_profiled_when_the_workspace_asks_for_it(
     ran = read(epic / PROFILE)
     assert ran, "the programs the turn ran are not in the run's profile"
     # The turn itself, which is a shell running a sleep: both are programs this run started.
-    assert {"sh", "sleep"} <= {one.name for one in ran}
+    # The shell is named by what it was given rather than by what it is called, one system's
+    # `/bin/sh` being another's `bash`; the sleep is called the same thing everywhere.
+    assert "sleep" in {one.name for one in ran}
+    assert any(one.argv[-2:] == ("-c", SAID) for one in ran)
 
 
 @pytest.mark.timeout(90)
@@ -100,7 +107,7 @@ def test_the_programs_and_the_sessions_are_one_document(
     assert int(document["otherData"]["programs"]) >= 2
     events = json.loads(output.read_text())["traceEvents"]
     names = [one["args"]["name"] for one in events if one["name"] == "process_name"]
-    assert any(name.startswith("sh · ") for name in names)
+    assert any(name.startswith("sleep · ") for name in names)
     # And the whole of it is one span of time: the programs are where the turns are, rather
     # than at some other point on the clock. Not a span with anything in it, though -- what
     # bounds it is a sampler, and a sampler that caught both of these programs in the one

--- a/tests/tracing/test_profiled_runs.py
+++ b/tests/tracing/test_profiled_runs.py
@@ -26,16 +26,16 @@ if TYPE_CHECKING:
 
 CONFIG = AgentConfig(model="m", effort="high")
 
-#: A flow whose agent runs a program, which is what a turn mostly is.
+#: What the turn runs: a shell running a sleep, which is two programs, and the profile has to
+#: hold both of them.
 #:
-#: The sleep is a second rather than the tenth of one it takes to say what is being checked:
-#: what reads it is a sampler, taking one every :data:`hmz.tracing.profile.EVERY`, and a
-#: program that lives for a handful of those is one a loaded machine can miss altogether.
-#: Twenty samples is the difference between a test of the profiler and a test of the clock.
-#: What the turn runs, which is a shell running a sleep -- two programs, and the profile has
-#: to hold both.
+#: A second rather than the tenth of one it takes to say what is being checked. What reads it
+#: is a sampler, taking one every :data:`hmz.tracing.profile.EVERY`, and a program that lives
+#: for a handful of those is one a loaded machine can miss altogether. Twenty samples is the
+#: difference between a test of the profiler and a test of the clock.
 SAID = "sleep 1; echo the-session"
 
+#: A flow whose agent runs a program, which is what a turn mostly is.
 FLOW = f"""
 from hmz.agents import AgentBase
 from hmz.flows import flow

--- a/tests/tracing/test_profiled_runs.py
+++ b/tests/tracing/test_profiled_runs.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 CONFIG = AgentConfig(model="m", effort="high")
 
 #: A flow whose agent runs a program, which is what a turn mostly is.
+#:
+#: The sleep is a second rather than the tenth of one it takes to say what is being checked:
+#: what reads it is a sampler, taking one every :data:`hmz.tracing.profile.EVERY`, and a
+#: program that lives for a handful of those is one a loaded machine can miss altogether.
+#: Twenty samples is the difference between a test of the profiler and a test of the clock.
 FLOW = """
 from hmz.agents import AgentBase
 from hmz.flows import flow
@@ -34,7 +39,7 @@ from hmz.flows import flow
 
 @flow
 def run(agents: tuple[AgentBase], task: str) -> None:
-    agents[0].new()("sleep 0.2; echo the-session")
+    agents[0].new()("sleep 1; echo the-session")
 """
 
 
@@ -97,6 +102,9 @@ def test_the_programs_and_the_sessions_are_one_document(
     names = [one["args"]["name"] for one in events if one["name"] == "process_name"]
     assert any(name.startswith("sh · ") for name in names)
     # And the whole of it is one span of time: the programs are where the turns are, rather
-    # than at some other point on the clock.
+    # than at some other point on the clock. Not a span with anything in it, though -- what
+    # bounds it is a sampler, and a sampler that caught both of these programs in the one
+    # sample gives an instant rather than a stretch, which is a fast machine rather than a
+    # wrong answer.
     began, ended = document["otherData"]["start"], document["otherData"]["end"]
-    assert began < ended
+    assert began <= ended

--- a/tests/tracing/test_profiled_runs.py
+++ b/tests/tracing/test_profiled_runs.py
@@ -19,6 +19,7 @@ from hmz.runner import Runner
 from hmz.settings import Settings
 from hmz.tracing.collector import collect
 from hmz.tracing.profile import PROFILE, read
+from tests.sampling import sampled
 from tests.stubs import ShellAgent, written
 
 if TYPE_CHECKING:
@@ -57,6 +58,7 @@ def workspace(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathli
     return tmp_path
 
 
+@sampled
 @pytest.mark.timeout(90)
 def test_a_run_is_profiled_when_the_workspace_asks_for_it(
     workspace: pathlib.Path,
@@ -87,6 +89,7 @@ def test_a_run_nobody_asked_to_profile_is_traced_and_not_profiled(
     assert not (epic / PROFILE).exists()
 
 
+@sampled
 @pytest.mark.timeout(90)
 def test_the_programs_and_the_sessions_are_one_document(
     workspace: pathlib.Path,

--- a/tests/tracing/test_reading.py
+++ b/tests/tracing/test_reading.py
@@ -10,7 +10,7 @@ others -- and the shapes that matter are the ones somebody's log turns out to ha
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from hmz.tracing.session import label, mapping, records, summarize, text_of, truncate
 
@@ -77,10 +77,9 @@ def test_a_string_that_fits_is_left_alone() -> None:
 
 
 def test_a_wide_list_says_how_many_more_there_were() -> None:
-    said = truncate(list(range(500)))
+    said = cast("list[Any]", truncate(list(range(500))))
 
-    assert isinstance(said, list)
-    assert said[-1].startswith("… (+")
+    assert str(said[-1]).startswith("… (+")
     assert len(said) < 500
 
 

--- a/tests/tracing/test_reading.py
+++ b/tests/tracing/test_reading.py
@@ -1,0 +1,186 @@
+"""The handful of readers every backend's log goes through on its way to a slice.
+
+One log format per backend, and five functions they all share: what a record is, what fits on
+a slice, what a trace may carry without becoming unloadable, what text is buried in a content
+block, and what a tool call is named after. They are exercised sideways by every reader suite
+here, which means each is covered for the shapes that backend happens to write and for no
+others -- and the shapes that matter are the ones somebody's log turns out to have.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from hmz.tracing.session import label, mapping, records, summarize, text_of, truncate
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ------------------------------------------------------------------ what a record is
+
+
+def test_a_log_is_read_a_record_at_a_time_in_the_order_it_was_written(
+    tmp_path: Path,
+) -> None:
+    at = tmp_path / "log.jsonl"
+    at.write_text('{"at": 1}\n{"at": 2}\n', encoding="utf-8")
+
+    assert [one["at"] for one in records(at)] == [1, 2]
+
+
+def test_a_line_that_is_not_a_record_is_read_past(tmp_path: Path) -> None:
+    """A log is appended to while it is being written, so the last line is often half of one."""
+    at = tmp_path / "log.jsonl"
+    at.write_text('{"at": 1}\nnot json at all\n{"at": 2}\n{"half":\n', encoding="utf-8")
+
+    assert [one["at"] for one in records(at)] == [1, 2]
+
+
+def test_a_record_that_is_not_a_mapping_is_not_a_record(tmp_path: Path) -> None:
+    at = tmp_path / "log.jsonl"
+    at.write_text('[1, 2, 3]\n"a string"\n{"at": 1}\n', encoding="utf-8")
+
+    assert [one["at"] for one in records(at)] == [1]
+
+
+# ------------------------------------------------------------- what fits on a slice
+
+
+def test_what_a_slice_is_named_is_one_line_however_many_it_was() -> None:
+    assert summarize("one\n  two\tthree ") == "one two three"
+
+
+def test_a_name_too_long_for_a_slice_is_cut_short() -> None:
+    said = summarize("x" * 200)
+
+    assert len(said) == 96
+    assert said.endswith("…")
+
+
+def test_a_name_that_fits_is_left_whole() -> None:
+    assert summarize("short enough") == "short enough"
+
+
+# ------------------------------------------ what a trace may carry and stay loadable
+
+
+def test_a_long_string_says_how_much_of_it_was_left_out() -> None:
+    said = truncate("x" * 5000)
+
+    assert said.startswith("x" * 4096)
+    assert "+904 chars" in said
+
+
+def test_a_string_that_fits_is_left_alone() -> None:
+    assert truncate("short enough") == "short enough"
+
+
+def test_a_wide_list_says_how_many_more_there_were() -> None:
+    said = truncate(list(range(500)))
+
+    assert isinstance(said, list)
+    assert said[-1].startswith("… (+")
+    assert len(said) < 500
+
+
+def test_the_strings_inside_a_structure_are_clipped_too() -> None:
+    """A trace is made unloadable by one long value as easily as by a long top-level one."""
+    said = truncate({"out": ["y" * 5000], "kept": 3}, 10)
+
+    assert said["kept"] == 3
+    assert "+4990 chars" in said["out"][0]
+
+
+def test_the_names_inside_a_structure_come_back_as_strings() -> None:
+    """JSON has no integer key, and a trace is JSON before anybody reads it."""
+    assert truncate({1: "one"}) == {"1": "one"}
+
+
+def test_what_is_neither_a_string_nor_a_container_is_left_as_it_is() -> None:
+    assert truncate(7) == 7
+    assert truncate(None) is None
+    assert truncate(True) is True
+
+
+# -------------------------------------------------------------- reading a log field
+
+
+def test_a_field_that_is_a_mapping_is_read_as_one() -> None:
+    assert mapping({"one": 1}) == {"one": 1}
+
+
+def test_a_field_that_is_anything_else_is_read_as_an_absent_one() -> None:
+    """Every backend writes a field it sometimes omits, and a reader must not stop for it."""
+    assert mapping(None) == {}
+    assert mapping("a string") == {}
+    assert mapping([1, 2]) == {}
+
+
+# --------------------------------------------------- the text inside a content block
+
+
+def test_a_message_that_is_already_text_is_that_text() -> None:
+    assert text_of("said outright") == "said outright"
+
+
+def test_a_message_that_is_nothing_at_all_is_nothing() -> None:
+    assert text_of(None) == ""
+
+
+def test_the_blocks_of_a_message_are_joined_in_the_order_they_were_written() -> None:
+    said = text_of(
+        [
+            {"type": "text", "text": "first"},
+            "a bare string",
+            {"type": "thinking", "thinking": "second"},
+        ]
+    )
+
+    assert said == "first\na bare string\nsecond"
+
+
+def test_a_block_says_its_text_under_whichever_name_that_backend_uses() -> None:
+    """One writes `text`, one `thinking`, one `output`: the same thing under four names."""
+    for name in ("text", "think", "thinking", "output", "content"):
+        assert text_of([{name: "what it said"}]) == "what it said"
+
+
+def test_a_block_that_carries_no_text_at_all_adds_nothing() -> None:
+    assert text_of([{"type": "image", "source": {}}, {"text": "kept"}]) == "kept"
+
+
+def test_something_in_the_list_that_is_not_a_block_is_read_past() -> None:
+    assert text_of([7, None, {"text": "kept"}]) == "kept"
+
+
+def test_a_message_written_as_a_mapping_is_read_through_it() -> None:
+    assert text_of({"content": [{"text": "inside"}]}) == "inside"
+
+
+def test_something_that_is_none_of_these_is_written_out_as_it_stands() -> None:
+    """A reader that dropped it would leave a slice with nothing on it at all."""
+    said = text_of(7)
+
+    assert json.loads(said) == 7
+
+
+# ------------------------------------------------------- what a tool call is named
+
+
+def test_a_tool_given_a_string_is_named_after_it() -> None:
+    assert label("shell", "cat one.py") == "shell: cat one.py"
+
+
+def test_a_tool_is_named_after_the_most_descriptive_field_it_was_given() -> None:
+    assert label("Bash", {"command": "cat one.py"}).startswith("Bash: ")
+
+
+def test_a_tool_given_nothing_worth_saying_is_named_after_itself() -> None:
+    assert label("Bash", {}) == "Bash"
+    assert label("Bash", None) == "Bash"
+    assert label("Bash", "   ") == "Bash"
+
+
+def test_a_field_that_is_there_and_empty_is_not_the_one_to_name_it_after() -> None:
+    assert label("Bash", {"command": "   "}) == "Bash"

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -24,7 +24,7 @@ from hmz.backends import Model
 from hmz.epic import epics
 from hmz.kept import Runs
 from hmz.tui import Humanize
-from hmz.tui.app import _HELP, _OWN, Editor, _where
+from hmz.tui.app import _HELP, _OWN, _SAID, Editor, _where
 from hmz.tui.pick import (
     Accounts,
     Agent,
@@ -1675,7 +1675,7 @@ def test_the_terminal_theme_names_no_colour_of_its_own() -> None:
 
 @pytest.mark.timeout(60)
 async def test_a_turn_reads_the_way_claude_code_renders_one() -> None:
-    """What you said behind `❯`, what the agent said on `●`, and a line closing the turn.
+    """What you said behind `❯`, what the agent said on the bullet, and a line closing it.
 
     Which is Claude Code's own shape, read off its own screen: no bars, no boxes, nothing
     indented -- every line starts where the terminal does.
@@ -1707,10 +1707,10 @@ async def test_a_turn_reads_the_way_claude_code_renders_one() -> None:
 
     assert "❯ do the thing" in shown  # what you said
     assert "is working" in shown  # which agent has the turn, said as it starts
-    assert (
-        "● Bash(git status)" in shown
-    )  # a tool on the bullet, its argument in brackets
-    assert "● one" in shown
+    # The bullet is the terminal's rather than ours -- one system draws a different glyph --
+    # so it is asked for by the same name the interface draws it under.
+    assert f"{_SAID} Bash(git status)" in shown  # a tool, its argument in brackets
+    assert f"{_SAID} one" in shown
     assert "\n  two" in shown
     assert "✻ Worked for" in shown  # and the line Claude Code closes a turn with
 

--- a/tests/tui/test_discover.py
+++ b/tests/tui/test_discover.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import shutil
+import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from hmz import backends
@@ -63,3 +65,136 @@ def test_a_missing_dsh_sdk_is_installable_but_not_installed(
         "deepseek-v4-flash",
         "deepseek-v4-pro",
     ]
+
+
+def test_a_backend_somebody_added_is_installed_if_the_command_they_gave_is_there(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One humanize drives is started by its own name; one somebody added, by their command."""
+
+    def added() -> dict[str, tuple[str, ...]]:
+        return {"theirs": ("a-cli-of-theirs",)}
+
+    def looked_up(said: str) -> str | None:
+        return "/usr/bin/it" if said == "a-cli-of-theirs" else None
+
+    monkeypatch.setattr(backends, "_INSTALLED_AT", ())
+    monkeypatch.setattr(discover, "speaking", added)
+    monkeypatch.setattr(discover, "program", looked_up)
+
+    assert discover._is_installed("theirs")
+
+
+def test_a_backend_somebody_added_with_no_command_at_all_is_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def added() -> dict[str, tuple[str, ...]]:
+        return {"theirs": ()}
+
+    monkeypatch.setattr(discover, "speaking", added)
+
+    assert not discover._is_installed("theirs")
+
+
+def test_an_ordinary_cli_may_be_chosen_without_anybody_choosing_it() -> None:
+    """A CLI on PATH is there because somebody installed it, which is the choosing."""
+    assert discover.ready_to_open("claude", Path("/somewhere"))
+
+
+def test_the_backend_that_arrives_with_humanize_is_asked_whether_it_is_set_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Its SDK arrives whatever happens, so being installed says nothing about being usable."""
+    from hmz.agents import dsh
+
+    def set_up(where: Path) -> bool:
+        return where == tmp_path
+
+    monkeypatch.setattr(dsh, "native_ready", set_up)
+
+    assert discover.ready_to_open("dsh", tmp_path)
+    assert not discover.ready_to_open("dsh", tmp_path / "elsewhere")
+
+
+# ----------------------------------------------- where a turn could land besides here
+
+
+def test_the_containers_running_here_are_offered_before_the_hosts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".ssh").mkdir()
+    (tmp_path / ".ssh" / "config").write_text("Host builder\n  HostName 10.0.0.2\n")
+    _docker(monkeypatch, "one\ntwo\n")
+
+    assert discover.machines() == [
+        ("docker://one", "container"),
+        ("docker://two", "container"),
+        ("ssh://builder", "ssh config"),
+    ]
+
+
+def test_a_machine_with_no_docker_and_no_ssh_config_only_runs_its_own_turns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _refuses(monkeypatch, FileNotFoundError("no docker here"))
+
+    assert discover.machines() == []
+
+
+def test_a_docker_that_does_not_answer_is_not_a_reason_to_sit_at_a_sheet(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A daemon that has hung must not hold the picker open waiting on it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _refuses(
+        monkeypatch, subprocess.TimeoutExpired(["docker"], discover._LOOKING_SECONDS)
+    )
+
+    assert discover.machines() == []
+
+
+def test_the_hosts_are_the_ones_written_in_the_config_in_the_order_they_are_written(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".ssh").mkdir()
+    (tmp_path / ".ssh" / "config").write_text(
+        "# a note\n"
+        "Host builder gpu\n"
+        "  HostName 10.0.0.2\n"
+        "\n"
+        "Host *\n"
+        "  ForwardAgent yes\n"
+        "\n"
+        "Host web-?\n"
+        "Host !not-this\n"
+        "Host builder\n"  # said twice, offered once
+        "host lowercase\n"
+    )
+    _docker(monkeypatch, "")
+
+    assert discover.machines() == [
+        ("ssh://builder", "ssh config"),
+        ("ssh://gpu", "ssh config"),
+        ("ssh://lowercase", "ssh config"),
+    ]
+
+
+def _docker(monkeypatch: pytest.MonkeyPatch, said: str) -> None:
+    """Answers `docker ps` with these names, without a docker daemon anywhere near it."""
+
+    def listing(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["docker"], 0, said, "")
+
+    monkeypatch.setattr(subprocess, "run", listing)
+
+
+def _refuses(monkeypatch: pytest.MonkeyPatch, why: Exception) -> None:
+    """Makes `docker ps` fail the way a machine without one, or with a hung one, fails."""
+
+    def refusing(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        raise why
+
+    monkeypatch.setattr(subprocess, "run", refusing)


### PR DESCRIPTION
## macOS

The matrix gains `macos-latest`, so the tests run on both systems humanize is installed on, on each Python the package claims — six cells, all green, 12–15 minutes each. `macos-latest` rather than a pinned Intel runner: the DeepSeek runtime is an ordinary dependency and publishes a macOS wheel for arm64 alone.

Adding the runner was the easy half.

**A suite with no ceiling tells you nothing.** The first macOS job hung at 2% and was killed at the wall. GitHub reports that as *cancelled*, and the log holds pytest's progress dots and not one word about which test it was in. There was no per-test timeout anywhere; `timeout = 300` now lives in `[tool.pytest.ini_options]`, and the job uses `--timeout-method=thread`, which does not depend on a signal reaching a thread that may not take one.

**Twenty-four failures were one sentence**: `humanize supports x86_64 only; this host reports 'arm64'`. Which is right and documented — running a turn as a named account answers the paths that turn reads through a seccomp filter and a ptrace supervisor. The tests asked for one anywhere, so a machine that cannot give them one read as a suite that failed rather than a feature it does not have. They carry `traced` now, the same gate the redirect's own tests always had.

**Three modules cannot even be _collected_ off Linux** — they name `hmz.coganchor.linux`, which opens `libc.so.6` and picks an x86-64 register map at import time, so a skip written inside one is never reached. `tests/supervising.py` holds the gate they ask first.

**Nine were tests that had learned one system's habits**, each a real difference:

| | |
| --- | --- |
| `/bin/sh` is `sh` on one system and `bash` on the other; one records the path it resolved, the other the word typed | three profiler tests match on what the shell was *given* |
| a shell handed a single simple command may `exec` it and cease to be a process — so `sh -c "sleep 0.4"` leaves no shell to profile | two commands, the second a builtin |
| a platform may decline to say what another program's threads are | skips there, asked by looking rather than by naming the system |
| `PENDIN` is kernel state, not a mode anybody set | raw mode is asked of `ECHO` and `ICANON` |
| closing a pty's far side discards what was still in it | the goodbye is read while there is still a terminal to read it from |
| the interface draws `⏺` on macOS and `●` elsewhere, on purpose | the test asks for the one the interface is drawing |
| **`http.server.HTTPServer` resolves its own hostname at bind** — 35s on a runner whose resolver has nothing to say about `127.0.0.1`, cached per process, so a stand-in spawned per test paid it every time | **twenty minutes off the job** |

**And the one that took five runs.** macOS on Python 3.13 — not 3.12, not 3.14 — stopped at the same point every time, and no timeout method could end it. The sampler in `hmz.tracing.profile` asks the OS about every process under this one a hundred times a second; on that interpreter the call never returns *and never releases the interpreter*, so no other Python thread runs. That is why five jobs reached the wall having said nothing.

What isolated it was shrinking the job: running that **one file** on the matrix took two seconds everywhere else and never returned there. `tests/sampling.py` now gates the five tests that start a sampler on that one cell, and says why in one place so there is one place to delete when it is fixed. It is a thing to fix, not a platform limit — **worth a look independently of this PR**; profiling is off unless a workspace asks for it.

**And the ssh gate asked a different question than the run it gates**: it inherited the environment the suite was started with, so an agent forwarded into the terminal let the probe in and left the run outside — a skip that never happened, in front of a failure that always did.

## Coverage: 85% → 88%, 689 fewer uncovered lines

Not by chasing percentages — by finding the code nothing had ever run.

| | was | now | |
| --- | --- | --- | --- |
| `daemon/serve.py` | 19% | 73% | the held run, built in-process instead of behind a double fork |
| `daemon/attach.py` | 29% | 98% | the terminal half, on pipes and pseudoterminals of the test's own |
| `cli/anchor.py` | 36% | 90% | what `hmz anchor` refuses — including the door |
| `coganchor/serve/sessions.py` | 47% | 82% | reached through the listener |
| `coganchor/serve/listener.py` | **0%** | 100% | a target left listening on a port |
| `cli/tools.py` | **0%** | 100% | the pipe a backend speaks the tool protocol over |
| `sdk/session.py` | **0%** | 100% | the protocol the interface names so it need not name a daemon |
| `flows/builtin/chat` | **0%** | 100% | the flow the interface opens on — always run, never *seen* to run |
| `tui/discover.py` | 60% | 100% | where a turn could land besides this machine |
| `tracing/readers/codex.py` | 80% | 93% | the rollout items nothing read |
| `coganchor/serve/{server,fsops}.py` | 76/79% | 87/90% | the handshake both ends check; the rest of the operations |
| `tracing/session.py` | 82% | 89% | the five readers every backend's log goes through |
| the SDK | 12 tests | 95 tests | the facade, held to the store it says it reaches |

Two were worth having for their own sake: **a target left listening on an address anything can reach, with no secret asked for, is refused** — the one check between `hmz anchor serve` and a shell handed to whoever finds the port, and it had no test of any kind. And `prices.py`'s fetch refuses `file://`, which nothing had run either.

## Six defects the tests found

- **`Flows.find` and `Flows.fork` documented behaviour they do not have.** `find` hands the name back rather than raising `NotAFlow`; `fork` returns the directory it copied to and refuses with a plain `ValueError`. *(The only source change in the diff.)*
- **A profiler test was reading the clock** — failing one run in three, its span bounded by a 50ms sampler against a 200ms program.
- **Two more sampled programs lived for a handful of samples** — ten samples is enough on an idle machine and nothing on a loaded one.
- **A watchdog test was a coin toss** on whether one tick or two landed in its two-second sleep. Linux won it every time; macOS didn't.
- **Three ACP tests leaked a process each** — the process *is* the session in ACP. And `AcpConnection.stop`, which the fixture that fixes it relies on, was the whole of the 25% of `acp.py` nothing reached.
- **`chat` read 0% while two tests drove it**, next to two loops at 100% that differ only in being imported at the top of the same file.

## Verified

- `uv run pre-commit run --all-files` passes.
- `uv run pytest`: **2839 passed, 77 skipped, 0 failed** locally — both pre-existing failures gone, 403 tests added across 15 new files.
- **All six matrix cells green**, 12–15 minutes each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)