### PR TITLE
feat(cli)!: gather what humanize spawns under one visible `hmz internal`

### DIFF
--- a/docs/.vitepress/theme/components/HmzAnchor.vue
+++ b/docs/.vitepress/theme/components/HmzAnchor.vue
@@ -148,7 +148,7 @@ const lit = (where: Where) => (call.value.where === where ? 'lit' : '')
       <text x="452" y="118" class="sub mid">ssh · docker · tcp · a pipe</text>
 
       <rect x="676" y="56" width="288" height="40" rx="9" class="box strong" />
-      <text x="820" y="81" class="title mid">hmz anchor serve</text>
+      <text x="820" y="81" class="title mid">hmz internal anchor serve</text>
 
       <g class="dest" :class="lit('files')">
         <rect x="676" y="112" width="288" height="46" rx="9" class="box" />

--- a/docs/.vitepress/theme/components/HmzArch.vue
+++ b/docs/.vitepress/theme/components/HmzArch.vue
@@ -80,7 +80,7 @@ const BANDS: Band[] = [
     chips: [
       'this machine',
       'a container of its own',
-      'a remote target through hmz anchor',
+      'a remote target through hmz internal anchor',
       'worktrees',
     ],
   },

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -114,8 +114,8 @@ Three edges are worth explaining:
 - **`epic → tracing`**, because a profiled run samples the programs its agents start. `tracing`
   itself knows how to *drive* nothing; it needs the home directories and log globs, and
   nothing else.
-- **`cli` reaches `coganchor` directly**, for `hmz internal anchor`. That command is the only line the
-  target half is ever started by, and it must cost nothing else of humanize on the way.
+- **`cli` reaches `coganchor` directly**, for `hmz internal anchor`. That command is the only
+  line the target half is ever started by, and it must cost nothing else of humanize on the way.
 
 And one edge deliberately absent: **`coganchor` does not name `epic`.** A run is written out
 of the agents it drove, so naming the run from an agent would be a circle. What an agent needs
@@ -143,8 +143,8 @@ checked at all.
 3. **Every top-level module is in the table.** One left out is unchecked, and reads exactly like
    one deliberately exempt. `cli` is the only exemption, and it is checked differently:
 4. **Serving loads only what it may** — against a real target half, not statically. The bundle
-   is built, `hmz internal anchor serve` is run out of it with an empty `PYTHONPATH`, and what it loaded
-   is compared with the table.
+   is built, `hmz internal anchor serve` is run out of it with an empty `PYTHONPATH`, and what
+   it loaded is compared with the table.
 
 That last one is why `coganchor/serve/` may import nothing but `proto` — not even the package it sits in, whose name would be leave to name every driver in it. It is also why the bundle carries the anchor half alone: `DRIVING` in `coganchor/transport.py` names what a target has no use for, and `test_the_bundle_carries_nothing_that_drives_an_agent` is what notices a new one. The serving half runs on
 the target, which may be any architecture, while `coganchor/linux/` picks a register map at

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -114,7 +114,7 @@ Three edges are worth explaining:
 - **`epic → tracing`**, because a profiled run samples the programs its agents start. `tracing`
   itself knows how to *drive* nothing; it needs the home directories and log globs, and
   nothing else.
-- **`cli` reaches `coganchor` directly**, for `hmz anchor`. That command is the only line the
+- **`cli` reaches `coganchor` directly**, for `hmz internal anchor`. That command is the only line the
   target half is ever started by, and it must cost nothing else of humanize on the way.
 
 And one edge deliberately absent: **`coganchor` does not name `epic`.** A run is written out
@@ -143,7 +143,7 @@ checked at all.
 3. **Every top-level module is in the table.** One left out is unchecked, and reads exactly like
    one deliberately exempt. `cli` is the only exemption, and it is checked differently:
 4. **Serving loads only what it may** — against a real target half, not statically. The bundle
-   is built, `hmz anchor serve` is run out of it with an empty `PYTHONPATH`, and what it loaded
+   is built, `hmz internal anchor serve` is run out of it with an empty `PYTHONPATH`, and what it loaded
    is compared with the table.
 
 That last one is why `coganchor/serve/` may import nothing but `proto` — not even the package it sits in, whose name would be leave to name every driver in it. It is also why the bundle carries the anchor half alone: `DRIVING` in `coganchor/transport.py` names what a target has no use for, and `test_the_bundle_carries_nothing_that_drives_an_agent` is what notices a new one. The serving half runs on
@@ -225,8 +225,13 @@ them, so one added without them is a site that says there are fewer than there a
 **A machine.** Two classes in `coganchor/machines/`, per [Machines](/reference/machines#writing-a-machine-of-your-own).
 
 **A command.** A module under `cli/` if it takes a parser of its own, a thin wrapper in
-`cli/__init__.py`, and an entry in `COMMANDS`. Import your layer *inside* the function, not at
-the top of the module. Write through `cli/output.py` rather than through `print` where the
+`cli/__init__.py`, and an entry in `COMMANDS` — or in `INTERNAL`, which is what `hmz internal`
+routes, if the line is one humanize renders and spawns rather than one a person types. Both
+tables are `name: (what carries it out, the summary the listing shows)`, and everything routed
+is listed: there is no third table for things that run but are not shown. Import your layer
+*inside* the function, not at the top of the module — `cli/__init__.py` is loaded by every
+command including the one the bundled target half runs, so an import at the top is a cost every
+other command pays. Write through `cli/output.py` rather than through `print` where the
 command has a `--json` of its own: `Out.row` is one call for the line a person reads and the
 object a program reads, and holding one open is what keeps a stray print out of the stream.
 

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -869,7 +869,7 @@ stream a turn is read from would be describing a tool that had already run.
 
 On the backends whose CLI takes a hook table meant for a single run — the ones
 [`anchor:hooked`](#what-each-backend-can-do) names — humanize puts the moment in that table
-instead, pointed at `hmz hook`, a relay that carries the call to a socket this process is
+instead, pointed at `hmz internal hook`, a relay that carries the call to a socket this process is
 serving and the verdict back again. The CLI stops and waits for it, and a refusal means the
 tool does not run:
 
@@ -1752,7 +1752,7 @@ agent's: two conversations offering a tool of one name are offering one tool.
 
 The road between the two is the **Model Context Protocol**, that being the one way every one of
 these CLIs takes a tool it was not shipped with. What a backend is handed is a command to run —
-`hmz tools --at <socket>` — which relays its pipe back to the flow's process. Nothing is
+`hmz internal tools --at <socket>` — which relays its pipe back to the flow's process. Nothing is
 started until something is offered: an agent whose flow hands it no callbacks has no socket, no
 thread and no bridge.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,6 +12,11 @@ is not a command is a usage error listing the commands there are. Everything aft
 name reaches that command untouched — `--help` included — so each answers for its own
 arguments.
 
+There are two commands. `hmz exec` runs a flow, and is the one anybody types.
+[`hmz internal`](#hmz-internal) is the door onto the four lines humanize spawns for itself —
+listed rather than hidden, because a command nobody can discover is a command nobody can
+debug, and these are exactly what turns up in a process table when a run has gone wrong.
+
 `python -m hmz` is the same command line, which is how a turn spawns itself under an
 [anchor](/reference/remote-execution).
 
@@ -214,18 +219,41 @@ hmz exec -f official/humanize1:rlcr -c setup.yaml -a claude/claude-opus-5:max \
 
 Nobody is at a prompt, so an agent that stops to ask is told nobody answered and carries on.
 
-## `hmz anchor`
+## `hmz internal`
+
+```
+hmz internal COMMAND [ARGS...]
+```
+
+The four lines humanize starts processes with, under one name. Nobody types one of these: each
+exists because starting a process needs a command line, and each takes arguments humanize
+renders for it.
+
+They are listed and documented rather than hidden behind an undocumented name, because every
+one of them is what a person *finds* rather than what they run — the process under a turn in
+`ps`, the line in a backend's MCP configuration, the program a hook's error came from. A door
+marked `internal` tells you both what is there and that it is not for you; a listing that left
+them out would simply be untrue about what humanize runs.
+
+| Command | |
+| --- | --- |
+| [`hmz internal anchor`](#hmz-internal-anchor) | A turn whose work lands on another machine, and — under `serve` — the half that lands it. |
+| [`hmz internal cred`](#hmz-internal-cred) | A program run with its credentials answered out of an account's own directory. |
+| [`hmz internal hook`](#hmz-internal-hook) | One moment of a coding agent's hook table, carried to the flow whose moment it is. |
+| [`hmz internal tools`](#hmz-internal-tools) | A coding agent's tool calls, carried to the flow whose callbacks they are. |
+
+## `hmz internal anchor`
 
 Runs a coding agent on this machine whose work lands on another one. See
 [Remote execution](/reference/remote-execution).
 
-**Not one of the commands the listing shows.** humanize spawns it for every turn whose work
-lands on another machine, and the zipapp bootstrapped onto a target runs `hmz anchor serve` to
-answer one — the same reason `hmz tools` is a command line. It still runs when it is typed,
+**Not a command anybody types.** humanize spawns it for every turn whose work lands on another
+machine, and the zipapp bootstrapped onto a target runs `hmz internal anchor serve` to answer
+one — the same reason `hmz internal tools` is a command line. It still runs when it is typed,
 which is what `--check` is for.
 
 ```
-hmz anchor [options] AGENT [ARGS...]
+hmz internal anchor [options] AGENT [ARGS...]
 ```
 
 Everything after the agent's name is the agent's own.
@@ -260,20 +288,21 @@ every shell uses for a command it could not find, so that whatever spawned it re
 that is not installed.
 
 ```sh
-hmz anchor --target ssh://build-box claude
-hmz anchor --target ssh://gpu-01 codex exec "run the test suite"
-hmz anchor --target docker://build-container --workspace /srv/project claude
-hmz anchor --native --target docker://build-container --remote-path /srv/project claude
-hmz anchor --check --target ssh://build-box
+hmz internal anchor --target ssh://build-box claude
+hmz internal anchor --target ssh://gpu-01 codex exec "run the test suite"
+hmz internal anchor --target docker://build-container --workspace /srv/project claude
+hmz internal anchor --native --target docker://build-container --remote-path /srv/project claude
+hmz internal anchor --check --target ssh://build-box
 ```
 
-## `hmz anchor serve`
+## `hmz internal anchor serve`
 
-The other half of a session: replays on this machine what an `hmz anchor` elsewhere asks of it.
-Needs only a POSIX system and a recent `python3` — no root, no compiler, nothing installed.
+The other half of a session: replays on this machine what an `hmz internal anchor` elsewhere
+asks of it. Needs only a POSIX system and a recent `python3` — no root, no compiler, nothing
+installed.
 
 ```
-hmz anchor serve --export VIRTUAL[:REAL] (--stdio | --listen [HOST:]PORT) [--token TOKEN]
+hmz internal anchor serve --export VIRTUAL[:REAL] (--stdio | --listen [HOST:]PORT) [--token TOKEN]
 ```
 
 | Flag | |
@@ -282,7 +311,7 @@ hmz anchor serve --export VIRTUAL[:REAL] (--stdio | --listen [HOST:]PORT) [--tok
 | `--stdio` | Serve one session over stdin/stdout. This is what a bootstrapped target runs. |
 | `--listen [HOST:]PORT` | Serve TCP connections on this address. A bare port listens on `127.0.0.1`. |
 | `--token TOKEN` | Shared secret required from clients. Defaults to `$HUMANIZE_TOKEN`. |
-| `--log-level` | As for `hmz anchor`. |
+| `--log-level` | As for `hmz internal anchor`. |
 
 `--stdio` and `--listen` are mutually exclusive, and one is required.
 
@@ -290,13 +319,62 @@ hmz anchor serve --export VIRTUAL[:REAL] (--stdio | --listen [HOST:]PORT) [--tok
 to a shell on that machine — read [Security](/user/security).
 
 ```sh
-hmz anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
+hmz internal anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
 ```
 
-## `hmz tools`
+## `hmz internal cred`
 
 ```sh
-hmz tools --at <socket>
+hmz internal cred --map FROM=TO [--map ...] -- COMMAND [ARGS...]
+```
+
+Runs a program with some of its paths answered by others, and exits with its status. What a
+turn under a [provider](/reference/providers) is spawned as, and what a login run for one is
+spawned as: the program runs here, unchanged and on this terminal, and the handful of syscalls
+that name one of its credential files are handed a path inside that account's directory
+instead.
+
+**Not a command anybody types.** It is a command of its own rather than something the driver
+does in this process because the supervisor forks the program and takes the process's signal
+handling with it, which a flow pumping turns from threads of its own has none to lend.
+
+| Flag | |
+| --- | --- |
+| `--map FROM=TO` | **Required, repeatable.** Answer this path — the file it names, or everything under the directory it names — with that one. |
+| `--` | Ends the flags. Everything after it is the program and its own arguments. |
+
+A line with nothing to answer, or nothing to run, is a usage error. A run that could not be
+supervised exits 1 rather than running the program unsupervised: that would be a turn taken as
+whoever is at this machine, which is the wrong account rather than a failed turn.
+
+## `hmz internal hook`
+
+```sh
+hmz internal hook --at <socket>
+```
+
+Carries one call of a coding agent's own [hook table](/reference/agents#hooks) to the flow
+whose moment it is, and the verdict back again: it reads the call on its stdin, sends it to the
+flow's socket and writes the answer back out. It is what makes a refusal at `PreToolUse` stop
+the tool rather than describe one that has already run.
+
+**Not a command anybody types.** A CLI takes a hook by starting a program and waiting for what
+it says, so there is a program — humanize writes this line into the CLI's own hook table and
+spawns it once per moment.
+
+| Flag | |
+| --- | --- |
+| `--at PATH` | **Required.** The unix socket the flow is serving its moments on. |
+
+It exits 0 whatever the flow said, and never with the status these CLIs read as the hook
+itself having refused: a relay that could not reach anybody would otherwise be refusing on a
+flow's behalf without having asked it. A socket that is not there lets the tool through and
+says so on stderr, where the CLI shows it and carries on.
+
+## `hmz internal tools`
+
+```sh
+hmz internal tools --at <socket>
 ```
 
 Carries the tool protocol between a coding agent and the flow whose
@@ -304,22 +382,26 @@ Carries the tool protocol between a coding agent and the flow whose
 answers back out to its stdout, and does nothing else.
 
 **Not a command anybody types.** A CLI takes a tool by starting a program, so there is a
-program — the same reason `hmz cred` exists. humanize spawns it and tells the backend to run
-it; a socket that is not there exits 1, which the CLI reads as tools being unavailable rather
-than as a turn that failed.
+program — the same reason `hmz internal cred` exists. humanize spawns it and tells the backend
+to run it; a socket that is not there exits 1, which the CLI reads as tools being unavailable
+rather than as a turn that failed.
+
+| Flag | |
+| --- | --- |
+| `--at PATH` | **Required.** The unix socket the flow is serving its toolbox on. |
 
 ## Environment variables
 
 | Variable | Read by | |
 | --- | --- | --- |
 | `HUMANIZE_HOME` | everything | Where humanize keeps what outlives one run. Defaults to `~/.humanize`. |
-| `HUMANIZE_TARGET` | `hmz anchor` | Default for `--target`. |
-| `HUMANIZE_TOKEN` | `hmz anchor`, `hmz anchor serve` | Default for `--token`. |
-| `HUMANIZE_LOG` | `hmz anchor`, `hmz anchor serve` | Default for `--log-level`. |
+| `HUMANIZE_TARGET` | `hmz internal anchor` | Default for `--target`. |
+| `HUMANIZE_TOKEN` | `hmz internal anchor`, `hmz internal anchor serve` | Default for `--token`. |
+| `HUMANIZE_LOG` | `hmz internal anchor`, `hmz internal anchor serve` | Default for `--log-level`. |
 | `HUMANIZE_DAEMON` | `hmz` with no command | `off`, `0` or `no` opens the interface in this terminal rather than [holding the run apart from it](/reference/daemon). Anything else — including empty — is silence, and silence holds the run. |
 | `HUMANIZE_SENTRY` | everything | `on` or `off`, answering the [reporting](/user/reporting) question for one process without writing anything down. Nothing else is looked at while it is set. |
 | `HUMANIZE_WATCHDOG` | everything that runs a turn | How long a turn may say nothing before [the watchdog looks at it](/reference/agents#when-a-cli-stops-answering), in seconds, overriding each backend's own. `0` turns it off. |
-| `HUMANIZE_SHADOWS` | `hmz anchor`, a container or a machine an agent works on | Where the mirrors coganchor has been pointed at are recorded. Defaults to `~/.cache/humanize/shadows`. |
+| `HUMANIZE_SHADOWS` | `hmz internal anchor`, a container or a machine an agent works on | Where the mirrors coganchor has been pointed at are recorded. Defaults to `~/.cache/humanize/shadows`. |
 | `CLAUDE_CONFIG_DIR` | the traces `/epics` gathers, the TUI's cost readout | Claude Code's home. Defaults to `~/.claude`. |
 | `CODEX_HOME` | same | Codex's home. Defaults to `~/.codex`. |
 | `DSH_HOME` | same | DeepSeek Harness's home. Defaults to `~/.dsh`. |
@@ -384,7 +466,7 @@ into them.
 | `1` | It could not: the target could not be reached, the listener could not be started, a turn could not be supervised. |
 | `2` | The command line was wrong — argparse's own rejections, a flow that is not there or takes other agents, a malformed listen address, a non-loopback listener with no token. |
 | `130` | Interrupted. |
-| *the agent's own* | `hmz anchor` exits with the status of the program it ran, and `hmz cred` with that of the program it supervised. |
+| *the agent's own* | `hmz internal anchor` exits with the status of the program it ran, and `hmz internal cred` with that of the program it supervised. |
 
 ## Python entry points
 
@@ -415,8 +497,8 @@ and restates none of them:
 ```python
 from hmz.runtime.runner import Runner          # hmz exec
 from hmz.runtime.tracing import collect        # the trace /epics gathers
-from hmz.coganchor import connect      # hmz anchor
-from hmz.coganchor import check        # hmz anchor --check
+from hmz.coganchor import connect      # hmz internal anchor
+from hmz.coganchor import check        # hmz internal anchor --check
 from hmz.daemon import running, start  # the run hmz holds apart from the terminal
 ```
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -27,5 +27,5 @@ a quickstart apiece: [run a flow](/#run-a-flow), [weave a flow](/#weave-a-flow),
 | [Agents](/reference/agents) | Driving a coding agent from Python: an agent is settings, a session is memory |
 | [Machines](/reference/machines) | Where an agent's turns land — here, a container, or a machine already running |
 | [Providers](/reference/providers) | Which account an agent runs as, kept apart from the CLI's own |
-| [Remote execution](/reference/remote-execution) | `hmz anchor`: an agent on this machine whose work lands on another |
+| [Remote execution](/reference/remote-execution) | `hmz internal anchor`: an agent on this machine whose work lands on another |
 | [Tracing](/reference/tracing) | The sessions and the programs a run left behind, gathered into one timeline of it |

--- a/docs/reference/machines.md
+++ b/docs/reference/machines.md
@@ -308,8 +308,8 @@ Read [Remote execution](/reference/remote-execution).
 
 **Isolation here is about environment, not permission.** A container gives the agent a
 different toolchain and a different filesystem, and mounts your workspace into it. It does not
-stop the agent editing that workspace, and an `hmz internal anchor` export bounds which files a request
-may name but does not confine the commands that request can run. Read
+stop the agent editing that workspace, and an `hmz internal anchor` export bounds which files a
+request may name but does not confine the commands that request can run. Read
 [Security](/user/security).
 
 ## Writing a machine of your own

--- a/docs/reference/machines.md
+++ b/docs/reference/machines.md
@@ -308,7 +308,7 @@ Read [Remote execution](/reference/remote-execution).
 
 **Isolation here is about environment, not permission.** A container gives the agent a
 different toolchain and a different filesystem, and mounts your workspace into it. It does not
-stop the agent editing that workspace, and an `hmz anchor` export bounds which files a request
+stop the agent editing that workspace, and an `hmz internal anchor` export bounds which files a request
 may name but does not confine the commands that request can run. Read
 [Security](/user/security).
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -412,8 +412,8 @@ Both happen whichever way the provider was made, so an agent on a gateway never 
 your CLI is signed into either.
 
 The paths are answered by a seccomp-filtered ptrace supervisor — the technique
-[`hmz internal anchor`](/reference/remote-execution) runs a whole session under, here handling only the handful of
-syscalls that name one of those files. Everything else the agent does is untouched and runs at
+[`hmz internal anchor`](/reference/remote-execution) runs a whole session under, here handling
+only the handful of syscalls that name one of those files. Everything else the agent does is untouched and runs at
 native speed, and the agent is told none of it. That supervisor is a process humanize spawns
 for itself: a supervisor forks the program it watches, and a flow pumping turns from threads
 of its own has no signal handling to lend one.

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -412,7 +412,7 @@ Both happen whichever way the provider was made, so an agent on a gateway never 
 your CLI is signed into either.
 
 The paths are answered by a seccomp-filtered ptrace supervisor — the technique
-[`hmz anchor`](/reference/remote-execution) runs a whole session under, here handling only the handful of
+[`hmz internal anchor`](/reference/remote-execution) runs a whole session under, here handling only the handful of
 syscalls that name one of those files. Everything else the agent does is untouched and runs at
 native speed, and the agent is told none of it. That supervisor is a process humanize spawns
 for itself: a supervisor forks the program it watches, and a flow pumping turns from threads

--- a/docs/reference/remote-execution.md
+++ b/docs/reference/remote-execution.md
@@ -189,8 +189,8 @@ config = ClaudeCodeAgentConfig(
 )
 ```
 
-Every option of `hmz internal anchor` is a field of `AnchorConfig` and every field is an option, so the
-two spellings mean exactly the same thing — a flow spawns what an operator would have typed.
+Every option of `hmz internal anchor` is a field of `AnchorConfig` and every field is an option,
+so the two spellings mean exactly the same thing — a flow spawns what an operator would have typed.
 Settings no session could run under are refused where they are *written* rather than where they
 are used, so a flow that misspells a target hears about it as it configures its agents, not
 hours into the loop.
@@ -290,8 +290,8 @@ Each of these is deliberate, and each looks like a defect if you meet it cold.
 
 ## Security
 
-**An `hmz internal anchor` port is equivalent to a shell on that machine.** Give `--token` a real secret,
-and prefer `ssh://` or `docker://`, which need no open port at all.
+**An `hmz internal anchor` port is equivalent to a shell on that machine.** Give `--token` a
+real secret, and prefer `ssh://` or `docker://`, which need no open port at all.
 
 The full statement, including what running any agent under humanize means, is in
 [Security](/user/security).

--- a/docs/reference/remote-execution.md
+++ b/docs/reference/remote-execution.md
@@ -1,6 +1,6 @@
 # Remote execution
 
-`hmz anchor` runs a coding agent on this machine whose work lands on another one. The agent
+`hmz internal anchor` runs a coding agent on this machine whose work lands on another one. The agent
 needs no plugin, no configuration and no cooperation: it is told none of this and takes part in
 none of it.
 
@@ -20,8 +20,8 @@ own path by default, so the paths the agent sees are the target's own.
      this machine                              the target
 ┌────────────────────┐                   ┌────────────────────┐
 │  claude / codex …  │                   │                    │
-│        ↓ syscalls  │                   │                    │
-│  ┌──────────────┐  │   one channel     │  hmz anchor serve  │
+│        ↓ syscalls  │                   │  hmz internal      │
+│  ┌──────────────┐  │   one channel     │    anchor serve    │
 │  │  supervisor  │──┼──────────────────▶│         ↓          │
 │  └──────────────┘  │  ssh / docker /   │  files, processes, │
 │   local mirror     │  tcp / a pipe     │  the network       │
@@ -40,8 +40,8 @@ sends it the signals aimed here, and exits with its own status.
 ```
      this machine                              the target
 ┌────────────────────┐                   ┌────────────────────┐
-│  hmz anchor        │   one channel     │  claude / codex …  │
-│    --native        │──────────────────▶│         ↕          │
+│  hmz internal      │   one channel     │  claude / codex …  │
+│    anchor --native │──────────────────▶│         ↕          │
 │    ↕ three streams │  ssh / docker /   │  files, processes, │
 │                    │  tcp / a pipe     │  the network       │
 └────────────────────┘                   └────────────────────┘
@@ -54,7 +54,7 @@ framed protocol to a process humanize spawns — the frames cross a machine boun
 end is told.
 
 ```sh
-hmz anchor --native --target docker://build-container --remote-path /srv/project claude
+hmz internal anchor --native --target docker://build-container --remote-path /srv/project claude
 ```
 
 Three things do not follow the CLI across on their own, so the anchor carries each:
@@ -88,15 +88,15 @@ the credentials and the skills are written again each time.
 ## Quick start
 
 ```sh
-hmz anchor --target ssh://build-box claude
-hmz anchor --target ssh://gpu-01 codex exec "run the test suite"
+hmz internal anchor --target ssh://build-box claude
+hmz internal anchor --target ssh://gpu-01 codex exec "run the test suite"
 ```
 
 Everything after the agent's name is the agent's own. Before running anything, ask the target
 what it is:
 
 ```console
-$ hmz anchor --check --target ssh://build-box
+$ hmz internal anchor --check --target ssh://build-box
 target      ssh://build-box
 hostname    build-box
 python      3.12.3 (pid 41207)
@@ -104,7 +104,7 @@ export      /home/me/code/myproject -> /home/me/code/myproject
 workspace   /home/me/code/myproject (184 entries)
 ```
 
-Every flag is in the [CLI reference](/reference/cli#hmz-anchor).
+Every flag is in the [CLI reference](/reference/cli#hmz-internal-anchor).
 
 ## Targets
 
@@ -189,7 +189,7 @@ config = ClaudeCodeAgentConfig(
 )
 ```
 
-Every option of `hmz anchor` is a field of `AnchorConfig` and every field is an option, so the
+Every option of `hmz internal anchor` is a field of `AnchorConfig` and every field is an option, so the
 two spellings mean exactly the same thing — a flow spawns what an operator would have typed.
 Settings no session could run under are refused where they are *written* rather than where they
 are used, so a flow that misspells a target hears about it as it configures its agents, not
@@ -213,10 +213,10 @@ Instead of bootstrapping over ssh each time, a target can be left listening:
 
 ```sh
 # on the target
-hmz anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
+hmz internal anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
 
 # on this machine
-HUMANIZE_TOKEN=$SECRET hmz anchor --target tcp://build-box:7777 --workspace /srv/project claude
+HUMANIZE_TOKEN=$SECRET hmz internal anchor --target tcp://build-box:7777 --workspace /srv/project claude
 ```
 
 `--export VIRTUAL[:REAL]` says which directory to expose, and under what path the agent believes
@@ -225,7 +225,7 @@ it is using. Repeat it for more than one.
 Listening on anything but loopback **without** `--token` is refused. Read
 [Security](#security) before opening one.
 
-The same program serves both ends — the bundle shipped to a target runs `hmz anchor serve
+The same program serves both ends — the bundle shipped to a target runs `hmz internal anchor serve
 --stdio`, which is one session over a pipe.
 
 ## From Python
@@ -242,7 +242,7 @@ status = connect(["claude", "--print"], config)   # the agent's own exit status
 `connect` returns once the agent has exited and everything it wrote has been pushed.
 
 `AnchorConfig` fields map one-to-one onto the flags in the
-[CLI reference](/reference/cli#hmz-anchor): `target`, `workspace`, `chdir`, `remote_path`,
+[CLI reference](/reference/cli#hmz-internal-anchor): `target`, `workspace`, `chdir`, `remote_path`,
 `shadow`, `local_paths`, `local_execs`, `redirects`, `private`, `net`, `net_allow`, `token`,
 `force`.
 
@@ -290,7 +290,7 @@ Each of these is deliberate, and each looks like a defect if you meet it cold.
 
 ## Security
 
-**An `hmz anchor` port is equivalent to a shell on that machine.** Give `--token` a real secret,
+**An `hmz internal anchor` port is equivalent to a shell on that machine.** Give `--token` a real secret,
 and prefer `ssh://` or `docker://`, which need no open port at all.
 
 The full statement, including what running any agent under humanize means, is in

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -167,7 +167,7 @@ list appears under the editor with a line about each.
 `/details` and `/afk` flip when given nothing, and take `on` or `off` when you want to say
 which.
 
-**`hmz anchor` is deliberately not here.** It is not a thing to do to a
+**`hmz internal anchor` is deliberately not here.** It is not a thing to do to a
 flow that is running, and a command that only ever means one thing is a command line.
 
 ### Starting a flow outright

--- a/docs/user/remote-execution.md
+++ b/docs/user/remote-execution.md
@@ -70,8 +70,8 @@ humanize ships the target half as a zipapp and caches it there by digest. It nee
 installation. The two halves refuse to run against each other if their versions disagree.
 
 ::: details It cannot connect
-Run `ssh build-box` yourself first. `hmz internal anchor` uses your own ssh config, agent and keys, and
-it adds nothing. Then check that there is a Python 3.12 or newer there; it need not be on the
+Run `ssh build-box` yourself first. `hmz internal anchor` uses your own ssh config, agent and
+keys, and it adds nothing. Then check that there is a Python 3.12 or newer there; it need not be on the
 `PATH`, since humanize looks where a Mac and a Homebrew keep one too. See
 [Troubleshooting](/user/troubleshooting#the-target-cannot-be-reached).
 :::
@@ -136,8 +136,8 @@ config = ClaudeCodeAgentConfig(
 )
 ```
 
-Every option of `hmz internal anchor` is a field of `AnchorConfig`, and every field is an option. A flow
-spawns what an operator would have typed. Settings no session could run under are refused where
+Every option of `hmz internal anchor` is a field of `AnchorConfig`, and every field is an
+option. A flow spawns what an operator would have typed. Settings no session could run under are refused where
 they are *written*, so a flow that misspells a target hears about it as it configures its
 agents rather than hours into the loop.
 
@@ -190,8 +190,8 @@ happens in the only names the far end has.
 /tmp/elsewhere is not inside /srv/project, which is the workspace this agent's turns land in
 ```
 
-The same paths are flags on `hmz internal anchor`. Where the project lives at a different path there,
-name both:
+The same paths are flags on `hmz internal anchor`. Where the project lives at a different path
+there, name both:
 
 ```sh
 hmz internal anchor --target ssh://build-box \

--- a/docs/user/remote-execution.md
+++ b/docs/user/remote-execution.md
@@ -9,8 +9,8 @@ cooperation: it is told none of this and takes part in none of it.
      this machine                              the target
 ┌────────────────────┐                   ┌────────────────────┐
 │  claude / codex …  │                   │                    │
-│        ↓ syscalls  │                   │                    │
-│  ┌──────────────┐  │   one channel     │  hmz anchor serve  │
+│        ↓ syscalls  │                   │  hmz internal      │
+│  ┌──────────────┐  │   one channel     │    anchor serve    │
 │  │  supervisor  │──┼──────────────────▶│         ↓          │
 │  └──────────────┘  │  ssh / docker /   │  files, processes, │
 │   local mirror     │  tcp / a pipe     │  the network       │
@@ -28,7 +28,7 @@ the agent sees are the target's own.
 Ask the target what it is before you run anything against it:
 
 ```sh
-hmz anchor --check --target ssh://build-box
+hmz internal anchor --check --target ssh://build-box
 ```
 
 ```console
@@ -42,7 +42,7 @@ workspace   /home/me/code/myproject (184 entries)
 Then run an agent against it:
 
 ```sh
-hmz anchor --target ssh://build-box claude
+hmz internal anchor --target ssh://build-box claude
 ```
 
 The agent runs here while its commands run on the build box. Inside the workspace it sees the
@@ -54,7 +54,7 @@ either spelling reaches the same file.
 Everything after the agent's name is the agent's own:
 
 ```sh
-hmz anchor --target ssh://gpu-01 codex exec "run the test suite"
+hmz internal anchor --target ssh://gpu-01 codex exec "run the test suite"
 ```
 
 ## Targets
@@ -70,7 +70,7 @@ humanize ships the target half as a zipapp and caches it there by digest. It nee
 installation. The two halves refuse to run against each other if their versions disagree.
 
 ::: details It cannot connect
-Run `ssh build-box` yourself first. `hmz anchor` uses your own ssh config, agent and keys, and
+Run `ssh build-box` yourself first. `hmz internal anchor` uses your own ssh config, agent and keys, and
 it adds nothing. Then check that there is a Python 3.12 or newer there; it need not be on the
 `PATH`, since humanize looks where a Mac and a Homebrew keep one too. See
 [Troubleshooting](/user/troubleshooting#the-target-cannot-be-reached).
@@ -103,7 +103,7 @@ it adds nothing. Then check that there is a Python 3.12 or newer there; it need 
 Name what must stay here with `--local-path` or `--local-exec`:
 
 ```sh
-hmz anchor --target ssh://build-box \
+hmz internal anchor --target ssh://build-box \
     --local-path /home/me/code/myproject/.venv \
     --local-exec /usr/bin/rg \
     claude
@@ -136,7 +136,7 @@ config = ClaudeCodeAgentConfig(
 )
 ```
 
-Every option of `hmz anchor` is a field of `AnchorConfig`, and every field is an option. A flow
+Every option of `hmz internal anchor` is a field of `AnchorConfig`, and every field is an option. A flow
 spawns what an operator would have typed. Settings no session could run under are refused where
 they are *written*, so a flow that misspells a target hears about it as it configures its
 agents rather than hours into the loop.
@@ -190,11 +190,11 @@ happens in the only names the far end has.
 /tmp/elsewhere is not inside /srv/project, which is the workspace this agent's turns land in
 ```
 
-The same paths are flags on `hmz anchor`. Where the project lives at a different path there,
+The same paths are flags on `hmz internal anchor`. Where the project lives at a different path there,
 name both:
 
 ```sh
-hmz anchor --target ssh://build-box \
+hmz internal anchor --target ssh://build-box \
     --workspace /home/me/code/myproject \
     --remote-path /srv/build/myproject \
     claude
@@ -212,7 +212,7 @@ hmz anchor --target ssh://build-box \
 Where there is no ssh and no container, run the target half on the far machine:
 
 ```sh
-hmz anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
+hmz internal anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
 ```
 
 It needs only a POSIX system and a recent `python3`. No root, no compiler, nothing installed.
@@ -220,7 +220,7 @@ It needs only a POSIX system and a recent `python3`. No root, no compiler, nothi
 Then connect from here:
 
 ```sh
-hmz anchor --target tcp://build-box:7777 --workspace /srv/project --token "$SECRET" claude
+hmz internal anchor --target tcp://build-box:7777 --workspace /srv/project --token "$SECRET" claude
 ```
 
 A `tcp://` target is **cheap to reconnect**, which matters for a loop of short turns. A backend
@@ -248,6 +248,6 @@ looked for if it finds none.
 
 - [Containers](/user/containers) — the same arrangement, with a container as the target
 - [Remote execution reference](/reference/remote-execution) — what is and is not guaranteed
-- [CLI › `hmz anchor`](/reference/cli#hmz-anchor)
+- [CLI › `hmz internal anchor`](/reference/cli#hmz-internal-anchor)
 - [Troubleshooting](/user/troubleshooting#the-target-cannot-be-reached)
 - [humanize in CI](/user/ci)

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -45,7 +45,7 @@ package does. Add the ones you would clone and run.
 [humanfia/flowverse](https://github.com/humanfia/flowverse). humanize does not fetch it until
 something wants what is in it.
 
-## An `hmz anchor` port is equivalent to a shell on that machine
+## An `hmz internal anchor` port is equivalent to a shell on that machine
 
 [Remote execution](/user/remote-execution) has three transports. Two of them need no open port
 at all:
@@ -54,7 +54,7 @@ at all:
 | --- | --- |
 | `ssh://host` | bootstrapped over your own ssh. Nothing listens. |
 | `docker://container` | over `docker exec`. Nothing listens. |
-| `tcp://host:port` | an `hmz anchor serve` listening there. |
+| `tcp://host:port` | an `hmz internal anchor serve` listening there. |
 
 For the third, `--export` bounds which files a request may *name*. It does **not** confine the
 commands that request can run. Anyone who can reach the port can run anything on that machine
@@ -65,7 +65,7 @@ as the user serving it.
 - Prefer `ssh://` or `docker://`.
 
 ```sh
-hmz anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
+hmz internal anchor serve --listen 0.0.0.0:7777 --export /srv/project --token "$SECRET"
 ```
 
 ## What humanize does not hold

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -232,7 +232,7 @@ exactly `on` or `off`.
 
 ### `no such command: /foo`
 
-Type `/` to see the list. `hmz anchor` is deliberately not a command here: it is not a thing to
+Type `/` to see the list. `hmz internal anchor` is deliberately not a command here: it is not a thing to
 do to a flow that is running. `/epics` is where the runs of this directory are, and where one
 of them is collected into a trace.
 
@@ -400,7 +400,7 @@ An open port is equivalent to a shell on that machine. Give `--token` a real sec
 Ask it what it is. This runs nothing there:
 
 ```sh
-hmz anchor --check --target ssh://build-box
+hmz internal anchor --check --target ssh://build-box
 ```
 
 It bootstraps the target half, opens the channel and reads the workspace back — the whole path,
@@ -460,7 +460,7 @@ That cannot reach past you on a machine several people share.
 
 ## Still stuck
 
-- `--log-level debug` on `hmz anchor`, both ends.
+- `--log-level debug` on `hmz internal anchor`, both ends.
 - The SPECs under `specs/` say what it is *supposed* to do, normatively.
   `specs/coganchor.md` is the one worth reading when a remote session behaves strangely.
 - [Architecture](/contributing/architecture) says which layer to look in.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -232,8 +232,8 @@ exactly `on` or `off`.
 
 ### `no such command: /foo`
 
-Type `/` to see the list. `hmz internal anchor` is deliberately not a command here: it is not a thing to
-do to a flow that is running. `/epics` is where the runs of this directory are, and where one
+Type `/` to see the list. `hmz internal anchor` is deliberately not a command here: it is not a
+thing to do to a flow that is running. `/epics` is where the runs of this directory are, and where one
 of them is collected into a trace.
 
 ### A line I typed did not reach the agent

--- a/docs/weaver/tools.md
+++ b/docs/weaver/tools.md
@@ -137,7 +137,7 @@ The road is the **Model Context Protocol**, that being the one way every one of 
 takes a tool it was not shipped with. What the backend is handed is a command to run:
 
 ```
-hmz tools --at /tmp/humanize-tools-XXXX/tools.sock
+hmz internal tools --at /tmp/humanize-tools-XXXX/tools.sock
 ```
 
 which relays its pipe to a socket in the flow's process. So the function that runs is the one

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -862,6 +862,13 @@ hmz [<command> [<args>...]]
   what those ask for; whatever else one of them needs -- reading a flow for what will not
   run, gathering a trace, packaging a run up -- MUST be asked of `sdk`, which is the same
   object this line holds.
+- What humanize spawns for itself MUST be reachable under one further command, `hmz internal`,
+  and every command the line routes MUST be in the listing. There MUST be no name that is
+  carried out but left out: a program whose help describes less than it runs is one nobody can
+  debug from the outside, and each of these is exactly what a person sees in a process table
+  when a run has gone wrong. Gathering them under one name is what keeps the listing readable
+  -- one entry rather than four, saying what they are and that none of them is a line to type
+  -- and is why the answer is a door rather than either four more entries or a trapdoor.
 - A line naming no command at all MUST open the terminal interface, which is every command at
   one prompt. There MUST be no command that opens it too: one way in is one way in. A line
   naming something that is not a command MUST be a usage error listing the commands there
@@ -1006,57 +1013,92 @@ Args:
   words themselves, what the turn cost, and when. It MUST NOT write anything a terminal needed
   and a program does not.
 
-## `hmz anchor`
+## `hmz internal`
 
 ```shell
-hmz anchor [<options>] <agent> [<args>...]
-hmz anchor serve --export <virtual>[:<real>] (--stdio | --listen [<host>:]<port>)
+hmz internal <command> [<args>...]
+```
+
+The door onto what humanize spawns for itself. Behind it are the four lines humanize starts
+processes with -- the anchor, the supervisor a turn under an account runs in, and the two
+relays a coding agent reaches a flow's callbacks and hooks through -- and nothing else.
+
+- Every one of them MUST be under this one command rather than beside `hmz exec` at the top.
+  Four more entries in the top-level listing would read as four more things to do with
+  humanize, which is the opposite of what they are: they name no capability a person wants,
+  and a listing is read for what there is to do.
+- It MUST be one of the commands a listing shows, and what is under it MUST be documented. A
+  command nobody can discover is a command nobody can debug, and every one of these is what a
+  person finds in a process table, a `ps` line or a backend's error when a run has gone wrong
+  -- so hiding them costs exactly the people who most need them named. A listing that leaves
+  out half of what a program runs is worse than one with a door marked `internal` on it: the
+  first is untrue about the program, and the second is true and says where not to go.
+- None of them MUST be a line anybody types by hand. Being listed is documentation of what
+  humanize runs, not an invitation: each is a command line because starting a process needs
+  one, each takes arguments only humanize knows how to render, and the help of each MUST say
+  so.
+- Everything after the name of one of them MUST reach it untouched, `--help` included, for
+  the reason the top of the line works that way: each answers for its own arguments, and a
+  parser here that ate one would be a second spelling of every line humanize renders.
+- Reaching one of them MUST cost no module of any of the others, exactly as at the top of the
+  line: the door is a lookup and not a layer.
+
+## `hmz internal anchor`
+
+```shell
+hmz internal anchor [<options>] <agent> [<args>...]
+hmz internal anchor serve --export <virtual>[:<real>] (--stdio | --listen [<host>:]<port>)
 ```
 
 Runs an agent here whose work lands on another machine, and -- under `serve` -- is the half
 that lands it. What each of the two takes is `coganchor`'s and is specified there.
 
 - It MUST be a command of its own because a turn whose work lands elsewhere is a process of
-  its own -- one holding a session to a target, with the agent under it -- and it MUST NOT be
-  one of the commands a listing shows nor be documented as a way in. humanize spawns it for
-  every such turn, the agent's own configuration rendering the line, and the zipapp
-  bootstrapped onto a target runs `hmz anchor serve` to answer one. Neither is a line anybody
-  types.
+  its own -- one holding a session to a target, with the agent under it. humanize spawns it
+  for every such turn, the agent's own configuration rendering the line, and the zipapp
+  bootstrapped onto a target runs `hmz internal anchor serve` to answer one. Neither is a line
+  anybody types.
 - Reaching it MUST load `coganchor` and nothing else of humanize, since `serve` is what runs
   on a target where it is the only layer there is and the architecture is whatever the target
-  happens to be.
+  happens to be. That MUST hold through `internal` as well: the door is what the bundled
+  target half is reached through.
 
-## `hmz cred`
+## `hmz internal cred`
 
 ```shell
-hmz cred --map <from>=<to> [--map ...] -- <command> [<args>...]
+hmz internal cred --map <from>=<to> [--map ...] -- <command> [<args>...]
 ```
 
 Runs a program with some of its paths answered by others, and exits with its status. What a
 turn under a provider is spawned as, and what a login run for one is spawned as.
 
 - It MUST be a command of its own rather than something the driver does in this process, for
-  the reason `hmz anchor` is: the supervisor forks the program and takes the process's signal
-  handling with it, which a flow pumping turns from threads of its own cannot lend it.
-- It MUST NOT be one of the commands a listing shows, and MUST NOT be documented as a way in:
-  it is a command line because a process is started by one, not because it is a thing anybody
-  types. What it runs is whatever it is given, so a listing offering it would be offering a
-  way to run something that is not humanize.
+  the reason `hmz internal anchor` is: the supervisor forks the program and takes the
+  process's signal handling with it, which a flow pumping turns from threads of its own cannot
+  lend it.
+- It MUST be under `internal` rather than at the top of the listing: it is a command line
+  because a process is started by one, not because it is a thing anybody types, and what it
+  runs is whatever it is given -- an entry beside `hmz exec` would read as humanize offering
+  to run something that is not humanize. What it is MUST still be written down, there and in
+  the documentation: it is the process a turn under an account actually runs as, so it is the
+  name on the failure when an account's credentials were not where it looked.
 - A line naming nothing to answer MUST be a usage error: a run with nothing to redirect is a
   supervisor started for no reason.
 
-## `hmz tools`
+## `hmz internal tools`
 
 ```shell
-hmz tools --at <socket>
+hmz internal tools --at <socket>
 ```
 
 Carries the tool protocol between a coding agent and the flow whose callbacks it is: this
 process's standard input into the flow's socket, and the flow's answers back out again.
 
-- It MUST be a command of its own for the reason `hmz cred` is, the other way round: a CLI
-  takes a tool by starting a program, so there has to be a program. It MUST NOT be one of the
-  commands a listing shows and MUST NOT be documented as a way in.
+- It MUST be a command of its own for the reason `hmz internal cred` is, the other way round:
+  a CLI takes a tool by starting a program, so there has to be a program. It MUST be under
+  `internal` with the rest, listed and documented as what it is: the line a backend's own tool
+  configuration holds is this one, and somebody reading that configuration has to be able to
+  look it up.
 - It MUST do nothing but carry lines. The callback belongs in the process the flow is in, and
   anything answered here would be a tool the flow never wrote.
 - Both directions MUST be carried at once, and the end of either MUST end the other: a CLI that
@@ -1064,19 +1106,21 @@ process's standard input into the flow's socket, and the flow's answers back out
 - A socket that is not there MUST be a status rather than a crash: it is a flow that has ended,
   and a CLI reads it as its tools being unavailable rather than as a turn that failed.
 
-## `hmz hook`
+## `hmz internal hook`
 
 ```shell
-hmz hook --at <socket>
+hmz internal hook --at <socket>
 ```
 
 Carries one call of a coding agent's own hook table to the flow whose moment it is, and the
 verdict back again. It is what makes a refusal at `PreToolUse` stop the tool rather than
 describe one that has already run, and what it serves is specified in `agents.md`.
 
-- It MUST be a command of its own for the reason `hmz tools` is: a CLI takes a hook by starting
-  a program and waiting for what it says, so there has to be a program. It MUST NOT be one of
-  the commands a listing shows and MUST NOT be documented as a way in.
+- It MUST be a command of its own for the reason `hmz internal tools` is: a CLI takes a hook by
+  starting a program and waiting for what it says, so there has to be a program. It MUST be
+  under `internal` with the rest, listed and documented: it is the line written into a CLI's
+  own hook table, it is spawned once per tool call, and it is what shows up when a gate stops
+  answering -- all of which is unreadable if the command has no name anybody may look up.
 - It MUST do nothing but carry the one call. The hook belongs in the process the flow is in,
   and anything decided here would be a verdict the flow never gave.
 - It MUST exit zero whatever the flow said, and MUST NOT exit with the status these CLIs read

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -357,8 +357,8 @@ stops and waits to be told, and `Gate` is what stands in that place.
   comes down while the agent runs, so a table that depended on what was hung when the CLI
   started would be one that had to restart the CLI; what is hung MUST be asked at the moment it
   fires, which is the only moment the answer is true.
-- The relay MUST be `hmz hook`, and the callback MUST run in the process the flow is in, for
-  the reason `hmz tools` exists: a hook that ran anywhere else would be a subprocess and not a
+- The relay MUST be `hmz internal hook`, and the callback MUST run in the process the flow is
+  in, for the reason `hmz internal tools` exists: a hook that ran anywhere else would be a subprocess and not a
   callable of the flow's. The socket MUST be in a directory this user alone may enter.
 - A CLI whose table will not run until it has been trusted, where that trust is a thing
   written into the person's own configuration, MUST NOT be given one. Codex is that CLI: it

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -358,8 +358,8 @@ stops and waits to be told, and `Gate` is what stands in that place.
   started would be one that had to restart the CLI; what is hung MUST be asked at the moment it
   fires, which is the only moment the answer is true.
 - The relay MUST be `hmz internal hook`, and the callback MUST run in the process the flow is
-  in, for the reason `hmz internal tools` exists: a hook that ran anywhere else would be a subprocess and not a
-  callable of the flow's. The socket MUST be in a directory this user alone may enter.
+  in, for the reason `hmz internal tools` exists: a hook that ran anywhere else would be a
+  subprocess and not a callable of the flow's. The socket MUST be in a directory this user alone may enter.
 - A CLI whose table will not run until it has been trusted, where that trust is a thing
   written into the person's own configuration, MUST NOT be given one. Codex is that CLI: it
   takes `hooks.pre_tool_use` through the same `-c` its other settings go through, but a hook

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -167,7 +167,7 @@ line, with what the flow is doing beside the transcript.
   line: an account outlives the flow that was set up with it, and the one place a person is
   asked anything is the one place a credential can be typed. It is the one thing said in both
   places, and the same store either way.
-- `hmz anchor` MUST NOT be a command here: it is not a thing to do to a flow that is running,
+- `hmz internal anchor` MUST NOT be a command here: it is not a thing to do to a flow that is running,
   and a command that only ever means one thing is a command line. Gathering a trace MUST NOT
   be one either -- it is a thing done to a run that has already happened, so it is one of the
   things `/epics` offers about the run under the cursor rather than a command of its own.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -167,8 +167,8 @@ line, with what the flow is doing beside the transcript.
   line: an account outlives the flow that was set up with it, and the one place a person is
   asked anything is the one place a credential can be typed. It is the one thing said in both
   places, and the same store either way.
-- `hmz internal anchor` MUST NOT be a command here: it is not a thing to do to a flow that is running,
-  and a command that only ever means one thing is a command line. Gathering a trace MUST NOT
+- `hmz internal anchor` MUST NOT be a command here: it is not a thing to do to a flow that is
+  running, and a command that only ever means one thing is a command line. Gathering a trace MUST NOT
   be one either -- it is a thing done to a run that has already happened, so it is one of the
   things `/epics` offers about the run under the cursor rather than a command of its own.
 - `/resume` MUST carry the last run in this directory on, as `/epics` carries the run under

--- a/src/hmz/cli/__init__.py
+++ b/src/hmz/cli/__init__.py
@@ -7,14 +7,21 @@ There is one command anybody types, and everything else humanize keeps is walked
 prompt: a listing with a noun in it for every store would be a second interface to learn, and
 the one with the sheets in it is the interface.
 
+The other command in the listing is `hmz internal`, which is the four lines humanize spawns
+for itself gathered under one name. They are listed rather than hidden because a command
+nobody can discover is a command nobody can debug, and a listing that leaves out half of what
+a program runs says something untrue about it. What they are is said instead of concealed:
+one door marked `internal`, so that `hmz --help` is the whole of what this program does and
+still reads as one command anybody types.
+
 A command imports what it needs when it is the one asked for, and no earlier. Two things turn
 on that: `hmz exec` must not pay for the terminal interface it is not opening, and
-`hmz anchor serve` is what the zipapp bootstrapped onto a target runs, where coganchor is the
-only layer present and the architecture is whatever the target happens to be.
+`hmz internal anchor serve` is what the zipapp bootstrapped onto a target runs, where
+coganchor is the only layer present and the architecture is whatever the target happens to be.
 
 A command whose line takes a parser of its own has a module of its own here, so that reaching
 one of them costs nothing for the others -- which is what `anchor.py`, `cred.py`, `hook.py` and
-`tools.py`, the four humanize spawns for itself, are. `exec` has none: the line it takes is
+`tools.py`, the four under `hmz internal`, are. `exec` has none: the line it takes is
 read by :func:`hmz.runtime.runner.flow_and_agents`, since the terminal interface starts a flow from
 that same line.
 
@@ -34,7 +41,7 @@ if TYPE_CHECKING:
 
     from hmz.daemon import Held
 
-__all__ = ["APART", "COMMANDS", "apart", "main", "many", "opens"]
+__all__ = ["APART", "COMMANDS", "INTERNAL", "apart", "main", "many", "opens"]
 
 #: What says whether a run may be held apart from the terminal at all, for a machine that
 #: would rather it went with the window. `off`, `0` or `no`; anything else is silence, and
@@ -188,6 +195,44 @@ def _hook(argv: list[str]) -> int:
     from .hook import hook
 
     return hook(argv)
+
+
+def _internal(argv: list[str]) -> int:
+    """Routes to whichever of the lines humanize spawns for itself was named.
+
+    The same routing as the top of the line, one level down, and for the same reason: a name
+    it knows is handed the rest of the line untouched, so that `hmz internal anchor --help` is
+    answered by the anchor's own parser rather than eaten by this one, and reaching one of
+    them loads no module of any other. Anything else -- a name nobody has, or nothing at all
+    -- is answered by a parser built here, which lists the four and exits.
+
+    Args:
+      argv: What followed `internal`, beginning with the name of one of them.
+
+    Returns:
+      That command's exit status.
+    """
+    if not argv or argv[0] not in INTERNAL:
+        import argparse
+
+        # Its own parser rather than a subparser of the one at the top: the top-level help
+        # names the commands and not what they take, so this is where the four are written
+        # out, and it is reached only when somebody asks about them.
+        parser = argparse.ArgumentParser(
+            prog="hmz internal",
+            description="What humanize spawns for itself: an agent's turn on another "
+            "machine, a turn under an account, and the two relays a coding agent reaches a "
+            "flow's own callbacks and hooks through. Each is a command line because a "
+            "process is started by one, and none of them is a line to type.",
+            epilog="Run `hmz internal COMMAND --help` for what a command takes.",
+        )
+        commands = parser.add_subparsers(metavar="COMMAND", required=True)
+        for name, (_, summary) in INTERNAL.items():
+            commands.add_parser(name, help=summary, add_help=False)
+        # Says which there are and exits, so nothing below this runs.
+        parser.parse_args(argv)
+
+    return INTERNAL[argv[0]][0](argv[1:])
 
 
 def _line() -> ArgumentParser:
@@ -347,28 +392,41 @@ def _at_a_terminal() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-#: Each command, as what carries it out and the line a listing shows it as. There is one:
-#: running a flow in a directory is what a line is for, and everything else humanize keeps is
-#: walked at the prompt rather than typed. There is no command for the terminal interface
-#: either: naming nothing at all is how it opens.
-COMMANDS = {
-    "exec": (_exec, "run an agent flow in this directory"),
+#: What humanize spawns for itself, each as what carries it out and the line `hmz internal`
+#: shows it as. A turn taken as an account runs the CLI with the paths it keeps its
+#: credentials at pointed into that account's directory, and the supervisor doing the pointing
+#: has to be a process of its own -- it forks the program and takes the signal handling with
+#: it, which a flow pumping turns from threads of its own has none to lend. A flow's own
+#: callbacks are the same shape the other way round: a CLI takes a tool by starting a program,
+#: so there is a program, and it does nothing but carry the protocol back to the process the
+#: callbacks are in. A moment of a flow's is that same shape once more: a CLI takes a hook by
+#: starting a program and waiting for what it says, which is the one place a `PreToolUse` can
+#: be refused rather than watched. An anchored turn is the fourth: `AnchorConfig.command()`
+#: renders one for every turn whose work lands on another machine, and the zipapp
+#: bootstrapped onto a target answers it by running `hmz internal anchor serve`. All four are
+#: a command line because there is no other way to start a process, and none of them is a line
+#: anybody types -- which is a reason to keep them together under one name and behind one
+#: sentence saying so, and not a reason to keep them out of the listing. A command that is not
+#: in the listing is one nobody can look up when it is the thing that failed, and every one of
+#: these fails where a person is reading: a relay that could not reach a flow, a supervisor
+#: whose program was not there, a target that answered nothing.
+INTERNAL = {
+    "anchor": (_anchor, "take a turn whose work lands on another machine"),
+    "cred": (_cred, "run a program with its credentials answered from elsewhere"),
+    "hook": (_hook, "carry one moment of a coding agent's hook table to a flow"),
+    "tools": (_tools, "carry a coding agent's tool calls to the flow whose they are"),
 }
 
-#: What humanize spawns for itself, carried out like any command and listed as none of them.
-#: A turn taken as an account runs the CLI with the paths it keeps its credentials at pointed
-#: into that account's directory, and the supervisor doing the pointing has to be a process of
-#: its own -- it forks the program and takes the signal handling with it, which a flow pumping
-#: turns from threads of its own has none to lend. A flow's own callbacks are the same shape
-#: the other way round: a CLI takes a tool by starting a program, so there is a program, and it
-#: does nothing but carry the protocol back to the process the callbacks are in. A moment of a
-#: flow's is that same shape once more: a CLI takes a hook by starting a program and waiting
-#: for what it says, which is the one place a `PreToolUse` can be refused rather than watched.
-#: An anchored turn is the fourth: `AnchorConfig.command()` renders one for every turn whose
-#: work lands on another machine, and the zipapp bootstrapped onto a target answers it by
-#: running `hmz anchor serve`. All four are a command line because there is no other way to
-#: start a process, and none of them is a line anybody types.
-_SPAWNED = {"anchor": _anchor, "cred": _cred, "hook": _hook, "tools": _tools}
+#: Each command, as what carries it out and the line a listing shows it as. One is for
+#: anybody: running a flow in a directory is what a line is for, and everything else humanize
+#: keeps is walked at the prompt rather than typed. The other is the door onto :data:`INTERNAL`
+#: -- one entry rather than four, so that what a person may type stays one line long while
+#: what humanize runs stays something they can read. There is no command for the terminal
+#: interface either: naming nothing at all is how it opens.
+COMMANDS = {
+    "exec": (_exec, "run an agent flow in this directory"),
+    "internal": (_internal, "what humanize spawns for itself; not a line to type"),
+}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -395,7 +453,7 @@ def main(argv: list[str] | None = None) -> int:
         ["-h"],
     ):
         return _tui(arguments)
-    if arguments[0] not in COMMANDS and arguments[0] not in _SPAWNED:
+    if arguments[0] not in COMMANDS:
         if arguments == ["--version"]:
             # Read from the installed metadata, which costs more to reach than everything
             # else here put together -- so it is reached only when it is what was asked for.
@@ -410,13 +468,15 @@ def main(argv: list[str] | None = None) -> int:
 
         # The same line `hmz` itself takes, with the commands added: one help, saying both
         # what may be opened and what may be run, since both are `hmz` and somebody typing
-        # `hmz --help` is asking about the whole of it. It knows the commands by name and not
-        # by what they take -- each one answers `hmz COMMAND --help` itself.
+        # `hmz --help` is asking about the whole of it. Every command is in it, including the
+        # door onto what humanize spawns for itself -- a listing that showed only the line a
+        # person types would be describing a different program from the one that runs. It
+        # knows the commands by name and not by what they take -- each one answers
+        # `hmz COMMAND --help` itself.
         parser = _line()
         commands = parser.add_subparsers(metavar="COMMAND", required=True)
         for name, (_, summary) in COMMANDS.items():
             commands.add_parser(name, help=summary, add_help=False)
         parser.parse_args(arguments)
 
-    carries = _SPAWNED.get(arguments[0])
-    return (carries or COMMANDS[arguments[0]][0])(arguments[1:])
+    return COMMANDS[arguments[0]][0](arguments[1:])

--- a/src/hmz/cli/anchor.py
+++ b/src/hmz/cli/anchor.py
@@ -101,7 +101,9 @@ def _serve(argv: list[str]) -> int:
 
     parser = argparse.ArgumentParser(
         prog="hmz internal anchor serve",
-        description="Replay an `hmz internal anchor` session's operations on this machine.",
+        description="Replay an `hmz internal anchor` session's operations on this "
+        "machine. The zipapp bootstrapped onto a target runs this line to answer a "
+        "session; it is not one to type by hand.",
     )
     parser.add_argument(
         "--export",

--- a/src/hmz/cli/anchor.py
+++ b/src/hmz/cli/anchor.py
@@ -1,4 +1,4 @@
-"""``hmz anchor`` -- both halves of a session, routed apart before either is reached.
+"""``hmz internal anchor`` -- both halves of a session, routed apart before either is reached.
 
 `serve` is what the zipapp bootstrapped onto a target runs, and it is answered first: only
 the agent half needs ptrace and an x86-64 register map, which is what lets the same program
@@ -48,7 +48,7 @@ def anchor(argv: list[str]) -> int:
         stream=sys.stderr,
     )
     if not args.command and not args.check:
-        parser.error("no agent given; try `hmz anchor claude`")
+        parser.error("no agent given; try `hmz internal anchor claude`")
     try:
         config = line.settings(args)
     except ValueError as exc:
@@ -85,7 +85,7 @@ def anchor(argv: list[str]) -> int:
 
 
 def _serve(argv: list[str]) -> int:
-    """Replays on this machine what an `hmz anchor` elsewhere asks of it.
+    """Replays on this machine what an `hmz internal anchor` elsewhere asks of it.
 
     Args:
       argv: What followed the command name.
@@ -100,8 +100,8 @@ def _serve(argv: list[str]) -> int:
     import os
 
     parser = argparse.ArgumentParser(
-        prog="hmz anchor serve",
-        description="Replay an `hmz anchor` session's operations on this machine.",
+        prog="hmz internal anchor serve",
+        description="Replay an `hmz internal anchor` session's operations on this machine.",
     )
     parser.add_argument(
         "--export",

--- a/src/hmz/cli/cred.py
+++ b/src/hmz/cli/cred.py
@@ -29,7 +29,9 @@ def cred(argv: list[str]) -> int:
 
     parser = argparse.ArgumentParser(
         prog="hmz internal cred",
-        description="Run a coding agent whose credentials are kept somewhere else.",
+        description="Run a coding agent whose credentials are kept somewhere else. "
+        "humanize renders this line for every turn taken as an account; it is not one to "
+        "type by hand.",
     )
     parser.add_argument(
         "--map",

--- a/src/hmz/cli/cred.py
+++ b/src/hmz/cli/cred.py
@@ -1,12 +1,12 @@
-"""``hmz cred`` -- run a program with some of its paths answered by others.
+"""``hmz internal cred`` -- run a program with some of its paths answered by others.
 
 What a turn under a provider is spawned as, and what a login run for one is spawned as: the
 program runs here, unchanged and on this terminal, and the handful of syscalls that name one
 of its credential files are handed a path inside the provider's directory instead.
 
 Its own command rather than something the driver does in this process, for the reason
-`hmz anchor` is: the supervisor forks the program and takes the process's signal handling with
-it, which a flow pumping turns from threads of its own has no way to lend it.
+`hmz internal anchor` is: the supervisor forks the program and takes the process's signal
+handling with it, which a flow pumping turns from threads of its own has no way to lend it.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ def cred(argv: list[str]) -> int:
     import argparse
 
     parser = argparse.ArgumentParser(
-        prog="hmz cred",
+        prog="hmz internal cred",
         description="Run a coding agent whose credentials are kept somewhere else.",
     )
     parser.add_argument(
@@ -52,7 +52,9 @@ def cred(argv: list[str]) -> int:
 
     command = args.command[1:] if args.command[:1] == ["--"] else args.command
     if not command:
-        parser.error("no program given; try `hmz cred --map FROM=TO -- claude`")
+        parser.error(
+            "no program given; try `hmz internal cred --map FROM=TO -- claude`"
+        )
     try:
         swaps = redirect.read(args.maps)
     except ValueError as why:
@@ -66,5 +68,5 @@ def cred(argv: list[str]) -> int:
         # A run that could not be supervised must not fall back to running unsupervised: the
         # program would read the credentials of whoever is at this machine, which is a turn
         # taken as the wrong account rather than a turn that failed.
-        print(f"hmz cred: {why}", file=sys.stderr)
+        print(f"hmz internal cred: {why}", file=sys.stderr)
         return 1

--- a/src/hmz/cli/hook.py
+++ b/src/hmz/cli/hook.py
@@ -1,4 +1,4 @@
-"""`hmz hook`: the one call a coding agent's own hook table makes, relayed to a flow.
+"""`hmz internal hook`: the one call a coding agent's own hook table makes, relayed to a flow.
 
 A moment of a flow's is a Python callable in the flow's own process, and a CLI takes a hook by
 starting a program, writing what is happening on its stdin and reading what to do about it off
@@ -10,9 +10,9 @@ was reached for and then the tool runs, so a verdict read off that stream arrive
 be one; the CLI's own table is the one place it is waiting to be told, and this is what stands
 in that place.
 
-Spawned rather than typed, like `hmz cred` and `hmz tools`: it is a command line because
-starting a process is what a backend does with a hook, and not because it is a thing anybody
-runs by hand.
+Spawned rather than typed, like `hmz internal cred` and `hmz internal tools`: it is a command
+line because starting a process is what a backend does with a hook, and not because it is a
+thing anybody runs by hand.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def hook(argv: list[str]) -> int:
     """Carries one call of a CLI's hook table to the flow whose moment it is.
 
     Args:
-      argv: The arguments after `hmz hook`.
+      argv: The arguments after `hmz internal hook`.
 
     Returns:
       Zero, whatever the flow said and whether or not it was there to say it, and one for a
@@ -40,7 +40,7 @@ def hook(argv: list[str]) -> int:
       gone says is nothing, which is the tool going ahead exactly as it would have.
     """
     parser = argparse.ArgumentParser(
-        prog="hmz hook",
+        prog="hmz internal hook",
         description="relay one hook call to the flow whose moment it is",
     )
     parser.add_argument(
@@ -70,7 +70,7 @@ def hook(argv: list[str]) -> int:
         # A flow that has ended. Said where a person would see it and nowhere the agent will:
         # every one of these CLIs shows a hook's stderr and goes on with the turn, which is
         # what a gate with nobody behind it has to come to.
-        print(f"hmz hook: {args.at}: {why}", file=sys.stderr)
+        print(f"hmz internal hook: {args.at}: {why}", file=sys.stderr)
         held.close()
         return 0
     answer = b""

--- a/src/hmz/cli/hook.py
+++ b/src/hmz/cli/hook.py
@@ -41,7 +41,9 @@ def hook(argv: list[str]) -> int:
     """
     parser = argparse.ArgumentParser(
         prog="hmz internal hook",
-        description="relay one hook call to the flow whose moment it is",
+        description="relay one hook call to the flow whose moment it is. humanize writes "
+        "this line into a coding agent's own hook table and the agent spawns it; it is "
+        "not one to type by hand",
     )
     parser.add_argument(
         "--at",

--- a/src/hmz/cli/tools.py
+++ b/src/hmz/cli/tools.py
@@ -35,7 +35,9 @@ def tools(argv: list[str]) -> int:
     """
     parser = argparse.ArgumentParser(
         prog="hmz internal tools",
-        description="relay the tool protocol to the flow whose callbacks these are",
+        description="relay the tool protocol to the flow whose callbacks these are. "
+        "humanize writes this line into a coding agent's own tool configuration and the "
+        "agent spawns it; it is not one to type by hand",
     )
     parser.add_argument(
         "--at",

--- a/src/hmz/cli/tools.py
+++ b/src/hmz/cli/tools.py
@@ -1,12 +1,13 @@
-"""`hmz tools`: the pipe a coding agent speaks the tool protocol over, relayed to a flow.
+"""`hmz internal tools`: the pipe a coding agent speaks the tool protocol over, relayed to a flow.
 
 A callback of a flow's is a Python function in the flow's own process, and a CLI takes a tool
 by starting a program and talking to it over that program's stdin and stdout. This is the
 program: it does nothing but carry each line between the two, so that the function runs where
 the flow is rather than in a process of its own.
 
-Spawned rather than typed, like `hmz cred`: it is a command line because starting a process is
-what a backend does with a tool server, and not because it is a thing anybody runs by hand.
+Spawned rather than typed, like `hmz internal cred`: it is a command line because starting a
+process is what a backend does with a tool server, and not because it is a thing anybody runs
+by hand.
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ def tools(argv: list[str]) -> int:
     """Relays this process's stdin and stdout to a flow's toolbox.
 
     Args:
-      argv: The arguments after `hmz tools`.
+      argv: The arguments after `hmz internal tools`.
 
     Returns:
       Zero once either end has gone, and one for a socket that is not there -- which is a
@@ -33,7 +34,7 @@ def tools(argv: list[str]) -> int:
       turn that failed.
     """
     parser = argparse.ArgumentParser(
-        prog="hmz tools",
+        prog="hmz internal tools",
         description="relay the tool protocol to the flow whose callbacks these are",
     )
     parser.add_argument(
@@ -47,7 +48,7 @@ def tools(argv: list[str]) -> int:
     try:
         held.connect(args.at)
     except OSError as why:
-        print(f"hmz tools: {args.at}: {why}", file=sys.stderr)
+        print(f"hmz internal tools: {args.at}: {why}", file=sys.stderr)
         held.close()
         return 1
 

--- a/src/hmz/coganchor/agents/claude.py
+++ b/src/hmz/coganchor/agents/claude.py
@@ -317,7 +317,7 @@ class ClaudeCodeSession(StreamSessionBase):
         Claude has announced the tool and is about to run it: a flow refusing one would be
         describing what already happened. Claude's own table is the one place it stops and
         waits to be told, so that is where humanize puts the moment -- pointed at
-        `hmz hook --at <socket>`, which carries it back to the hooks hung on this agent.
+        `hmz internal hook --at <socket>`, which carries it back to the hooks hung on this agent.
 
         Said whether or not anything is hung on that moment, and not made conditional on it:
         a hook goes up and comes down while the agent runs, and a table that depended on what

--- a/src/hmz/coganchor/agents/hooks.py
+++ b/src/hmz/coganchor/agents/hooks.py
@@ -570,8 +570,9 @@ def _serves(
 class Gate:
     """One agent's moments, served where the CLI's own hook table can reach them.
 
-    A CLI takes a hook as a program to run, so there is a program -- `hmz hook --at <socket>`,
-    which does nothing but carry the one call back to this process. The socket is in a
+    A CLI takes a hook as a program to run, so there is a program --
+    `hmz internal hook --at <socket>`, which does nothing but carry the one call back to this
+    process. The socket is in a
     directory this user alone may enter, made in this process and taken away with it, and what
     answers is the flow's own :class:`Hooks`: the same callables a turn fires from its own
     thread, fired here from the CLI's instead. Which is the whole of the difference this
@@ -683,7 +684,7 @@ class Gate:
         """
         import sys
 
-        return [sys.executable, "-m", "hmz", "hook", "--at", self.address()]
+        return [sys.executable, "-m", "hmz", "internal", "hook", "--at", self.address()]
 
     def table(self, wait: int) -> dict[str, Any]:
         """These moments as the hook table a CLI's own settings hold.

--- a/src/hmz/coganchor/agents/tools.py
+++ b/src/hmz/coganchor/agents/tools.py
@@ -14,7 +14,7 @@ of these CLIs already takes a tool it was not shipped with. It is spoken here ra
 through a client library for the reason `hmz.coganchor` speaks its own protocol here: what is
 needed is four methods of a JSON-RPC subset over a pipe, in a process that is threaded rather
 than asynchronous, and every library for it is written the other way round. What a backend is
-handed is a command to run -- `hmz tools --at <socket>` -- which relays that pipe to this
+handed is a command to run -- `hmz internal tools --at <socket>` -- which relays that pipe to this
 process. The callback therefore runs where the flow is, which is the whole point: a tool that
 ran anywhere else would be a subprocess and not a callback.
 
@@ -220,7 +220,15 @@ class Toolbox:
         """
         import sys
 
-        return [sys.executable, "-m", "hmz", "tools", "--at", self.address()]
+        return [
+            sys.executable,
+            "-m",
+            "hmz",
+            "internal",
+            "tools",
+            "--at",
+            self.address(),
+        ]
 
     def config(self, named: str = _WHOSE) -> dict[str, Any]:
         """These callbacks as the entry a CLI's own MCP configuration holds.

--- a/src/hmz/coganchor/argv.py
+++ b/src/hmz/coganchor/argv.py
@@ -1,4 +1,4 @@
-"""The `hmz anchor` line, both ways round: read into settings, and written back out.
+"""The `hmz internal anchor` line, both ways round: read into settings, and written back out.
 
 Here rather than in the command line, because the two directions have to agree and only one
 of them is a command line. :meth:`~hmz.coganchor.anchor.AnchorConfig.command` renders a
@@ -22,7 +22,7 @@ __all__ = ["parser", "render", "settings"]
 
 
 def parser() -> ArgumentParser:
-    """Builds the parser for `hmz anchor`, whose every option is a setting of the session.
+    """Builds the parser for `hmz internal anchor`, whose every option is a setting of the session.
 
     Returns:
       A parser whose result is what :class:`~hmz.coganchor.anchor.AnchorConfig` takes.
@@ -31,9 +31,9 @@ def parser() -> ArgumentParser:
     import os
 
     built = argparse.ArgumentParser(
-        prog="hmz anchor",
+        prog="hmz internal anchor",
         description="Run a coding agent on this machine that acts on another one.",
-        epilog="Example: hmz anchor --target ssh://build-box claude --model opus",
+        epilog="Example: hmz internal anchor --target ssh://build-box claude --model opus",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     built.add_argument(
@@ -217,7 +217,7 @@ def settings(args: Namespace) -> AnchorConfig:
 
 
 def render(config: AnchorConfig, argv: Sequence[str]) -> list[str]:
-    """Writes the settings back out as the `hmz anchor` line that would read as them.
+    """Writes the settings back out as the `hmz internal anchor` line that would read as them.
 
     The interpreter is named explicitly, so the child is the one humanize is installed in
     whether or not the console script is on PATH.
@@ -262,7 +262,7 @@ def render(config: AnchorConfig, argv: Sequence[str]) -> list[str]:
         options.append("--force")
     if config.native:
         options.append("--native")
-    return [sys.executable, "-m", "hmz", "anchor", *options, *argv]
+    return [sys.executable, "-m", "hmz", "internal", "anchor", *options, *argv]
 
 
 def _pair(said: str) -> tuple[str, str]:

--- a/src/hmz/coganchor/argv.py
+++ b/src/hmz/coganchor/argv.py
@@ -32,8 +32,13 @@ def parser() -> ArgumentParser:
 
     built = argparse.ArgumentParser(
         prog="hmz internal anchor",
-        description="Run a coding agent on this machine that acts on another one.",
-        epilog="Example: hmz internal anchor --target ssh://build-box claude --model opus",
+        # Wrapped by hand: the raw formatter below keeps the epilog's own line breaks,
+        # and pays for that by not re-wrapping the description either.
+        description="Run a coding agent on this machine that acts on another one.\n"
+        "humanize renders this line for every turn whose work lands\n"
+        "elsewhere; it is not one to type by hand.",
+        epilog="What humanize renders looks like this:\n"
+        "  hmz internal anchor --target ssh://build-box claude --model opus",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     built.add_argument(

--- a/src/hmz/coganchor/providers/redirect.py
+++ b/src/hmz/coganchor/providers/redirect.py
@@ -139,7 +139,7 @@ def command(
     if not held:
         return list(argv)
     mapped = [f"--map={named}={instead}" for named, instead in held.pairs]
-    return [sys.executable, "-m", "hmz", "cred", *mapped, "--", *argv]
+    return [sys.executable, "-m", "hmz", "internal", "cred", *mapped, "--", *argv]
 
 
 def run(swaps: Swaps, argv: Sequence[str]) -> int:

--- a/src/hmz/coganchor/remote.py
+++ b/src/hmz/coganchor/remote.py
@@ -1,4 +1,4 @@
-"""Client for a connection to ``hmz anchor`` on the target.
+"""Client for a connection to ``hmz internal anchor`` on the target.
 
 One reader thread demultiplexes replies by message id.  Filesystem calls are
 synchronous -- the traced process is stopped anyway, so blocking the caller

--- a/src/hmz/coganchor/serve/__init__.py
+++ b/src/hmz/coganchor/serve/__init__.py
@@ -1,6 +1,6 @@
 """The target half: carrying out on this machine what a client asks for.
 
-Reached as ``hmz anchor``.  Nothing here may import from the agent half of
+Reached as ``hmz internal anchor``.  Nothing here may import from the agent half of
 the package -- only :mod:`hmz.coganchor.proto` is shared -- because this is the
 half that runs on the target, where there is no ptrace, no seccomp filter and
 no guarantee of an x86-64 register map.

--- a/src/hmz/coganchor/serve/listener.py
+++ b/src/hmz/coganchor/serve/listener.py
@@ -88,7 +88,7 @@ def serve_forever(host: str, port: int, table: ExportTable, token: str | None) -
         # Not a message but a handshake: whoever started this reads the port it landed on
         # off this line, a port of 0 having been the way to ask for any free one.
         print(  # noqa: T201
-            f"hmz anchor serve listening {bound[0]} {bound[1]}",
+            f"hmz internal anchor serve listening {bound[0]} {bound[1]}",
             file=sys.stderr,
             flush=True,
         )

--- a/src/hmz/coganchor/transport.py
+++ b/src/hmz/coganchor/transport.py
@@ -11,7 +11,7 @@ Four ways in:
     machine like any other here; it needs no port, no secret and no cooperation
     beyond a ``python3``.
 ``tcp://host:port``
-    Attach to an ``hmz anchor serve --listen`` someone already started.
+    Attach to an ``hmz internal anchor serve --listen`` someone already started.
 ``local[:REAL]``
     Run ``serve`` as a child process on this machine.  Used for development and
     by the test suite, where ``REAL`` is the directory standing in for the
@@ -198,6 +198,7 @@ def _connect_local(target: Target, exports: list[str], token: str | None) -> Tra
         sys.executable,
         "-m",
         "hmz",
+        "internal",
         "anchor",
         "serve",
         "--stdio",
@@ -259,7 +260,14 @@ def _connect_docker(target: Target, exports: list[str]) -> Transport:
 
     # Unquoted, unlike ssh: docker is handed the command as argv and passes it on, so an export
     # holding a space or a quote needs nothing done to it to survive the trip.
-    serve = [remote_file, "anchor", "serve", "--stdio", *_export_args(exports)]
+    serve = [
+        remote_file,
+        "internal",
+        "anchor",
+        "serve",
+        "--stdio",
+        *_export_args(exports),
+    ]
     return _spawn([*exec_in, *python_command(serve)], None)
 
 
@@ -297,6 +305,7 @@ def _ssh_serve_line(remote_file: str, exports: list[str]) -> str:
             "exec",
             *(shlex.quote(word) for word in python_command([])),
             remote_file,
+            "internal",
             "anchor",
             "serve",
             "--stdio",
@@ -390,8 +399,8 @@ def build_bundle(destination: Path | None = None) -> Path:
                 f'"""{".".join(parts[:depth])}, cut down to {parts[depth]}."""\n'
             )
         # The command line comes too, because it is the only one: what the target runs is the
-        # same ``hmz anchor`` a user would run there, and each of its commands names the layers
-        # it needs only from inside itself, none of which is this one.
+        # same ``hmz internal anchor`` a user would run there, and each of its commands names
+        # the layers it needs only from inside itself, none of which is this one.
         # Taken off disk rather than imported, so that the serving half still names nothing
         # above itself.
         package = Path(coganchor.__file__).parent.parent

--- a/src/hmz/sdk/core.py
+++ b/src/hmz/sdk/core.py
@@ -7,7 +7,7 @@ here, because there is one of each and one place to ask for it.
 
 Each of them is fetched when it is asked for and not before. A command line that only lists the
 places flows come from must not load the tracer, the sandbox and every coding agent driver
-there is to do it, and `hmz anchor` must not load any of this at all.
+there is to do it, and `hmz internal anchor` must not load any of this at all.
 """
 
 from __future__ import annotations

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -112,7 +112,7 @@ if TYPE_CHECKING:
 #: here is a flow rather than an agent, so opencode's `/agents` is `/flow`, and what a flow
 #: runs on is an agent apiece rather than one model, so its `/models` is the page along from
 #: it. There is no command for an agent on its own: an agent belongs to the flow that drives
-#: it, and is set up on the page of `/flow` its agents are on. `hmz anchor` is not here
+#: it, and is set up on the page of `/flow` its agents are on. `hmz internal anchor` is not here
 #: either: it is not a thing to do to a flow that is running, and it is a command line of its
 #: own. What a run left behind is `/epics`, which is where the runs of this directory are.
 _OWN = (

--- a/src/hmz/tui/complete.py
+++ b/src/hmz/tui/complete.py
@@ -8,8 +8,8 @@ starts one. A flow anywhere else is a path, and a path is typed: looking for one
 reading every Python file below here to see which declare a flow, which is a guess, and far
 too slow to make between keystrokes.
 
-`hmz anchor` is not offered: it is not something to do to a flow while it runs, and it takes
-a command line of its own. What a run left behind is `/epics`, which is where the runs are.
+`hmz internal anchor` is not offered: it is not something to do to a flow while it runs, and
+it takes a command line of its own. What a run left behind is `/epics`, which is where the runs are.
 """
 
 from __future__ import annotations

--- a/tests/agents/test_hooks_gate.py
+++ b/tests/agents/test_hooks_gate.py
@@ -216,7 +216,7 @@ def test_a_relay_with_no_flow_behind_it_lets_the_tool_through(serving: Hooks) ->
 
 def test_a_relay_given_a_line_it_cannot_read_still_refuses_nothing() -> None:
     """Argparse exits two for a bad line, and two is the one status this must never use."""
-    argv = [sys.executable, "-m", "hmz", "hook", "--nonsense"]
+    argv = [sys.executable, "-m", "hmz", "internal", "hook", "--nonsense"]
     done = subprocess.run(argv, input=b"{}", capture_output=True, check=False)
 
     assert done.returncode == 1
@@ -224,7 +224,13 @@ def test_a_relay_given_a_line_it_cannot_read_still_refuses_nothing() -> None:
 
 def test_the_relay_is_the_python_running_this_flow(serving: Hooks) -> None:
     """The callback is in this process, so what carries a call to it has to start here."""
-    assert serving.gate().command()[:4] == [sys.executable, "-m", "hmz", "hook"]
+    assert serving.gate().command()[:5] == [
+        sys.executable,
+        "-m",
+        "hmz",
+        "internal",
+        "hook",
+    ]
 
 
 def test_the_gate_is_reached_only_by_whoever_is_running_the_flow(

--- a/tests/agents/test_providers.py
+++ b/tests/agents/test_providers.py
@@ -246,7 +246,7 @@ def test_what_a_provider_adds_to_the_command_line_is_added_to_the_backends(
 
     spawned = agent.spawned(["claude", "--print"])
 
-    assert spawned[:4] == [sys.executable, "-m", "hmz", "cred"]
+    assert spawned[:5] == [sys.executable, "-m", "hmz", "internal", "cred"]
     # The backend's own line, the provider's arguments at the end of it.
     assert spawned[spawned.index("--") + 1 :] == [
         "claude",
@@ -351,7 +351,7 @@ def test_a_provider_reaches_the_command_a_real_backend_builds(
 
     assert agent.environment() == {"ANTHROPIC_API_KEY": "not-real"}
     spawned = agent.spawned(["claude", "--print"])
-    assert spawned[:4] == [sys.executable, "-m", "hmz", "cred"]
+    assert spawned[:5] == [sys.executable, "-m", "hmz", "internal", "cred"]
     assert any(f"--map={home}/.claude/.credentials.json=" in one for one in spawned), (
         spawned
     )

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -370,7 +370,12 @@ def test_claude_is_told_about_the_callbacks_on_its_own_command_line(
     (argv,) = _starts(claude)
     held = json.loads(argv[argv.index("--mcp-config") + 1])
     assert list(held["mcpServers"]) == ["humanize"]
-    assert held["mcpServers"]["humanize"]["args"][:2] == ["-m", "hmz"]
+    assert held["mcpServers"]["humanize"]["args"][:4] == [
+        "-m",
+        "hmz",
+        "internal",
+        "tools",
+    ]
     # And what the person at this machine has configured is left alone: adding ours is not
     # the same as taking theirs away.
     assert "--strict-mcp-config" not in argv

--- a/tests/coganchor/test_anchor.py
+++ b/tests/coganchor/test_anchor.py
@@ -53,7 +53,7 @@ def test_a_rendered_command_is_parsed_back_as_the_settings_it_came_from(
     monkeypatch.setattr("hmz.coganchor.anchor.connect", record)
     rendered = FULL.command(["claude", "--print"])
     # The interpreter running the flow, so the child is the one humanize is installed in.
-    assert rendered[:4] == [sys.executable, "-m", "hmz", "anchor"]
+    assert rendered[:5] == [sys.executable, "-m", "hmz", "internal", "anchor"]
 
     assert cli.main(rendered[3:]) == 0
 
@@ -67,11 +67,11 @@ def test_an_agent_argument_is_never_read_as_one_of_ours() -> None:
 
     rendered = AnchorConfig(target="ssh://build-box", force=True).command(argv)
 
-    assert parser().parse_args(rendered[4:]).command == argv
+    assert parser().parse_args(rendered[5:]).command == argv
 
 
 def test_a_default_anchor_says_only_where_the_work_lands() -> None:
-    assert AnchorConfig().command(["claude"])[4:] == [
+    assert AnchorConfig().command(["claude"])[5:] == [
         "--target=local",
         "--net=local",
         "claude",
@@ -134,7 +134,7 @@ def test_a_target_nobody_can_read_is_refused_the_way_argparse_refuses_an_argumen
     None
 ):
     with pytest.raises(SystemExit) as refused:
-        cli.main(["anchor", "--target", "rsync://build-box", "claude"])
+        cli.main(["internal", "anchor", "--target", "rsync://build-box", "claude"])
     assert refused.value.code == 2
 
 

--- a/tests/coganchor/test_anchor_command.py
+++ b/tests/coganchor/test_anchor_command.py
@@ -1,4 +1,4 @@
-"""`hmz anchor` as a command line: what it refuses, and where it routes what it accepts.
+"""`hmz internal anchor` as a command line: what it refuses, and where it routes what it accepts.
 
 Both halves are here. `serve` is answered first and without loading the agent half at all,
 which is what lets one program serve a target of any architecture -- so everything below runs
@@ -93,7 +93,7 @@ def test_an_address_that_is_not_one_is_a_bad_argument(
 def test_listening_where_anything_can_reach_it_without_a_secret_is_refused(
     exported: str, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An `hmz anchor` port is equivalent to a shell on that machine."""
+    """An `hmz internal anchor` port is equivalent to a shell on that machine."""
     monkeypatch.delenv("HUMANIZE_TOKEN", raising=False)
 
     assert anchor(["serve", "--export", exported, f"--listen={EVERYWHERE}:8080"]) == 2

--- a/tests/coganchor/test_listener.py
+++ b/tests/coganchor/test_listener.py
@@ -156,7 +156,7 @@ def test_the_port_it_landed_on_is_announced_to_whoever_started_it(
 
     said = capsys.readouterr().err
 
-    assert f"hmz anchor serve listening 127.0.0.1 {held.port}" in said
+    assert f"hmz internal anchor serve listening 127.0.0.1 {held.port}" in said
     assert held.port != 0
 
 
@@ -216,7 +216,7 @@ def test_a_session_presenting_the_secret_is_served(
 def test_a_session_presenting_the_wrong_secret_is_refused(
     serving: Callable[[str | None], _Listening],
 ) -> None:
-    """An `hmz anchor` port is equivalent to a shell on that machine, so this is the door."""
+    """An `hmz internal anchor` port is equivalent to a shell on that machine, so this is it."""
     held = serving(TOKEN)
 
     with pytest.raises(OSError, match="token"):

--- a/tests/coganchor/test_native.py
+++ b/tests/coganchor/test_native.py
@@ -105,7 +105,7 @@ def test_every_setting_a_native_turn_takes_survives_being_written_back_out() -> 
     assert rendered[-2:] == ["claude", "--print"]
     # Read back by the same parser the spawned process reads it with, which is the whole of
     # what makes this a bijection rather than two lists that happen to look alike.
-    written = line.settings(line.parser().parse_args(rendered[4:]))
+    written = line.settings(line.parser().parse_args(rendered[5:]))
     assert written == settings
 
 
@@ -419,7 +419,7 @@ def test_a_native_turn_is_spawned_as_the_anchor_line_and_looks_for_no_local_cli(
 
     rendered = agent.spawned(["claude", "--print"], "/work/sub")
 
-    assert rendered[1:4] == ["-m", "hmz", "anchor"]
+    assert rendered[1:5] == ["-m", "hmz", "internal", "anchor"]
     assert "--native" in rendered
     assert "--chdir=/work/sub" in rendered
     # The CLI is named as it was written. Where claude is installed is a fact about the

--- a/tests/coganchor/test_redirect.py
+++ b/tests/coganchor/test_redirect.py
@@ -50,7 +50,7 @@ def test_a_swap_a_turn_is_given_is_a_redirect_the_session_is_spawned_with(
     )
 
     assert f"--redirect={NAMED}={INSTEAD}" in rendered
-    assert settings(parser().parse_args(rendered[4:])) == AnchorConfig(
+    assert settings(parser().parse_args(rendered[5:])) == AnchorConfig(
         target="ssh://build-box", redirects=((NAMED, INSTEAD),)
     )
 
@@ -61,7 +61,7 @@ def test_a_turn_answers_what_the_settings_answer_as_well_as_its_own() -> None:
 
     rendered = config.command(["claude"], swaps=[(NAMED, INSTEAD)])
 
-    assert settings(parser().parse_args(rendered[4:])).redirects == (
+    assert settings(parser().parse_args(rendered[5:])).redirects == (
         ("/etc/machine-id", "/srv/borrowed-id"),
         (NAMED, INSTEAD),
     )
@@ -75,7 +75,7 @@ def test_a_turn_answers_what_the_settings_answer_as_well_as_its_own() -> None:
 def test_a_redirect_that_is_not_two_absolute_paths_is_refused(said: str) -> None:
     """Resolved against the turn's own directory, a relative answer is a different file."""
     with pytest.raises(SystemExit) as refused:
-        cli.main(["anchor", "--redirect", said, "claude"])
+        cli.main(["internal", "anchor", "--redirect", said, "claude"])
     assert refused.value.code == 2
 
 

--- a/tests/coganchor/test_transport.py
+++ b/tests/coganchor/test_transport.py
@@ -62,7 +62,7 @@ def test_bundle_is_self_contained(tmp_path: Path) -> None:
     assert bundle.stat().st_size > 0
 
     result = subprocess.run(
-        [sys.executable, str(bundle), "anchor", "serve", "--help"],
+        [sys.executable, str(bundle), "internal", "anchor", "serve", "--help"],
         capture_output=True,
         text=True,
         # An empty PYTHONPATH proves nothing is being imported from this repo.
@@ -129,6 +129,7 @@ def test_bundle_reports_failure_in_its_exit_status(tmp_path: Path) -> None:
         [
             sys.executable,
             str(bundle),
+            "internal",
             "anchor",
             "serve",
             "--export",
@@ -214,7 +215,7 @@ def test_the_line_ssh_carries_is_read_by_the_shell_there_before_anything_runs() 
     assert "for py in" in words[3], (
         "the line that finds the interpreter arrived in pieces"
     )
-    assert words[4:7] == ["humanize", bundle, "anchor"]
+    assert words[4:8] == ["humanize", bundle, "internal", "anchor"]
     assert words[-2:] == ["--export", "/a b:/c d"]
     assert f" {bundle} " in line, (
         "a quoted ~ is a directory of that name, not the home one"
@@ -277,6 +278,7 @@ def test_ssh_transport_bootstraps_and_runs(tmp_path: Path) -> None:
             sys.executable,
             "-m",
             "hmz",
+            "internal",
             "anchor",
             "--target",
             "ssh://localhost",

--- a/tests/providers/test_redirect.py
+++ b/tests/providers/test_redirect.py
@@ -1,7 +1,7 @@
 """Running a program whose credentials are somewhere other than where it looks for them.
 
 Two halves, as the module has two. The table -- which path is answered by which -- is read
-here directly. The rest is the real thing: `hmz cred` spawned exactly as a turn spawns it,
+here directly. The rest is the real thing: `hmz internal cred` spawned exactly as a turn spawns it,
 with a program underneath that reads, writes, renames, lists a directory, forks, and dies of
 a signal, on files that are all under `tmp_path`. Nothing here stands in for the supervisor,
 because the supervisor is what there is to be wrong.
@@ -11,8 +11,9 @@ this process ptrace a child of its own. Whether it can is answered by running on
 by asking what the kernel is -- a container without `CAP_SYS_PTRACE` has every module and can
 supervise nothing -- and where it cannot, those tests say so and skip.
 
-Whether this machine can trace, and how `hmz cred` is spawned, are `tests/supervising.py`'s:
-three suites and a conftest ask, and a conftest cannot import a test module.
+Whether this machine can trace, and how `hmz internal cred` is spawned, are
+`tests/supervising.py`'s: three suites and a conftest ask, and a conftest cannot import a test
+module.
 """
 
 from __future__ import annotations
@@ -148,6 +149,7 @@ def test_the_command_names_every_swap_and_then_the_program() -> None:
         sys.executable,
         "-m",
         "hmz",
+        "internal",
         "cred",
         "--map=/house/.claude=/store/mine/home",  # longest first, as the table is
         "--map=/house/x=/store/y",
@@ -193,7 +195,7 @@ def test_a_line_that_could_not_be_run_is_a_line_to_correct(
     argv: list[str], says: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
     with pytest.raises(SystemExit) as stopped:
-        cli.main(["cred", *argv])
+        cli.main(["internal", "cred", *argv])
 
     assert stopped.value.code == 2
     assert says in capsys.readouterr().err
@@ -209,7 +211,7 @@ def test_a_run_that_cannot_be_supervised_does_not_run_unsupervised(
 
     monkeypatch.setattr("hmz.coganchor.providers.redirect.run", refuse)
 
-    assert cli.main(["cred", "--map=/house/x=/store/y", "--", "true"]) == 1
+    assert cli.main(["internal", "cred", "--map=/house/x=/store/y", "--", "true"]) == 1
     assert "no supervisor here" in capsys.readouterr().err
 
 
@@ -602,6 +604,7 @@ def test_two_runs_at_once_do_not_see_each_others_accounts(tmp_path: Path) -> Non
                     sys.executable,
                     "-m",
                     "hmz",
+                    "internal",
                     "cred",
                     f"--map={machine}={instead}",
                     "--",

--- a/tests/providers/test_store.py
+++ b/tests/providers/test_store.py
@@ -277,7 +277,7 @@ def test_the_command_a_turn_is_spawned_as_names_every_path_it_is_answered_at() -
 
     spawned = provider.command(["claude", "--print"])
 
-    assert spawned[:4] == [sys.executable, "-m", "hmz", "cred"]
+    assert spawned[:5] == [sys.executable, "-m", "hmz", "internal", "cred"]
     assert spawned[spawned.index("--") + 1 :] == ["claude", "--print"]
     assert len([one for one in spawned if one.startswith("--map=")]) == len(
         provider.swaps()

--- a/tests/supervising.py
+++ b/tests/supervising.py
@@ -45,7 +45,7 @@ PATIENCE = 45
 def cred(
     argv: list[str], *, stdin: str = "", timeout: int = PATIENCE
 ) -> subprocess.CompletedProcess[str]:
-    """Runs `hmz cred` as a turn under a provider runs it: its own process, on its own.
+    """Runs `hmz internal cred` as a turn under a provider runs it: its own process, on its own.
 
     Args:
       argv: What follows the command name -- the swaps, `--`, and the program.
@@ -56,7 +56,7 @@ def cred(
       What the run came to, with its output read back.
     """
     return subprocess.run(
-        [sys.executable, "-m", "hmz", "cred", *argv],
+        [sys.executable, "-m", "hmz", "internal", "cred", *argv],
         input=stdin,
         capture_output=True,
         text=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,14 @@ COMMANDS = [
         },
     ),
     ("internal anchor", {"hmz.coganchor"}),
+    # The other three the door opens onto, each of which must cost its own module and
+    # nothing else at all. They are here rather than left to the anchor's entry because a
+    # budget nobody wrote is a budget nothing enforces: `cred` reaches the accounts and
+    # `tools` and `hook` reach a socket, and any of the three could grow an import at the top
+    # of its module that the one measured command would never notice.
+    ("internal cred", set[str]()),
+    ("internal hook", set[str]()),
+    ("internal tools", set[str]()),
 ]
 
 
@@ -241,7 +249,10 @@ def test_the_internal_listing_names_all_four(
 
     assert stopped.value.code == 0
     shown = capsys.readouterr().out
-    assert all(spawned in shown for spawned in cli.INTERNAL)
+    # Written out rather than read off the table the help is built from: an assertion that
+    # iterates `INTERNAL` cannot fail whatever is in it, which is a check that would go on
+    # passing through the very change it exists to catch.
+    assert all(spawned in shown for spawned in ("anchor", "cred", "hook", "tools"))
 
 
 def test_a_line_naming_no_internal_command_is_a_usage_error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,9 +22,12 @@ from hmz import cli
 #: names rather than as the directory each is in, because a directory is now several answers:
 #: `runtime` holds both what drives a run and the tracer that reads one back afterwards, and
 #: a budget saying `runtime` would stop noticing `hmz exec` paying for the second. A name
-#: here covers the modules inside it. `anchor` is in the list for being the one humanize
-#: spawns that a whole layer is behind: the target half of a session is this package with the
-#: anchor and nothing else on it.
+#: here covers the modules inside it. `internal anchor` is in the list for being the one
+#: humanize spawns that a whole layer is behind: the target half of a session is this package
+#: with the anchor and nothing else on it. A command is written here as the words that name
+#: it, because one of them is now two words deep -- and going through the door marked
+#: `internal` must cost nothing, since what it opens onto is the half that runs on a target
+#: where no other layer is installed.
 COMMANDS = [
     # The two leaves that say whether humanize reports its own failures and where the answer
     # is kept: a command that cannot report a crash is a crash nobody hears about. And what a
@@ -48,7 +51,7 @@ COMMANDS = [
             "hmz.sdk",
         },
     ),
-    ("anchor", {"hmz.coganchor"}),
+    ("internal anchor", {"hmz.coganchor"}),
 ]
 
 
@@ -56,14 +59,14 @@ COMMANDS = [
 def test_a_command_reaches_only_the_layers_it_is_carried_out_in(
     command: str, layers: set[str]
 ) -> None:
-    """`hmz exec` must not pay for the interface, nor `hmz anchor` for any of it."""
+    """`hmz exec` must not pay for the interface, nor the anchor for any of it."""
     probe = (
         "import contextlib, io, sys\n"
         "from hmz import cli\n"
         # The help itself goes to stdout, so it is swallowed: what is wanted is the list below.
         "with contextlib.redirect_stdout(io.StringIO()):\n"
         "    try:\n"
-        f"        cli.main([{command!r}, '--help'])\n"
+        f"        cli.main({[*command.split(), '--help']!r})\n"
         "    except SystemExit:\n"
         "        pass\n"
         "print(' '.join(m for m in sys.modules if m.startswith('hmz.')))\n"
@@ -90,10 +93,10 @@ def test_a_command_is_given_the_rest_of_the_line_untouched() -> None:
 
 
 def test_what_is_spawned_is_given_the_rest_of_the_line_untouched() -> None:
-    """It is routed as every other command is; being listed is the whole of the difference."""
+    """Routed exactly as every other command is, one word further in."""
     carry_out = unittest.mock.Mock(return_value=0)
-    with unittest.mock.patch.dict(cli._SPAWNED, {"anchor": carry_out}):
-        assert cli.main(["anchor", "--help", "-x", "claude"]) == 0
+    with unittest.mock.patch.dict(cli.INTERNAL, {"anchor": (carry_out, "")}):
+        assert cli.main(["internal", "anchor", "--help", "-x", "claude"]) == 0
     assert carry_out.call_args.args == (["--help", "-x", "claude"],)
 
 
@@ -101,8 +104,8 @@ def test_the_status_a_command_exits_with_is_the_one_that_is_returned() -> None:
     def refused(_argv: list[str]) -> int:
         return 130
 
-    with unittest.mock.patch.dict(cli._SPAWNED, {"anchor": refused}):
-        assert cli.main(["anchor", "claude"]) == 130
+    with unittest.mock.patch.dict(cli.INTERNAL, {"anchor": (refused, "")}):
+        assert cli.main(["internal", "anchor", "claude"]) == 130
 
 
 @pytest.mark.parametrize("argv", [["--target", "ssh://build-box"], ["-f", "chat"]])
@@ -120,14 +123,14 @@ def test_a_line_of_flags_the_interface_does_not_take_is_a_usage_error(
 def test_a_line_that_names_something_that_is_not_a_command_is_a_usage_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """And says which there are, which is now the one there is."""
+    """And says which there are, which is every one of them and not the typed ones only."""
     with pytest.raises(SystemExit) as stopped:
         cli.main(["fly"])
 
     assert stopped.value.code == 2
     said = capsys.readouterr().err
     assert "hmz" in said
-    assert "exec" in said
+    assert all(command in said for command in cli.COMMANDS)
 
 
 def test_a_line_naming_no_command_opens_the_interface() -> None:
@@ -202,24 +205,59 @@ def test_the_help_lists_every_command(
     # The line that opens the interface says nothing about what it opens on, so there is
     # nothing here to say it with: what to run is chosen at the prompt.
     assert not any(flag in shown for flag in ("--flow", "--agent", "--config"))
-    # And nothing humanize spawns for itself: a listing offering the supervisor a turn is
-    # run under would be offering a way to run something that is not humanize.
-    assert not any(spawned in shown for spawned in cli._SPAWNED)
+    # Including the door onto what humanize spawns for itself, which is in the listing under
+    # one name: a listing that showed only the line a person types would be describing a
+    # different program from the one that runs, and the four behind it are exactly the
+    # processes somebody debugging a run finds in their process table.
+    assert "internal" in shown
+
+
+def test_the_listing_shows_every_command_there_is() -> None:
+    """Nothing is routed that the help does not name: the old `_SPAWNED` is gone."""
+    assert set(cli.COMMANDS) == {"exec", "internal"}
 
 
 @pytest.mark.parametrize("spawned", ["anchor", "cred", "hook", "tools"])
-def test_what_humanize_spawns_for_itself_is_carried_out_but_not_listed(
+def test_what_humanize_spawns_for_itself_is_listed_under_the_one_name(
     spawned: str,
 ) -> None:
-    """A turn taken as an account is spawned as one of these; nobody types one."""
+    """A turn taken as an account is spawned as one of these; nobody types one by hand."""
+    # Not a command of its own at the top: four more entries there would read as four more
+    # things to do with humanize, which is what gathering them behind one door answers.
     assert spawned not in cli.COMMANDS
-    # Still a line that runs: it is a command line because a process is started by one.
+    assert spawned in cli.INTERNAL
     with pytest.raises(SystemExit) as stopped:
-        cli.main([spawned, "--help"])
+        cli.main(["internal", spawned, "--help"])
 
     assert stopped.value.code == 0
 
 
+def test_the_internal_listing_names_all_four(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """What the door opens onto is written down, which is the whole point of opening it."""
+    with pytest.raises(SystemExit) as stopped:
+        cli.main(["internal", "--help"])
+
+    assert stopped.value.code == 0
+    shown = capsys.readouterr().out
+    assert all(spawned in shown for spawned in cli.INTERNAL)
+
+
+def test_a_line_naming_no_internal_command_is_a_usage_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`hmz internal` on its own does nothing, and says what it would have taken."""
+    with pytest.raises(SystemExit) as stopped:
+        cli.main(["internal"])
+
+    assert stopped.value.code == 2
+    assert "hmz internal" in capsys.readouterr().err
+
+
 def test_what_is_spawned_carries_out_what_it_was_given() -> None:
     """The supervisor a turn under an account runs in, reached the way humanize reaches it."""
-    assert cli.main(["cred", "--map=/house/x=/store/y", "--", "true"]) in (0, 1)
+    assert cli.main(["internal", "cred", "--map=/house/x=/store/y", "--", "true"]) in (
+        0,
+        1,
+    )

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -284,7 +284,7 @@ def test_serving_loads_only_the_permitted_modules(tmp_path: Path) -> None:
         # A line it reads all the way through rather than `--help`, which now exits before the
         # serving half is reached at all: what is checked is what a run of it loads. The line
         # is refused for its port, which is a return rather than an exit.
-        "    cli.main(['anchor', 'serve', '--export', '/project:/tmp',\n"
+        "    cli.main(['internal', 'anchor', 'serve', '--export', '/project:/tmp',\n"
         "              '--listen', 'not-a-port'])\n"
         "print('\\n'.join(m for m in sys.modules if m.split('.')[0] == 'hmz'))\n"
     )

--- a/tests/test_tools_command.py
+++ b/tests/test_tools_command.py
@@ -1,4 +1,4 @@
-"""`hmz tools`: the pipe a coding agent speaks the tool protocol over, relayed to a flow.
+"""`hmz internal tools`: the pipe a coding agent speaks the tool protocol over, relayed to a flow.
 
 A callback of a flow's is a Python function in the flow's own process, and a CLI takes a tool
 by starting a program and talking to it over that program's stdin and stdout. This is that
@@ -176,7 +176,7 @@ def test_a_socket_that_is_not_there_is_a_flow_that_has_ended(
     assert tools(["--at", "nobody-is-serving-this.sock"]) == 1
 
     said = capsys.readouterr().err
-    assert "hmz tools" in said
+    assert "hmz internal tools" in said
     assert "nobody-is-serving-this.sock" in said
 
 


### PR DESCRIPTION
## What

`anchor`, `cred`, `hook` and `tools` were routed out of a second table (`_SPAWNED`) that the help parser never saw. A name in it never reached `add_subparsers`, so it got `argv[1:]` untouched — including `--help` — and `hmz --help` described a smaller program than the one that actually runs.

That workaround is gone. There is one `COMMANDS` table, every entry of it listed, and a new visible subcommand `hmz internal` carries the four as its own nested subparsers:

```
hmz internal anchor …
hmz internal anchor serve …
hmz internal cred --map FROM=TO -- …
hmz internal hook --at …
hmz internal tools --at …
```

## Why listed rather than hidden

A command nobody can discover is a command nobody can debug, and all four are exactly what a person *finds* rather than what they run — the process under a turn in `ps`, the line in a backend's MCP configuration, the program a hook's error came from. A listing that leaves out half of what a program runs is untrue about the program; a listing with a door marked `internal` on it is true, and says where not to go. None of them is a line anybody types by hand, which is now what the help says rather than what the absence of a listing used to imply.

## Behaviour kept

- Routing is the same one word further in: a name `hmz internal` knows is handed the rest of the line untouched, so each still answers its own `--help`.
- Reaching one loads no module of any other. `hmz internal anchor --help` still loads only `hmz.cli` + `hmz.coganchor`, which is what lets the bundled zipapp be the target half of a session.

## Call sites moved

`AnchorConfig.command()` (`coganchor/argv.py`), the provider supervisor (`providers/redirect.py`), the hook relay (`agents/hooks.py`), the tool bridge (`agents/tools.py`), and the three target-side builders in `transport.py` (`_connect_local`, `_connect_docker`, `_ssh_serve_line`).

## Specs and docs

- `specs/SPEC.md`: new `## hmz internal` section; the four sections renamed and their *"MUST NOT be one of the commands a listing shows"* clauses rewritten to say why a door beats a trapdoor. `specs/agents.md` and `specs/tui.md` follow the rename.
- `docs/reference/cli.md`: `hmz internal` section with a table of the four; `hmz cred` and `hmz hook` gain sections of their own.
- `docs/contributing/architecture.md` → **A command.** covers the nested table.
- Every other page, and the two ASCII diagrams and SVG labels, updated to the new spelling.

## Verification

- `uv run pytest` — 2865 passed, 72 skipped.
- `uv run pre-commit run --all-files` — ruff, ruff format, pyright strict all pass.
- `hmz --help` lists `exec` and `internal`; `hmz internal --help` and `--help` on each of the four.
- A real run from a scratch directory — `hmz exec -f chat -a claude@nvidia/azure/anthropic/claude-haiku-4-5:low "run ls and say how many files there are"` — took a turn with a tool call in it, which is the path that spawns `hmz internal hook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)