### PR TITLE
refactor(tui)!: a command is one row, and a mode you are in is one you can see

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -367,7 +367,7 @@ A backend home that does not exist is skipped rather than being an error.
 | `~/.humanize/daemons/<project>-<digest>/daemon.sock` | `hmz` with no command | The socket a terminal reaches a [held run](/reference/daemon) through. `0600`. |
 | `~/.humanize/daemons/<project>-<digest>/daemon.json` | the same | Which process is holding it, which workspace, and since when. |
 | `~/.humanize/daemons/<project>-<digest>/daemon.log` | the same | Whatever could not be said through a terminal about that run — what the daemon itself could not say, and what went wrong in a process reaching for its socket. |
-| `.humanize/<run>.epic.tar.gz` | `/export` | One whole run, packaged up to send: its records, its session logs in full, the transcript, and a manifest. `0600`. |
+| `.humanize/<run>.epic.tar.gz` | **export it**, on a run of `/epics` | One whole run, packaged up to send: its records, its session logs in full, and a manifest. `0600`. |
 | `~/.humanize/flowverses/<name>/` | **a** in `/flowverses` | A [flowverse](/weaver/flowverses), cloned. Every flow in it is offered as `<name>/<flow>`. |
 | `~/.humanize/skills/<owner>-<repo>-<digest>/` | a flow that named one | A repository of [skills a flow brings](/reference/flows#the-skills-a-flow-brings), cloned. The digest is of the URL, so two repositories of one name on two hosts are two directories. Fetched again the next time a run asks for it. |
 | `.humanize/flows/*/` | you | This project's own flows, offered as `local/<flow>`. |

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -19,7 +19,6 @@ terminal is your ssh session or one of these is not something it is told.
 | | |
 | --- | --- |
 | `hmz` | Reads whichever run is being held in this directory, and starts one where none is. |
-| `/detach` | Lets go of this terminal and leaves the flow running. |
 | `/exit` | Asks what is to become of a flow that is running: stop it and leave, or leave it running and let go of this terminal. With nothing running it is a window being closed. |
 | `ctrl+c` twice | Stops the flow, as it always did. It is not what lets go of a terminal. |
 | `ctrl+q` | The same question `/exit` puts, rather than leaving outright. |
@@ -29,7 +28,7 @@ terminal is your ssh session or one of these is not something it is told.
 [`hmz`](/reference/cli#hmz) in a directory is the whole of it at a terminal: it reads whichever
 run is being held here, and starts one where none is. There is nothing else to type, because
 there is nothing else a person sitting at one of these wants — reading it is what they came for,
-and letting go of it is `/detach` once they are in.
+and letting go of it is one of the answers `/exit` puts once they are in.
 
 Everything else there is to ask of a held run — what is being held on this machine, what one of
 them is doing, letting go of every terminal on it, stopping it — is [asked in Python](#python).
@@ -66,8 +65,9 @@ a time.
   without. What is lost is being able to walk away from the run, which is not a reason to
   refuse to open.
 
-In that case `/detach` says so rather than doing nothing: closing the terminal is what closes
-the run, so there is nothing to let go of.
+In that case `/exit` does not offer leaving it running at all: closing the terminal is what
+closes the run, so the second answer is staying here instead. An answer that cannot be carried
+out is not one to offer.
 
 ## One per directory
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -55,6 +55,13 @@ flow that has run out of things to do until you say something says `waiting for 
 nothing running at all, it names the flow that is set up to run and the directory it would run
 in, with your home written as `~`.
 
+**The status line, in front of all of that:** which modes the interface is in — `afk` in the
+colour of a warning while an agent may not stop and ask you, `details` while the working is
+being shown. Each is switched by a line in the transcript that has scrolled away by the time it
+matters, and neither changes anything else that is drawn, so a mode you cannot see you are in is
+one you find out about from what did not happen. In front rather than beside, because that is
+the one part of this row a narrow terminal cannot take away.
+
 **The status line, right:** the keys that do something *right now*, and only those. A shortcut
 listed in a state it does nothing in is worse than one that is not listed at all, and there is
 nowhere else to look them up. What **ctrl+c** would do next is what it is called by there,
@@ -118,8 +125,7 @@ is written to silently.
 **What comes back is what was written, not what was drawn.** A line too long for your terminal is
 drawn over four rows, and copying it gives you the line: no break where the terminal ran out of
 room, and none of the spaces that padded each row out to the edge. A break in what you copy is a
-break that was really there. The same goes for the transcript `/export` puts in the archive it
-writes.
+break that was really there.
 
 The box the interface opens with is a picture rather than a line, so dragging across it gives you
 its rows as they are drawn, borders and all.
@@ -160,9 +166,7 @@ list appears under the editor with a line about each.
 | `/afk` | `[on\|off]` | Whether an agent may stop and ask you something. See [below](#questions-and-being-away). |
 | `/fallback` | | Where a turn goes when what was taking it cannot: an agent that has nowhere left to run, and an account that has gone down. See [below](#where-a-turn-goes-when-it-cannot-be-taken). |
 | `/clear` | | Clears the screen, and nothing else: the transcript being read, not the others, and nothing that is running. |
-| `/export` | | Packages the whole run up as `.humanize/<run>.epic.tar.gz`: its own records, every session log the backends wrote for it as their contents rather than as the links the run keeps, and the transcript beside them — as it was written rather than as it was wrapped, and every conversation that has been read rather than only the one showing now. Credentials are struck out of all of it. See [Exporting a run](/user/export). |
-| `/detach` | | [Lets go of this terminal](/reference/daemon) and leaves the flow running. The run carries on where nothing is reading it, and `hmz` in this directory opens it again from the top. Where nothing is holding the run — no terminal to hand over to, or a machine whose [`HUMANIZE_DAEMON`](/reference/cli#environment-variables) says not to — it says so rather than doing nothing. |
-| `/exit` | | Leaves. With a flow running it asks first what is to become of it: stop it and leave, or leave it running and let go of this terminal. With nothing running it is a window being closed, and asks nothing. |
+| `/exit` | | Leaves; a flow that is running can be left running. With one going it asks first what is to become of it: stop it and leave, or [let go of this terminal](/reference/daemon) and leave it running — the run carries on where nothing is reading it, and `hmz` in this directory opens it again from the top. That second answer is offered only where something outside this terminal is holding the run; where nothing is, closing the terminal is what closes the run, so the answer offered instead is staying here. With nothing running it is a window being closed, and asks nothing. |
 
 `/details` and `/afk` flip when given nothing, and take `on` or `off` when you want to say
 which.
@@ -217,8 +221,8 @@ answer** — the next line you type is that answer, whatever it begins with.
 
 Closing the interface and stopping the run are two things. The run is
 [held in a process of its own](/reference/daemon), so a flow that is running goes on running
-where nothing is reading it — which is what makes `/detach` a thing there is, and what makes
-`/exit` ask rather than assume:
+where nothing is reading it — which is why `/exit` asks rather than assumes, and why letting go
+of the terminal is one of the answers rather than a command of its own:
 
 ```
 A flow is running here.
@@ -472,7 +476,9 @@ status line says `enter answer` while that is so.
 
 `/afk` says you are not there. An agent that wants to ask is then told nobody answered and
 carries on, rather than waiting on a reply that is not coming. Asking starts **allowed**: an
-agent that really needs a person gets one unless it has been said that none is there.
+agent that really needs a person gets one unless it has been said that none is there. While it
+is on, the status line says `afk` in front of everything else on it: the one sign that a turn
+went unanswered must not be a flow that finished early.
 
 A question still up when the flow ends or is stopped ends with it, so stopping a flow is never
 blocked on one.
@@ -810,7 +816,7 @@ each with a line saying what it does](/demo/epic-does.png)
 | --- | --- |
 | **carry on from here** | Runs that run's own flow again, on what that run left behind — which a flow that says it [can be picked up](/reference/flows#a-flow-that-can-be-picked-up) is handed. |
 | **collect a trace** | Gathers **that run's** sessions — and the programs it ran, for a [profiled](/reference/tracing#profiling-a-run) run — into `traces/` inside the run itself, rather than into whatever directory you are standing in. That run's and no others: they are asked for by the ids it wrote down, so a directory run in fifty times has fifty traces and none of them holds another's work. Where it went and what is in it are said under the list, and again in the transcript. |
-| **export it** | Packages **that run** up as one archive to send to somebody else — its own records, every session log the backends wrote for it as their contents rather than as the links the run keeps, and a manifest. There is no transcript in this one: what is on your screen is not that run. Where it landed and how big it came out are said under the list, and again in the transcript. See [Exporting a run](/user/export). |
+| **export it** | Packages **that run** up as one archive to send to somebody else — its own records, every session log the backends wrote for it as their contents rather than as the links the run keeps, and a manifest. No transcript goes in: what is on your screen is not that run. Where it landed and how big it came out are said under the list, and again in the transcript. See [Exporting a run](/user/export). |
 | **where it is** | The directory the run is written in, sessions and all, said under the list. |
 
 **Carrying on is offered where the flow says so now**, rather than where the run said so then.
@@ -1080,7 +1086,7 @@ the terminal's colours; a name no theme answers to is ignored rather than refuse
   what the flow itself takes is not asked. What each agent is stays open: that is the half
   worth changing mid-run.
 - **Guess at a bad line.** A line it cannot carry out is shown and the interface stays up. Only
-  `/exit` closes it — and `/detach`, which closes this terminal and not the run.
+  `/exit` closes it, and one of its answers closes this terminal and not the run.
 - **Ask the flow anything.** What is drawn beside and under the transcript is kept from the
   turns going past. A flow is Python that may branch any way it likes, so that is the
   only place a run is ever visible.

--- a/docs/user/afk.md
+++ b/docs/user/afk.md
@@ -29,6 +29,19 @@ turns them back on. See [Security](/user/security) and [Permissions](/user/permi
 Asking starts **allowed**. An agent that really needs a person gets one, unless you have said
 that nobody is there.
 
+**You can see which way it is set.** While it is on, the status line under the editor says
+`afk`, in the colour of a warning, in front of everything else on that line:
+
+```
+afk · ◉ chat · ~/work/api                         / commands · esc monitor · ctrl+c exit
+```
+
+The line the switch writes in the transcript has scrolled away by the time an agent wants to
+ask you something, and nothing else on the screen changes — so without the marker the first
+sign that a question went unanswered would be a run that finished early. It is in front of the
+flow and the directory rather than beside them because that is the one part of the row a narrow
+terminal cannot push off the end.
+
 While a question is up, the status line shows `enter answer`. The next line you type becomes
 the answer, rather than a word in the turn. The agent's offer appears with it, but an answer is
 not limited to those options — every backend that offers them also takes something else.

--- a/docs/user/conversations.md
+++ b/docs/user/conversations.md
@@ -108,6 +108,5 @@ is one transcript.
 ## See also
 
 - [Talking to a running turn](/user/steering)
-- [Exporting a run](/user/export), which puts every conversation that has been read in the
-  archive it writes
+- [Exporting a run](/user/export), which packages up every session a run opened
 - [Worktrees](/weaver/worktrees)

--- a/docs/user/details.md
+++ b/docs/user/details.md
@@ -35,6 +35,13 @@ Both settings draw from the same [events](/reference/agents#watching-a-turn-as-i
 discarded. Turning it back on does not recover what scrolled past, but the
 [trace](/user/tracing) has all of it either way, always.
 
+**You can see which way it is set.** While it is on, the status line under the editor says
+`details`, in front of the flow and the directory:
+
+```
+details · ◉ chat · ~/work/api                     / commands · esc monitor · ctrl+c exit
+```
+
 ## It is a screen setting, not an agent setting
 
 `/details` changes nothing about the run. The agent is not told about the setting, and it does
@@ -69,7 +76,7 @@ agent.watch(looking)
 - **On**, the first time you run an unfamiliar flow, to find out what shape its turns are.
 - **On**, when a turn is taking far longer than it should.
 - **Off**, which is where it starts: for a run you are reading rather than debugging, and for
-  anything you will [`/export`](/user/export) and show somebody.
+  anything you will [export](/user/export) and show somebody.
 
 ## See also
 

--- a/docs/user/export.md
+++ b/docs/user/export.md
@@ -1,6 +1,6 @@
-# Exporting a run — `/export`
+# Exporting a run
 
-`/export` packages the whole run up as one archive:
+An export packages one whole run up as one archive:
 
 ```
 .humanize/<run>.epic.tar.gz
@@ -14,7 +14,10 @@ carries what is behind it.
 
 ## Try it
 
-Run `/export`, then look at what it names:
+[`/epics`](/user/tracing#what-a-run-writes-down) lists every run of this directory, newest
+first. Enter on one opens what there is to do with it, and **export it** is there beside
+collecting its trace — a run is exported where the runs are, rather than by a command about
+whichever one your screen happens to be showing. Then look at what it names:
 
 ```sh
 tar tzf .humanize/20260809T014455.212Z-9f21ab.epic.tar.gz
@@ -32,7 +35,7 @@ Everything the run wrote down about itself, and everything its sessions were log
 | `profile.jsonl` | the programs it ran, for a [profiled](/user/tracing#profiling-a-run) run |
 | `traces/…` | every [trace](/user/tracing) gathered of it |
 | `sessions/<session>/…` | the backends' own logs, **as their contents** rather than as the links the run keeps — one directory per session, named for the agent, the CLI, the account and the id |
-| `transcript.md` | the screen, as the text it was written as rather than the rows it was drawn as — only for an export of the run that is on the screen |
+| `transcript.md` | a screen that went with the run, as the text it was written as rather than the rows it was drawn as — only where one was [handed in from Python](#from-python) |
 | `manifest.json` | what this was: see below |
 
 The manifest is what makes the rest readable by somebody who was not there — humanize's own
@@ -52,14 +55,11 @@ their own and write nothing humanize can read; a bundle that answered that with 
 directory would read exactly like a bundle that lost the logs. The manifest says which it is,
 against that session and against the backend.
 
-**The transcript is the whole screen**, everything drawn since the interface opened or since
-the last `/clear` — not the tail of it, so an export of a nine-hour run is the whole of it.
-Pressing **tab** steps between conversations and draws each into the same transcript, so it
-holds every conversation you have read rather than only the one showing now; see [Many
-conversations at once](/user/conversations). Whether tool calls and thinking are in it depends
-on what [`/details`](/user/details) is showing. And it goes in as it was written, not as it was
-wrapped: a line too long for your terminal is drawn over four rows and exported as the line, so
-a break in the file is a break that was really there.
+**No screen goes in by itself.** A run out of the list may be a week old, and what is on your
+screen now is not it — a bundle carrying somebody else's transcript would be a bundle saying
+something untrue. Something driving humanize from Python can hand one in, and then it goes in
+as it was written rather than as it was wrapped: a line too long for a terminal is drawn over
+four rows and written out as the line, so a break in the file is a break that was really there.
 
 ## What is never in it
 
@@ -97,16 +97,11 @@ It is your run. `tar xzf` it somewhere and read it — that is the point of it b
 of plain files rather than something only humanize opens.
 :::
 
-## A run that is not the one on the screen
+## Where it went
 
-[`/epics`](/user/tracing#what-a-run-writes-down) lists every run of this directory, newest
-first. Enter on one opens what there is to do with it, and **export it** is there beside
-collecting its trace. Use that for a run from last week: there is no transcript in it, because
-what is on your screen is not that run.
-
-`/export` and **export it** both say where the archive landed and how big it came out — under
-the list for a run picked out of it, and in the transcript either way, so a bundle made an hour
-ago is still found by reading back rather than by hunting through a directory:
+**export it** says where the archive landed and how big it came out — under the list, and again
+in the transcript, so a bundle made an hour ago is still found by reading back rather than by
+hunting through a directory:
 
 ```console
 /home/you/code/.humanize/20260809T014455.212Z-9f21ab.epic.tar.gz · 812 kB
@@ -115,7 +110,9 @@ ago is still found by reading back rather than by hunting through a directory:
 The archive is named for the run rather than for the moment you asked, so exporting the same
 run twice replaces the first — the second one is the first plus whatever has happened since.
 
-From Python it is the one call both of those come down to:
+## From Python
+
+It is one call, the same one the menu comes down to:
 
 ```python
 from hmz.sdk import Hmz
@@ -126,8 +123,7 @@ Hmz().epics.bundled(epic, output="/tmp/for-the-issue.tar.gz")
 `epic` is the run's own directory — what **where it is** says under the list, and what
 [`Hmz().epics.all()`](/reference/sdk#epics) hands back. An output that is a directory is written
 into under the run's own name, and no output at all is `.humanize/` beside wherever this is
-running. There is a `transcript=` as well, for the screen that went with the run, which only an
-export of the run you are watching has to give.
+running. There is a `transcript=` as well, for a screen of your own that went with the run.
 
 ## Copying instead
 
@@ -141,9 +137,9 @@ For a few lines, the mouse is faster and leaves no file:
 
 The status line says `copied` for a moment. That is the only sign there is.
 
-This copies what was written rather than what was drawn, exactly as the transcript in an export
-is. The box the interface opens with is a picture rather than a line. Dragging across it gives
-you its rows as they are drawn, borders and all.
+This copies what was written rather than what was drawn. The box the interface opens with is a
+picture rather than a line. Dragging across it gives you its rows as they are drawn, borders and
+all.
 
 **It works over ssh.** The interface has the mouse, so your terminal never sees the drag. What
 is selected goes out as OSC 52, the escape a terminal takes for its clipboard. It therefore
@@ -160,7 +156,7 @@ off.
 
 | | What it holds | Where |
 | --- | --- | --- |
-| `/export`, and **export it** on a run of `/epics` | the whole run: every record, every session log in full, the transcript, and a manifest | `.humanize/<run>.epic.tar.gz` |
+| **export it** on a run of `/epics` | the whole run: every record, every session log in full, and a manifest | `.humanize/<run>.epic.tar.gz` |
 | **collect a trace** on a run of `/epics` | every session of every agent as one [timeline](/user/tracing), with tool input and output | `traces/<datetime>.trace.json`, in the run's own epic |
 | the epic itself | the same records, with the session logs as links into the backends' own homes | `~/.humanize/epics/<workspace>/<run>/` |
 | the clipboard | whatever you dragged across | your machine's clipboard |

--- a/docs/user/history.md
+++ b/docs/user/history.md
@@ -40,8 +40,8 @@ its own is in it either.
 
 ## What it is not
 
-- **Not a session log.** For what actually happened, [`/export`](/user/export) packages the
-  whole run up and [a trace](/user/tracing) draws it as one timeline.
+- **Not a session log.** For what actually happened, [exporting a run](/user/export) packages
+  the whole of it up and [a trace](/user/tracing) draws it as one timeline.
 - **Not shared with the flow.** A flow gets the task it was started with. It cannot read the
   history.
 - **Not on the command line.** `hmz exec` takes its task as an argument. Your shell's own

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -39,7 +39,7 @@ whole piece of work start to finish; everything under them is for looking up.
 | [Falling back](/user/fallback) | `/fallback`: where a turn goes when what was taking it cannot |
 | [Completion](/user/completion) | What a half-typed line could become, under the editor |
 | [History](/user/history) | Everything typed here before, on ↑ and ↓ |
-| [Exporting a run](/user/export) | `/export` packages the whole run up as one archive to send |
+| [Exporting a run](/user/export) | **export it**, on a run of `/epics`: the whole run as one archive to send |
 | [What a project remembers](/user/settings) | Reopening finds it set up the way you left it |
 | [Stopping](/user/stopping) | **ctrl+c** twice ends the flow; what that does to a turn |
 

--- a/docs/user/questions.md
+++ b/docs/user/questions.md
@@ -40,6 +40,9 @@ on an answer that is not coming is a flow that has stopped, so this is the defau
 except an interface with `/afk` off. Asking starts **allowed**: an agent that really needs a
 person gets one unless it has been said that none is there.
 
+While it is on, the status line says `afk` in front of everything else on it — the whole point
+of the switch is that nothing stops to tell you, so the mode itself has to be visible.
+
 ## When the answer is not worth stopping for
 
 A question stops the turn until it is answered. For everything a run wants from you that is not

--- a/docs/user/reporting.md
+++ b/docs/user/reporting.md
@@ -66,7 +66,7 @@ whole task there. It is disabled where the reporter starts. Everything the SDK c
 ## Sending a run on purpose
 
 None of the above is a way of getting a run to us. When something goes wrong and the shape of
-the failure is not enough, [`/export`](/user/export) packages the whole run up as one archive —
+the failure is not enough, [exporting a run](/user/export) packages the whole of it up as one archive —
 every record, every session log in full, and a manifest saying what each backend was — for you
 to attach to an issue. It is the other half of this page: what a report never takes, an export
 carries, because you chose to send it. Credentials are struck out of it all the same.

--- a/docs/user/tracing.md
+++ b/docs/user/tracing.md
@@ -141,7 +141,7 @@ rather than a run that stops.
 
 Being links, they are worth nothing on any machine but this one — so sending a run to somebody
 else means following them and carrying what is behind them, which is what
-[`/export`](/user/export) does.
+[exporting a run](/user/export) does.
 
 ![one run's sessions/ directory, its name saying agent, CLI and account, holding a symlink to
 Claude Code's own log](/demo/run-linked.png)

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -167,6 +167,12 @@ line, with what the flow is doing beside the transcript.
   line: an account outlives the flow that was set up with it, and the one place a person is
   asked anything is the one place a credential can be typed. It is the one thing said in both
   places, and the same store either way.
+- The commands MUST be declared in one table: what each is called, the line said about it in
+  the list, what may be written after its name, and what carries it out. Adding one MUST be
+  one entry rather than one in the list of names, one in the help and one more branch in
+  whatever dispatches a sent line -- three declarations kept in step by a test is a command
+  that works and is offered to nobody, or is offered and does nothing, for as long as it takes
+  somebody to run the suite.
 - `hmz anchor` MUST NOT be a command here: it is not a thing to do to a flow that is running,
   and a command that only ever means one thing is a command line. Gathering a trace MUST NOT
   be one either -- it is a thing done to a run that has already happened, so it is one of the
@@ -223,6 +229,16 @@ line, with what the flow is doing beside the transcript.
   asking MUST start allowed, so that an agent that really needs a person gets one unless it has
   been said that none is there. A question still up when the flow ends or is stopped MUST end
   with it, so that stopping a flow is never blocked on one.
+- The status line MUST say which of those two modes the interface is in, for as long as it is
+  in one. Each is switched by a line that says which way it went and then scrolls away, and
+  neither changes anything else that is drawn -- so a mode nobody can see they are in is one
+  they find out about from what did not happen. `/afk` above all: it decides whether an agent
+  may stop and ask you at all, and a person who cannot see that they are away finds out from
+  a flow that carried on past the one question it needed answered.
+- That marker MUST be where a narrow terminal cannot take it away. The keys are clipped from
+  the front to make room and the flow and the directory can fill a small screen between them,
+  so a marker put among either is one that is there until the moment there is no room for it,
+  which is a marker nobody has.
 - `ctrl+c` MUST take back the nearest thing there is to take back: what is half-typed if
   anything is, and the run if not. The run MUST be asked for twice -- the first press saying
   what the next one does, the second one stopping the flow -- because a day's work is behind a
@@ -249,14 +265,20 @@ line, with what the flow is doing beside the transcript.
   terminal closing cannot reach, leave it running and let go of this terminal. Where it is
   not, the second answer MUST be staying here instead: an answer that cannot be carried out
   is not one to offer.
+- It MUST be the one way out. Letting go of the terminal MUST NOT also be a command of its
+  own: both words are about the same running flow, and two ways of saying one thing is one of
+  them typed by somebody who meant the other. What is said about `/exit` in the list of
+  commands MUST therefore say that a flow that is running can be left running -- that is the
+  one thing here that does not end what it closes, and a line reading `exit` is a line nobody
+  would read as an offer to leave a day's work going.
 - Every key that leaves MUST put the same question. A key bound to leaving outright is a way
   round the one thing this asks about, so a terminal's own habit -- `ctrl+q`, which is what a
   full-screen program is left on everywhere -- MUST mean what `/exit` means rather than being
   taken away: a key somebody's fingers know is a key they will press.
-- `/detach` MUST let go of the terminal and leave the flow running, which is the other half
-  of the same question asked outright. Where nothing is holding the run it MUST say so rather
-  than do nothing: what would be let go of is the terminal the interface is in, and closing
-  that closes the run.
+- Letting go of the terminal MUST leave the flow running: what is closed is the terminal
+  rather than the run, and `hmz` in this directory opens it again. It MUST be offered only
+  where something outside this terminal is holding the run, since where nothing is, closing
+  the terminal is what closes the run.
 - What is holding the run MUST be `hmz.sdk.Session` and no more of it: how many terminals are
   reading, and how to let go of them. The interface MUST name no daemon -- it draws on a
   terminal, and which terminal is not a thing it is told.
@@ -274,25 +296,10 @@ line, with what the flow is doing beside the transcript.
   editor MUST be copied from the same way, holding a selection of its own so that the screen's
   has nothing in it. That something was copied MUST be said for a moment, since a clipboard is
   written to silently and a gesture that says nothing is one nobody knows worked.
-- `/export` MUST write the whole run rather than the screen: what happened, what each of its
-  sessions was logged as by the backend that ran it, and the transcript beside those. The
-  screen was never the run -- the turns went to a coding agent that wrote its own log, and the
-  run points at that log by a link rather than holding it. A bundle sent to whoever is being
-  asked to fix something MUST therefore follow every one of those links and carry what is
-  behind it, since a link is worth nothing on any machine but the one that made it. It is
-  `hmz.runtime.exporting`, which is also what a run exported from `/epics` and
-  :meth:`hmz.sdk.Hmz.epics.bundled` ask: one archive, made one way, whichever way somebody
-  reached it.
-- The transcript that goes in MUST be the text the transcript was written as rather than the
-  rows it was drawn as, for the reason a selection gives back that text: a file of lines
-  broken where the terminal ran out of room is one nothing reads back.
-- It MUST say where the archive landed and how big it came out, and MUST NOT hold the
-  interface still while it is written: following a day's logs and compressing them is seconds,
-  and an interface that stopped redrawing for them would look as though it had gone away.
-- The run it exports MUST be the run this interface is showing, asked of the agents it drove
-  rather than of which directory sorts last -- a flow that is going is exported as itself.
-  A directory nothing has ever been run in MUST be said rather than answered with an archive
-  of no run.
+- Packaging a run up to send MUST NOT be a command here. It is a thing done to a run that has
+  already happened, like gathering its trace, so it is one of the things `/epics` offers about
+  the run under its cursor rather than a command about whichever run this screen happens to be
+  showing -- which is one of the runs in that list and not always the one somebody means.
 
 ## `selecting.py`
 
@@ -605,10 +612,13 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   session of the workspace, and nothing typed and nothing drawn calls it that way.
 - A run MUST also be exportable from here, beside gathering its trace: both are reading one
   back afterwards, and a report about something that went wrong last week is written about a
-  run out of this list rather than about the one on the screen. What is written MUST be the
-  same archive `/export` writes, less the transcript -- what is on the screen is not that run,
-  which may be a week old, and a screen of somebody else's run in it would be a bundle saying
-  something that is not true.
+  run out of this list rather than about the one on the screen. What is written MUST be what
+  `hmz.runtime.exporting` writes and MUST carry no transcript -- what is on the screen is not
+  that run, which may be a week old, and a screen of somebody else's run in it would be a
+  bundle saying something that is not true. Where the archive landed and how big it came out
+  MUST be said, and writing it MUST NOT hold the interface still: following a day's logs and
+  compressing them is seconds, and an interface that stopped redrawing for them would look as
+  though it had gone away.
 - Carrying a run on MUST run that run's own flow, on that run's own agents, with what it was
   asked to do -- what is being picked up is what ran, and an agent swapped under it would be
   a different run wearing its name. It MUST be a run of its own, saying which run it came
@@ -814,12 +824,23 @@ a flow being a Python file that may branch any way it likes.
 ## `complete.py`
 
 ```python
-def offered(typed: str, commands: tuple[str, ...]) -> list[str]: ...
-def flows(where: str | None = None) -> list[str]: ...
+@dataclass(frozen=True)
+class Command:
+    name: str
+    about: str
+    does: Callable[[Humanize, list[str]], object]
+    takes: str = ""
+
+
+def offered(typed: str, commands: tuple[Command, ...]) -> list[str]: ...
+def hinted(typed: str, commands: tuple[Command, ...]) -> str: ...
 ```
 
 What the editor offers to finish, which is the only way anything is chosen.
 
+- A command MUST be one of these and nothing besides: the name, the line said about it, what
+  may be written after it, and what running it does. What is offered here MUST be read off the
+  same rows that carry a sent line out, so that a command cannot be offered and do nothing.
 - Nothing MUST be chosen from a dialog. A `/` MUST offer the commands, and a flag MUST offer
   whatever it is for -- the flows below this directory, the backends an agent runs on -- so
   that there is one way to say a thing and it is the way it is written down.

--- a/src/hmz/cli/__init__.py
+++ b/src/hmz/cli/__init__.py
@@ -237,10 +237,10 @@ def _tui(argv: list[str]) -> int:
 def opens() -> int:
     """Opens the interface, on this terminal or on one a run of its own is being held on.
 
-    A run of a flow outlives the terminal it was started from, which is what makes `/detach`
-    a thing there is: the interface goes on running where nothing is reading it, and `hmz` in
-    this directory opens it again. So a line that opens the interface reads whichever run is
-    already being held here, and starts one where none is.
+    A run of a flow outlives the terminal it was started from, which is what makes leaving it
+    running an answer to `/exit`: the interface goes on running where nothing is reading it, and
+    `hmz` in this directory opens it again. So a line that opens the interface reads whichever
+    run is already being held here, and starts one where none is.
 
     A terminal is what makes that worth doing. With nothing to attach -- output going to a
     file, a test driving the interface itself -- the interface is opened here, in this
@@ -297,8 +297,8 @@ def apart(session: Held) -> None:
     and were only ever arguments here while a line could name them.
 
     Args:
-      session: What is holding the run, which is what `/detach` lets go of and what draws
-        the screen again for a terminal that has just arrived.
+      session: What is holding the run, which is what leaving it running lets go of and what
+        draws the screen again for a terminal that has just arrived.
     """
     # Here rather than inside the line that opens the interface: this is the one function
     # that runs in the process holding a run, which is the other side of a fork and has none

--- a/src/hmz/runtime/exporting.py
+++ b/src/hmz/runtime/exporting.py
@@ -87,9 +87,10 @@ BUNDLE = "{epic}.epic.tar.gz"
 #: What the archive says about itself.
 MANIFEST = "manifest.json"
 
-#: What the transcript goes in, for a bundle exported from the interface. There is none in
-#: one exported from a command line: nothing was drawn, and an empty file saying so would
-#: read as a run that said nothing.
+#: What a transcript goes in, for the caller that has one to hand in. There is none in a
+#: bundle asked for of a run out of `/epics` or from a command line: a run in that list may be
+#: a week old and what is on the screen now is not it, and an empty file saying so would read
+#: as a run that said nothing.
 TRANSCRIPT = "transcript.md"
 
 #: What stands where something was taken out. One word, so that a bundle can be read for what
@@ -214,8 +215,9 @@ def bundle(
         name, or None for `.humanize/` beside whatever directory this is being run in. A
         bundle is made to be sent, so it lands where somebody can find it rather than in
         humanize's own home the way a trace of a run does.
-      transcript: What was on the screen, as the interface wrote it rather than as it drew
-        it, or None for an export from a command line -- where nothing was drawn.
+      transcript: A screen that went with this run, as it was written rather than as it was
+        drawn, or None -- which is what everything humanize itself asks for a bundle with
+        hands in, the run being one read back rather than one being watched.
 
     Returns:
       Where it was written, and the manifest as it was written there -- so that whatever

--- a/src/hmz/sdk/epics.py
+++ b/src/hmz/sdk/epics.py
@@ -145,8 +145,9 @@ class Epics:
           epic: The run, by the directory it is written in.
           output: Where to write it -- a file, or a directory to write it into under its own
             name -- or None for `.humanize/` beside wherever this is being run.
-          transcript: What was on the screen, for an export from the interface, or None from
-            a command line, where nothing was drawn.
+          transcript: A screen that went with this run, for a caller that has one, or None
+            -- which is what a run exported out of the list of them goes in as, that run not
+            being the one on the screen.
 
         Returns:
           Where it was written, and the manifest as it was written there -- which is what

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -66,7 +66,7 @@ from hmz.runtime import telemetry
 from hmz.sdk import Hmz
 
 from .btw import AgentProgress, FlowSnapshot, Observation, compact, format_snapshot
-from .complete import about, hinted, offered, takes
+from .complete import Command, hinted, offered
 from .discover import installable, installed
 from .history import History
 from .monitor import Monitor, short, thousands
@@ -107,31 +107,6 @@ if TYPE_CHECKING:
     from hmz.coganchor.agents import AgentBase, Board, Event, Question, SessionBase
     from hmz.flows import Place
     from hmz.sdk import Session
-
-#: What the editor understands, named as opencode names them, one step along: what answers
-#: here is a flow rather than an agent, so opencode's `/agents` is `/flow`, and what a flow
-#: runs on is an agent apiece rather than one model, so its `/models` is the page along from
-#: it. There is no command for an agent on its own: an agent belongs to the flow that drives
-#: it, and is set up on the page of `/flow` its agents are on. `hmz anchor` is not here
-#: either: it is not a thing to do to a flow that is running, and it is a command line of its
-#: own. What a run left behind is `/epics`, which is where the runs of this directory are.
-_OWN = (
-    "flow",
-    "btw",
-    "flowverses",
-    "providers",
-    "fallback",
-    "epics",
-    "resume",
-    "settings",
-    "monitor",
-    "clear",
-    "details",
-    "afk",
-    "export",
-    "detach",
-    "exit",
-)
 
 #: How often the right-hand column and the status line are redrawn, in seconds.
 _REFRESH = 0.5
@@ -432,7 +407,7 @@ class Editor(TextArea):
             # The list is filled from a message the application handles, so it can be a
             # keystroke behind the editor. An offer that no longer finishes what is typed is
             # not the one enter was pressed over, and the line goes as it stands instead.
-            if whole in offered(self.text, _OWN):
+            if whole in offered(self.text, _COMMANDS):
                 self.take(whole)
                 return
         said, self.text = self.text.strip(), ""
@@ -668,6 +643,11 @@ class Humanize(App[None]):
         the next terminal to open it is drawn for from the top. So it is asked rather than
         assumed, and it is asked only where there is something to ask about -- with nothing
         running, `/exit` is a window being closed.
+
+        The one way out, letting go of the terminal included. That was a command of its own
+        and is an answer here instead: both were about the same running flow, and a person
+        who has decided to leave should be asked what becomes of it once rather than having
+        to know which of two words asks.
         """
         if not self._agents:
             self.action_quit()
@@ -676,23 +656,20 @@ class Humanize(App[None]):
         if said == STOPS:
             self.action_quit()
         elif said == DETACHES:
-            self.action_detach()
+            self._detach()
 
-    def action_detach(self) -> None:
+    def _detach(self) -> None:
         """Lets go of the terminal reading this, leaving the flow running.
 
-        The other half of `/exit`: what is closed is the terminal rather than the run. What
-        was running goes on running, and `hmz` in this directory opens it again.
+        The answer to `/exit` that closes the terminal rather than the run: what was running
+        goes on running, and `hmz` in this directory opens it again. Only ever reached where
+        something outside this terminal is holding the run -- where nothing is, the question
+        offers staying here instead, an answer that cannot be carried out not being one.
         """
         session = self._session
-        if session is None:
-            self.show(
-                "hmz: this run is in the terminal it was opened in, so there is nothing to "
-                "let go of: closing the terminal closes the run",
-                "red",
-            )
-            return
-        if not session.attached:
+        if session is None or not session.attached:
+            # The reader went while the question was up, which is the run carrying on either
+            # way: what would have been let go of has let go of itself.
             self.show("hmz: nothing is reading this run to let go of", "red")
             return
         session.detach()
@@ -828,7 +805,8 @@ class Humanize(App[None]):
             Checked by whatever read the line: an interface is opened set up, not corrected.
           session: What is holding this run somewhere a terminal closing cannot reach, or
             None for one opened in the terminal it is drawn on -- where letting go of the
-            terminal and stopping the run are the same thing, and `/detach` says so.
+            terminal and stopping the run are the same thing, and `/exit` offers staying
+            here rather than an answer that cannot be carried out.
         """
         # `ansi_color` up front rather than left to the theme: Textual picks the filter it
         # runs every colour through inside `App.__init__`, before a theme set below could
@@ -1507,11 +1485,11 @@ class Humanize(App[None]):
         # typed is that answer, whatever it begins with, so a list that took the enter would
         # finish a flow's name over an answer nobody ever gave.
         answering = self._asking is not None and typed.startswith("$")
-        offers = offered(typed, _OWN) if at_end and not answering else []
+        offers = offered(typed, _COMMANDS) if at_end and not answering else []
         # Nothing left to finish, but a command still being written: its own line stays up,
         # since what it takes after its name is written there and is what is wanted just
         # then. Shown and not offered -- `offering` is what says a key is the list's.
-        hint = hinted(typed, _OWN) if at_end and not offers else ""
+        hint = hinted(typed, _COMMANDS) if at_end and not offers else ""
         listing = self.query_one("#offers", OptionList)
         listing.clear_options()
         listing.set_class(bool(offers), "offering")
@@ -1538,13 +1516,17 @@ class Humanize(App[None]):
           The row. The bare name is its id, since that is what replaces the text -- taking
           an offer must not type the arguments in as well.
         """
-        named = offer.removeprefix("/")
+        # A flow is the other thing offered here, and it says nothing about itself: only a
+        # `/` names a command, so a flow that happens to be called `monitor` is not one.
+        command = _BY_NAME.get(offer[1:]) if offer.startswith("/") else None
+        takes = command.takes if command else ""
+        about = command.about if command else ""
         # Escaped: what a command takes is written in brackets, and a bracket left as it is
         # would be read as markup and swallowed -- which is what `[path]` did. Padded first,
         # since the escaping adds characters that are not columns.
         return Option(
-            escape(f"{f'{offer} {takes(named)}'.rstrip():<19}")
-            + f"[dim]{escape(about(named))}[/dim]",
+            escape(f"{f'{offer} {takes}'.rstrip():<19}")
+            + f"[dim]{escape(about)}[/dim]",
             id=offer,
         )
 
@@ -1596,6 +1578,19 @@ class Humanize(App[None]):
                 f"[$secondary]◉[/] {escape(self._flowing())}"
                 f"[$text-muted]{_DOT}{escape(_where())}[/]"
             )
+        # The modes this is in, ahead of everything else on the line. Both change what the
+        # interface does without changing anything drawn on it, and a mode nobody can see
+        # they are in is one they find out about from what did not happen -- an agent that
+        # wanted a person and was told there is none. In front rather than beside, since
+        # that is the one place on this row that survives a narrow terminal: the keys are
+        # clipped from their end and the flow and the directory can fill a small screen on
+        # their own, so a marker anywhere else is one that is there until it is needed.
+        # `afk` in the colour of a warning, being the one that decides whether an agent may
+        # reach you at all.
+        if self._details:
+            left = f"[$text-muted]details[/]{_DOT}{left}"
+        if self._afk:
+            left = f"[$warning]afk[/]{_DOT}{left}"
         # For a moment after it happens, beside whatever else the line says: writing to a
         # clipboard is silent, and a person who has just dragged across half a screen is
         # owed the one word that says it went somewhere.
@@ -1725,7 +1720,7 @@ class Humanize(App[None]):
                 return lines
         return lines
 
-    def _switched(self, argv: list[str], *, now: bool) -> bool | None:
+    def _switched(self, argv: Sequence[str], *, now: bool) -> bool | None:
         """What a switch becomes: what was asked for, or the other of what it is.
 
         A toggle is what you reach for at a prompt and the wrong thing to write down: a line
@@ -1952,55 +1947,47 @@ class Humanize(App[None]):
         ) as error:  # an unbalanced quote is a line to correct, not a crash
             self.show(f"hmz: {error}", "red")
             return
-        if name == "exit":
-            self.action_exit()
-        elif name == "detach":
-            self.action_detach()
-        elif name == "clear":
-            self.action_clear()
-        elif name == "btw":
-            self.action_btw(" ".join(argv).strip())
-        elif name == "flow":
-            self.action_flow(argv[0] if argv else "")
-        elif name == "providers":
-            self.action_providers()
-        elif name == "fallback":
-            self.action_fallback()
-        elif name == "epics":
-            self.action_epics()
-        elif name == "resume":
-            self.action_resume(argv)
-        elif name == "flowverses":
-            self.action_flowverses()
-        elif name == "settings":
-            self.action_settings()
-        elif name == "monitor":
-            self.action_monitor()
-        elif name == "details":
-            if (switched := self._switched(argv, now=self._details)) is None:
-                return
-            self._details = switched
-            self.show(
-                "[dim]showing the working: every tool call, all of the thinking, and "
-                "whatever a backend prints on its way past[/dim]"
-                if self._details
-                else "[dim]showing what each turn said, and nothing of how it got "
-                "there[/dim]"
-            )
-        elif name == "afk":
-            if (switched := self._switched(argv, now=self._afk)) is None:
-                return
-            self._afk = switched
-            self.show(
-                "[dim]away: an agent that wants to ask is told nobody is here[/dim]"
-                if self._afk
-                else "[dim]here: an agent may stop and ask you[/dim]"
-            )
-        elif name == "export":
-            self._export()
-        else:
+        command = _BY_NAME.get(name)
+        if command is None:
             telemetry.snag("unknown-command", length=len(name))
             self.show(f"hmz: no such command: /{name}", "red")
+            return
+        command.does(self, argv)
+
+    def action_details(self, argv: Sequence[str] = ()) -> None:
+        """Turns the working on or off, and says which way it went.
+
+        Args:
+          argv: What was written after the name, which is `on`, `off`, or nothing at all.
+        """
+        if (switched := self._switched(argv, now=self._details)) is None:
+            return
+        self._details = switched
+        self.show(
+            "[dim]showing the working: every tool call, all of the thinking, and "
+            "whatever a backend prints on its way past[/dim]"
+            if self._details
+            else "[dim]showing what each turn said, and nothing of how it got there[/dim]"
+        )
+        self._draw()  # and the status line says which mode this is in from now on
+
+    def action_afk(self, argv: Sequence[str] = ()) -> None:
+        """Says whether anybody is here to be asked, and marks the status line with it.
+
+        Args:
+          argv: What was written after the name, which is `on`, `off`, or nothing at all.
+        """
+        if (switched := self._switched(argv, now=self._afk)) is None:
+            return
+        self._afk = switched
+        self.show(
+            "[dim]away: an agent that wants to ask is told nobody is here[/dim]"
+            if self._afk
+            else "[dim]here: an agent may stop and ask you[/dim]"
+        )
+        # Said once in the transcript and from now on in the status line: a line that has
+        # scrolled away is not how somebody finds out that an agent may not reach them.
+        self._draw()
 
     def action_btw(self, question: str = "") -> None:
         """Answers a side question from a frozen flow snapshot.
@@ -2358,64 +2345,6 @@ class Humanize(App[None]):
         if held:
             self.show(f"[dim]   never sent: {because}[/dim]")
         self._draw()
-
-    @work
-    async def _export(self) -> None:
-        """Packages the whole run up as one archive, transcript and all.
-
-        The screen alone was never the run. What an agent actually did is in the log its
-        backend wrote, which the run points at by a link -- and a link is worth nothing on
-        any machine but this one, so a bundle sent to whoever is being asked to fix something
-        follows every one of them and carries what is behind it. The transcript goes in
-        beside those, as the text it was written as rather than the rows it was drawn as:
-        lines broken where the terminal ran out of room are lines nothing reads back.
-
-        Off the event loop. Following a day's logs and compressing them is seconds, and an
-        interface that stopped redrawing for them would look as though it had gone away.
-        """
-        import asyncio
-
-        from hmz.runtime.exporting import sized
-
-        epic = self._epic()
-        if epic is None:
-            self.show(
-                "hmz: nothing has been run here yet, so there is nothing to export",
-                "red",
-            )
-            return
-        said = self.query_one("#transcript", Transcript).text
-        self.show(f"[dim]packaging {escape(epic.name)}…[/dim]")
-        try:
-            at, _ = await asyncio.to_thread(
-                self.hmz.epics.bundled, epic, transcript=said
-            )
-            size = await asyncio.to_thread(lambda: at.stat().st_size)
-        except (OSError, ValueError) as why:
-            self.show(f"hmz: {escape(str(why))}", "red")
-            return
-        self.show(f"[dim]{escape(str(at))} — {sized(size)}[/dim]")
-
-    def _epic(self) -> Path | None:
-        """The run this interface is showing, by the directory it is written in.
-
-        Asked of the agents rather than of the workspace: the run holds the epic it is
-        writing into, so a flow that is going is exported as itself rather than as whichever
-        directory happens to sort last. Once it has ended the agents still hold it, which is
-        what makes exporting a run that has just finished the same key as exporting one that
-        is still going.
-
-        Returns:
-          It, or the last run of this directory where no flow has been started here yet, or
-          None where nothing has ever been run here.
-        """
-        from hmz.runtime.epic import Epic
-
-        for agent in self._ran:
-            if isinstance(agent.epic, Epic):
-                return agent.epic.path
-        found = self.hmz.epics.all()
-        return found[-1] if found else None
 
     @work
     async def action_flow(self, named: str = "", *, opening: int = 0) -> None:
@@ -3795,3 +3724,93 @@ def _machine() -> dict[str, object]:
             {"name": one.name, "fetched": one.fetched} for one in held.verses.all()
         ],
     }
+
+
+#: What the editor understands, named as opencode names them, one step along: what answers
+#: here is a flow rather than an agent, so opencode's `/agents` is `/flow`, and what a flow
+#: runs on is an agent apiece rather than one model, so its `/models` is the page along from
+#: it. There is no command for an agent on its own: an agent belongs to the flow that drives
+#: it, and is set up on the page of `/flow` its agents are on. `hmz anchor` is not here
+#: either: it is not a thing to do to a flow that is running, and it is a command line of its
+#: own. What a run left behind is `/epics`, which is where the runs of this directory are --
+#: and packaging one up to send is one of the things offered about the run under the cursor
+#: there, rather than a command of its own about whichever run this screen happens to show.
+#:
+#: One table, read by everything that has anything to do with a command: the list offers what
+#: is in it, the line under the editor says what each takes, and a line that was sent is
+#: carried out by the row it names. Adding one is one row here rather than an entry in three
+#: files that only a test kept in step.
+#:
+#: Written down here rather than beside the class, since a row names the method that carries
+#: it out and the class has to exist first.
+_COMMANDS: tuple[Command, ...] = (
+    Command(
+        "flow",
+        "Switch flow",
+        lambda app, argv: app.action_flow(argv[0] if argv else ""),
+        takes="[flow]",
+    ),
+    Command(
+        "btw",
+        "Ask a side question",
+        lambda app, argv: app.action_btw(" ".join(argv).strip()),
+        takes="<question>",
+    ),
+    Command(
+        "flowverses",
+        "Manage the places flows come from",
+        lambda app, _: app.action_flowverses(),
+    ),
+    Command(
+        "providers",
+        "Manage the accounts agents run as",
+        lambda app, _: app.action_providers(),
+    ),
+    Command(
+        "fallback",
+        "Where a turn goes when the place taking it cannot take it at all",
+        lambda app, _: app.action_fallback(),
+    ),
+    Command(
+        "epics",
+        "The runs of this directory, and what to do with one",
+        lambda app, _: app.action_epics(),
+    ),
+    Command(
+        "resume",
+        "Carry the last run here on from where it stopped",
+        lambda app, argv: app.action_resume(argv),
+    ),
+    Command(
+        "settings",
+        "What humanize remembers, here and everywhere",
+        lambda app, _: app.action_settings(),
+    ),
+    Command(
+        "monitor",
+        "Watch the run: the flow drawn, and the board",
+        lambda app, _: app.action_monitor(),
+    ),
+    Command("clear", "Clear the screen", lambda app, _: app.action_clear()),
+    Command(
+        "details",
+        "Toggle tool calls and thinking",
+        lambda app, argv: app.action_details(argv),
+        takes="[on|off]",
+    ),
+    Command(
+        "afk",
+        "Toggle whether an agent may ask you",
+        lambda app, argv: app.action_afk(argv),
+        takes="[on|off]",
+    ),
+    Command(
+        "exit",
+        "Leave; a flow that is running can be left running",
+        lambda app, _: app.action_exit(),
+    ),
+)
+
+#: The same rows by name, for the two readers that have a name in hand rather than a line to
+#: finish: the row drawn beside an offer, and the command a sent line turned out to be.
+_BY_NAME = {one.name: one for one in _COMMANDS}

--- a/src/hmz/tui/complete.py
+++ b/src/hmz/tui/complete.py
@@ -16,78 +16,55 @@ from __future__ import annotations
 
 import functools
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from hmz.flows import Offer
 
-__all__ = ["about", "hinted", "offered"]
+    from .app import Humanize
 
-#: What each command does, shown beside its name.
-_ABOUT = {
-    "flow": "Switch flow",
-    "btw": "Ask a side question",
-    "flowverses": "Manage the places flows come from",
-    "providers": "Manage the accounts agents run as",
-    "fallback": "Where a turn goes when the place taking it cannot take it at all",
-    "epics": "The runs of this directory, and what to do with one",
-    "resume": "Carry the last run here on from where it stopped",
-    "settings": "What humanize remembers, here and everywhere",
-    "monitor": "Watch the run: the flow drawn, and the board",
-    "clear": "Clear the screen",
-    "details": "Toggle tool calls and thinking",
-    "afk": "Toggle whether an agent may ask you",
-    "export": "Package this whole run up to send",
-    "detach": "Let go of this terminal, leaving the flow running",
-    "exit": "Exit humanize",
-}
+__all__ = ["Command", "hinted", "offered"]
 
 
-#: What a command takes after its name, shown beside it so that the list says what may be
-#: written and not only what may be started. A switch takes `on` or `off` as well as being
-#: flipped, and nothing says so unless the list does.
-_TAKES = {
-    "afk": "[on|off]",
-    "btw": "<question>",
-    "details": "[on|off]",
-    "flow": "[flow]",
-}
+@dataclass(frozen=True)
+class Command:
+    """One command of the editor, declared once and whole.
+
+    Everything there is to know about a command is here: what it is called, what it is for,
+    what may be written after its name, and what carries it out. Three of those used to be
+    declared in three files that a test kept in step, which is a command added in two of them
+    and missing from the third until somebody ran the suite -- offered but doing nothing, or
+    working but offered to nobody.
+    """
+
+    #: What is typed after the slash.
+    name: str
+    #: What it is for, shown beside its name in the list.
+    about: str
+    #: What running it does, given the interface and whatever was written after the name.
+    #: What it answers with is nothing to the caller -- a worker, a None -- so it says
+    #: nothing about that.
+    does: Callable[[Humanize, list[str]], object]
+    #: How its arguments are written, shown beside it so that the list says what may be
+    #: written and not only what may be started. A switch takes `on` or `off` as well as
+    #: being flipped, and nothing says so unless the list does. "" takes none.
+    takes: str = ""
+
 
 #: `/flow` and the name being typed after it. A third word is a line that has moved on.
 _FLOW_AND_NAME = 2
 
 
-def takes(name: str) -> str:
-    """What a command takes after its name.
-
-    Args:
-      name: The command, without its slash.
-
-    Returns:
-      How its arguments are written, or "" for a command that takes none.
-    """
-    return _TAKES.get(name, "")
-
-
-def about(name: str) -> str:
-    """What a command is for.
-
-    Args:
-      name: The command, without its slash.
-
-    Returns:
-      The one line said about it, or "" if it is not one to offer.
-    """
-    return _ABOUT.get(name, "")
-
-
-def offered(typed: str, commands: tuple[str, ...]) -> list[str]:
+def offered(typed: str, commands: tuple[Command, ...]) -> list[str]:
     """What the line being typed could be finished with.
 
     Args:
       typed: The line as it stands.
-      commands: The commands there are, without their slashes.
+      commands: The commands there are.
 
     Returns:
       Everything the last word could become, in full, so that taking one replaces what was
@@ -111,9 +88,9 @@ def offered(typed: str, commands: tuple[str, ...]) -> list[str]:
     elif not typed.startswith("/"):
         return []
     elif len(words) == 1:  # still naming the command
-        if tail.removeprefix("/") in commands:
+        if any(tail.removeprefix("/") == one.name for one in commands):
             return []
-        offers = sorted(f"/{name}" for name in commands if name in _ABOUT)
+        offers = sorted(f"/{one.name}" for one in commands)
     # The flow is the one thing `/flow` takes, so it is offered while that word is the one
     # being typed and not after it: a line that already names a flow is a finished line.
     elif words[0] == "/flow" and len(words) == _FLOW_AND_NAME:
@@ -166,12 +143,12 @@ def _found(_moment: int, _where: str) -> tuple[Offer, ...]:
     return tuple(found())
 
 
-def hinted(typed: str, commands: tuple[str, ...]) -> str:
+def hinted(typed: str, commands: tuple[Command, ...]) -> str:
     """The command a line is writing, for as long as it is still being written.
 
     Args:
       typed: The line as it stands.
-      commands: The commands there are, without their slashes.
+      commands: The commands there are.
 
     Returns:
       The command the line names, without its slash, or "" if it names none. Shown rather
@@ -183,4 +160,4 @@ def hinted(typed: str, commands: tuple[str, ...]) -> str:
     if not typed.startswith("/"):
         return ""
     named = typed[1:].partition(" ")[0]
-    return named if named in commands and about(named) else ""
+    return named if any(named == one.name for one in commands) else ""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,9 +6,10 @@ with nothing in it. So a bundle is the run with every link followed -- and with 
 credential taken out, since the one thing a person sending their own run must not also send is
 the key it ran on.
 
-`hmz.runtime.exporting` itself, and no command line: there is none any more. `/export` in the
-interface is what asks for a bundle now, and this is the layer under it, held to what a bundle
-holds and what it must never carry rather than to how a line said so.
+`hmz.runtime.exporting` itself, and no command line: there is none any more. What asks for a
+bundle now is `/epics` in the interface, on the run under its cursor, and this is the layer
+under that -- held to what a bundle holds and what it must never carry rather than to how
+anything asked for one.
 """
 
 from __future__ import annotations

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -24,7 +24,7 @@ from hmz.coganchor.backends import Model
 from hmz.runtime.epic import epics
 from hmz.runtime.kept import Runs
 from hmz.tui import Humanize
-from hmz.tui.app import _OWN, _SAID, Editor, _where
+from hmz.tui.app import _BY_NAME, _COMMANDS, _SAID, Editor, _where
 from hmz.tui.pick import (
     Accounts,
     Agent,
@@ -391,7 +391,7 @@ def test_only_the_flows_there_are_to_run_are_offered() -> None:
     from hmz.flows import found
     from hmz.tui.complete import offered
 
-    assert offered("/flow ", _OWN) == [one.name for one in found()]
+    assert offered("/flow ", _COMMANDS) == [one.name for one in found()]
 
 
 @pytest.mark.timeout(60)
@@ -602,19 +602,28 @@ async def test_nothing_is_offered_for_what_is_not_a_command() -> None:
 async def test_the_offer_is_taken_from_the_commands_there_actually_are() -> None:
     """A command this interface grows must be offered without being listed twice.
 
+    One table holds the name, the line about it, what it takes and what carries it out, so
+    what is offered and what a sent line reaches are the same rows by construction -- they
+    were three lists kept in step by a test, which is a command that works and is offered to
+    nobody for as long as it takes somebody to run the suite.
+
     And none of the three the command line has that are not things to do to a flow that is
     running: `exec` is what the first thing you say already does, and `collect`, `anchor` and
     the wrapper a turn is spawned as are each about a run rather than inside one. What both
     sides do have is the store of accounts, which is one thing said in two places.
     """
-    from hmz.tui.complete import about, offered
+    from hmz.tui.complete import offered
 
-    offers = offered("/", _OWN)
+    offers = offered("/", _COMMANDS)
 
-    assert {f"/{name}" for name in _OWN if about(name)} == set(offers)
+    assert {f"/{one.name}" for one in _COMMANDS} == set(offers)
+    assert {one.name for one in _COMMANDS} == set(_BY_NAME)
     assert not {"/exec", "/collect", "/anchor", "/cred"} & set(offers)
+    # Neither of the two that went: letting go of the terminal is an answer to `/exit`, and
+    # packaging a run up is one of the things `/epics` offers about the run under its cursor.
+    assert not {"/detach", "/export"} & set(offers)
     # And a command typed in full has nothing left to be finished with, so enter sends it.
-    assert offered("/exit", _OWN) == []
+    assert offered("/exit", _COMMANDS) == []
 
 
 @pytest.mark.timeout(90)
@@ -2297,11 +2306,68 @@ async def test_a_switch_takes_on_and_off_as_well_as_being_flipped() -> None:
         assert "say on or off" in _transcript(app)
 
 
+@pytest.mark.timeout(60)
+async def test_the_status_line_says_which_modes_this_is_in() -> None:
+    """A mode that decides whether an agent may stop and ask you is one you must be able to see.
+
+    Both switches say which way they went once, in the transcript, and that line has scrolled
+    away by the time an agent wants a person -- and what happens then is a question nobody is
+    ever put. So the line that says what is going on says which mode this is in while it is
+    in it, and says nothing once it is not.
+    """
+    app = Humanize()
+    async with app.run_test() as driver:
+        status = str(app.query_one("#status", Static).content)
+        assert "afk" not in status  # nothing to say while an agent may ask
+
+        await driver.press(*"/afk")
+        await driver.press("enter")
+        await driver.pause()
+        assert "afk" in str(app.query_one("#status", Static).content)
+
+        await driver.press(*"/details on")
+        await driver.press("enter")
+        await driver.pause()
+        status = str(app.query_one("#status", Static).content)
+        assert "afk" in status
+        assert "details" in status
+
+        await driver.press(*"/afk off")
+        await driver.press("enter")
+        await driver.pause()
+        status = str(app.query_one("#status", Static).content)
+        assert "afk" not in status
+        assert "details" in status  # the other switch is left where it was
+
+
+@pytest.mark.timeout(60)
+async def test_the_marker_is_where_a_narrow_terminal_cannot_take_it_away() -> None:
+    """A marker that falls off a small screen is a marker nobody has.
+
+    The keys on the right are dropped one at a time to make room, and what is running and
+    where it is running can fill a narrow row on their own -- so the modes go in front of
+    both, which is the one place on this line that is always drawn.
+    """
+    from textual.content import Content
+
+    app = Humanize()
+    async with app.run_test(size=(40, 12)) as driver:
+        app._afk = True
+        app._draw()
+        await driver.pause()
+
+        # As drawn rather than as written: what takes up the columns of a row this narrow is
+        # the text, and the markup naming its colours is not part of it.
+        drawn = str(Content.from_markup(str(app.query_one("#status", Static).content)))
+
+        assert drawn.startswith("afk")  # ahead of the flow, the directory and the keys
+
+
 def test_the_commands_are_offered_in_alphabetical_order() -> None:
     """The one order a list of commands has that a reader can predict."""
     from hmz.tui.complete import offered
 
-    offers = offered("/", _OWN)
+    offers = offered("/", _COMMANDS)
 
     assert offers == sorted(offers)
     assert "/help" not in offers  # the bottom bar says what the keys are
@@ -2375,14 +2441,12 @@ async def test_two_things_said_get_two_answers_and_not_three(
 
 def test_the_offers_say_what_each_command_takes() -> None:
     """A switch takes `on` or `off` as well as being flipped, and only the list says so."""
-    from hmz.tui.complete import about, takes
+    for one in _COMMANDS:
+        assert one.about, one.name  # or it is offered with nothing said about it
 
-    for name in _OWN:
-        assert about(name), name  # or it would not be offered at all
-
-    assert takes("afk") == "[on|off]"
-    assert takes("details") == "[on|off]"
-    assert takes("exit") == ""  # a command that takes nothing says nothing
+    assert _BY_NAME["afk"].takes == "[on|off]"
+    assert _BY_NAME["details"].takes == "[on|off]"
+    assert _BY_NAME["exit"].takes == ""  # a command that takes nothing says nothing
 
 
 @pytest.mark.timeout(60)

--- a/tests/tui/test_btw.py
+++ b/tests/tui/test_btw.py
@@ -11,7 +11,7 @@ import pytest
 from hmz.coganchor.agents import AgentBase, AgentConfig, Event, SessionBase
 from hmz.runtime.kept import Runs
 from hmz.tui import Humanize
-from hmz.tui.app import _OWN
+from hmz.tui.app import _COMMANDS
 from hmz.tui.btw import format_snapshot
 from hmz.tui.selecting import Transcript
 
@@ -123,9 +123,9 @@ def test_btw_snapshot_format_includes_runtime_progress() -> None:
 
 
 def test_btw_is_listed_as_a_command() -> None:
-    from hmz.tui.complete import about, offered, takes
+    from hmz.tui.app import _BY_NAME
+    from hmz.tui.complete import offered
 
-    assert "btw" in _OWN
-    assert about("btw")
-    assert takes("btw") == "<question>"
-    assert "/btw" in offered("/b", _OWN)
+    assert _BY_NAME["btw"].about
+    assert _BY_NAME["btw"].takes == "<question>"
+    assert "/btw" in offered("/b", _COMMANDS)

--- a/tests/tui/test_export.py
+++ b/tests/tui/test_export.py
@@ -1,16 +1,19 @@
-"""`/export` -- the whole run, packaged up to send to whoever is being asked to fix something.
+"""The whole run, packaged up to send to whoever is being asked to fix something.
 
 What is on the screen was never the run. The turns went to a coding agent that wrote its own
 log, under an id of its own, and the run points at that log by a link -- which is worth nothing
-the moment the archive leaves this machine. So `/export` follows every one of them and carries
-what is behind it, with the transcript in beside them as the text it was written as.
+the moment the archive leaves this machine. So a bundle follows every one of them and carries
+what is behind it.
+
+Asked for from `/epics`, which is where the runs of this directory are: exporting one belongs
+beside gathering its trace, both being things done to a run that has already happened rather
+than to whichever run this screen happens to be showing.
 
 Driven headlessly, as every test of the interface is.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 import tarfile
@@ -19,7 +22,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from hmz.runtime.epic import epics
-from hmz.runtime.exporting import MANIFEST, TRANSCRIPT
+from hmz.runtime.exporting import TRANSCRIPT
 from hmz.tui import Humanize
 from hmz.tui.pick import Does, Epics
 from tests.stubs import written
@@ -28,8 +31,6 @@ from .test_app import _transcript, onto, rows, until
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from textual.pilot import Pilot
 
 #: A flow that opens one session and says one thing, so that there is a run to package up.
 PLAIN = '''"""Runs once, and says what it was told."""
@@ -99,86 +100,27 @@ def _held(at: Path) -> dict[str, str]:
     return held
 
 
-async def _exports(app: Humanize, driver: Pilot[None]) -> None:
-    """Types `/export` and waits for it to have said where the archive landed."""
-    await driver.press(*"/export")
-    await driver.press("enter")
-    await until(lambda: "epic.tar.gz" in _transcript(app), driver)
-
-
-@pytest.mark.timeout(90)
-async def test_exporting_a_run_writes_the_whole_of_it(workspace: Path) -> None:
-    """Its own record, the session the backend logged, and the screen beside them."""
-    _ran("do the thing")
-
-    app = Humanize()
-    async with app.run_test() as driver:
-        await driver.press("h", "i")
-        await driver.press("enter")
-        await until(lambda: "hi" in _transcript(app), driver)
-        await _exports(app, driver)
-        said = _transcript(app)
-
-    (epic,) = epics(workspace)
-    at = workspace / ".humanize" / f"{epic.name}.epic.tar.gz"
-    assert at.is_file()
-    assert str(at) in said or f"{epic.name}.epic.tar.gz" in said
-    held = _held(at)
-    assert "epic.jsonl" in held
-    assert TRANSCRIPT in held
-    assert [one for one in held if one.startswith("sessions/")], held
-    # And the session came as its contents rather than as the link the epic keeps.
-    log = next(one for one in held if one.startswith("sessions/"))
-    assert held[log].strip()
-
-
-@pytest.mark.timeout(90)
-async def test_the_transcript_in_it_is_what_was_written(workspace: Path) -> None:
-    """The text the transcript was written as, not the rows it was drawn as."""
-    _ran("go")
-
-    app = Humanize()
-    async with app.run_test() as driver:
-        await _exports(app, driver)
-        said = _transcript(app)
-
-    (epic,) = epics(workspace)
-    held = _held(workspace / ".humanize" / f"{epic.name}.epic.tar.gz")
-    # Exactly what the widget held when the key was pressed, which is where the two lines
-    # the export itself wrote come after it.
-    assert held[TRANSCRIPT]
-    assert said.startswith(held[TRANSCRIPT])
-
-
-@pytest.mark.timeout(90)
-async def test_the_manifest_says_what_it_is_of(workspace: Path) -> None:
-    """Which run, which flow, which agents, and what each backend was when it ran."""
-    _ran("do the thing")
-
-    app = Humanize()
-    async with app.run_test() as driver:
-        await _exports(app, driver)
-
-    (epic,) = epics(workspace)
-    said = json.loads(
-        _held(workspace / ".humanize" / f"{epic.name}.epic.tar.gz")[MANIFEST]
-    )
-    assert said["epic"] == epic.name
-    assert said["run"]["task"] == "do the thing"
-    assert said["agents"][0]["backend"] == "claude"
-    assert "claude" in said["backends"]
-
-
 @pytest.mark.timeout(60)
-async def test_a_directory_nothing_has_been_run_in_says_so(workspace: Path) -> None:
-    """Rather than writing an archive of a run there is none of."""
+async def test_packaging_a_run_up_is_not_a_command_of_its_own() -> None:
+    """It is a thing done to a run that has already happened, so it is offered where those are.
+
+    A command would be about whichever run this screen happens to show, which is one of the
+    runs in the list and not always the one somebody means -- and it would be a second way in
+    to what `/epics` already offers about the run under its cursor.
+    """
+    from hmz.tui.app import _BY_NAME, _COMMANDS
+    from hmz.tui.complete import offered
+
+    assert "export" not in _BY_NAME
+    assert "/export" not in offered("/", _COMMANDS)
+
     app = Humanize()
     async with app.run_test() as driver:
         await driver.press(*"/export")
         await driver.press("enter")
-        await until(lambda: "nothing has been run here" in _transcript(app), driver)
+        await until(lambda: "no such command" in _transcript(app), driver)
 
-    assert not list((workspace / ".humanize").glob("*.tar.gz"))
+        assert app.is_running  # a line that is not a command leaves the interface up
 
 
 @pytest.mark.timeout(90)

--- a/tests/tui/test_leaving.py
+++ b/tests/tui/test_leaving.py
@@ -2,8 +2,9 @@
 
 Closing the interface and stopping the run are two things wherever the run is being held
 somewhere a terminal closing cannot reach: the flow goes on taking its turns, and `hmz` in
-this directory opens it again. So `/exit` asks and `/detach` says it outright, and what is
-checked here is that each of them does what it says and leaves the other alone.
+this directory opens it again. So `/exit` asks, and letting go of the terminal is one of the
+answers rather than a command of its own -- what is checked here is that each answer does what
+it says, and that the one command says outright that a flow can be left running.
 """
 
 from __future__ import annotations
@@ -91,49 +92,36 @@ async def _says(app: Humanize, driver: Pilot[None], line: str) -> None:
 
 
 @pytest.mark.timeout(60)
-async def test_detach_is_offered_as_a_command() -> None:
-    """Since nothing here is chosen from a dialog: a `/` offers what there is."""
-    from hmz.tui.app import _OWN
-    from hmz.tui.complete import about
+async def test_letting_go_of_the_terminal_is_not_a_command_of_its_own() -> None:
+    """It is an answer to `/exit`, which is the one question about leaving there is.
 
-    assert "detach" in _OWN
-    assert about("detach")
+    Two words for two halves of one decision is one of them typed by somebody who meant the
+    other, so there is one: `/exit` asks, and what it asks is what `/detach` used to say.
+    """
+    from hmz.tui.app import _BY_NAME, _COMMANDS
+    from hmz.tui.complete import offered
 
+    assert "detach" not in _BY_NAME
+    assert "/detach" not in offered("/", _COMMANDS)
 
-@pytest.mark.timeout(60)
-async def test_detach_lets_go_of_the_terminal_and_leaves_the_run() -> None:
-    holding = Holding()
-    app = Humanize(session=holding)
+    app = Humanize(session=Holding())
     async with app.run_test() as driver:
         await _says(app, driver, "/detach")
+        await until(lambda: "no such command" in transcript(app), driver)
 
-        assert holding.let_go == 1
-        assert app.is_running  # the interface is not closed: the terminal is let go of
-
-
-@pytest.mark.timeout(60)
-async def test_detach_says_so_where_nothing_is_holding_the_run() -> None:
-    """Closing the terminal it was opened in is what closes it, so there is nothing to do."""
-    app = Humanize()
-    async with app.run_test() as driver:
-        await _says(app, driver, "/detach")
-        await until(lambda: "nothing to" in transcript(app), driver)
-
-        assert "closing the terminal closes the run" in transcript(app)
         assert app.is_running
 
 
-@pytest.mark.timeout(60)
-async def test_detach_says_so_where_nothing_is_reading() -> None:
-    holding = Holding(reading=0)
-    app = Humanize(session=holding)
-    async with app.run_test() as driver:
-        await _says(app, driver, "/detach")
-        await until(lambda: "nothing is reading" in transcript(app), driver)
+def test_the_one_way_out_says_that_a_flow_goes_on_running() -> None:
+    """The list is where somebody reads what a command does before they type it.
 
-        assert "nothing is reading this run" in transcript(app)
-        assert holding.let_go == 0
-        assert app.is_running
+    Leaving with a flow running is the one thing here that does not end what it closes, so
+    the line beside `/exit` has to say so: a person who reads `Exit humanize` and means to
+    leave the run going has no way of knowing from there that they can.
+    """
+    from hmz.tui.app import _BY_NAME
+
+    assert "running" in _BY_NAME["exit"].about
 
 
 @pytest.mark.timeout(120)
@@ -227,6 +215,21 @@ async def test_leaving_it_running_lets_go_of_the_terminal_instead(
         assert holding.let_go == 1
         assert app.is_running  # the flow is still going, where nothing is reading it
         assert app._agents
+
+
+@pytest.mark.timeout(120)
+async def test_letting_go_says_so_where_nothing_is_reading(workspace: Path) -> None:
+    """The reader went while the question was up, so there is nothing left to let go of."""
+    written(workspace, "flow", FLOW)
+    holding = Holding(reading=0)
+    app = Humanize(session=holding)
+    async with app.run_test() as driver:
+        await _asks(app, driver)
+        app.screen.dismiss(DETACHES)
+        await until(lambda: "nothing is reading" in transcript(app), driver)
+
+        assert holding.let_go == 0
+        assert app.is_running
 
 
 def test_the_second_answer_is_whichever_one_is_true_here() -> None:

--- a/tests/tui/test_quick_flow.py
+++ b/tests/tui/test_quick_flow.py
@@ -19,7 +19,7 @@ from hmz.coganchor.backends import Model
 from hmz.runtime.kept import Runs
 from hmz.runtime.settings import Settings
 from hmz.tui import Humanize
-from hmz.tui.app import _OWN, Editor
+from hmz.tui.app import _COMMANDS, Editor
 from hmz.tui.complete import offered
 from hmz.tui.pick import Flows
 from hmz.tui.selecting import Transcript
@@ -366,10 +366,14 @@ def test_the_flows_there_are_are_offered_under_the_sigil_that_starts_one() -> No
     from hmz.flows import found
 
     every = [f"${one.name}" for one in found()]
-    assert offered("$", _OWN) == every
-    assert offered("$cha", _OWN) == [one for one in every if one.startswith("$cha")]
-    assert offered("$chat", _OWN) == []  # written out already, so enter sends the line
-    assert offered("$chat fix the", _OWN) == []  # the prompt, which is prose
+    assert offered("$", _COMMANDS) == every
+    assert offered("$cha", _COMMANDS) == [
+        one for one in every if one.startswith("$cha")
+    ]
+    assert (
+        offered("$chat", _COMMANDS) == []
+    )  # written out already, so enter sends the line
+    assert offered("$chat fix the", _COMMANDS) == []  # the prompt, which is prose
 
 
 @pytest.mark.timeout(60)

--- a/tests/tui/test_resume.py
+++ b/tests/tui/test_resume.py
@@ -346,9 +346,9 @@ async def test_a_line_that_named_a_run_is_said_back_rather_than_dropped(
 
 def test_the_command_is_offered_with_a_line_about_it() -> None:
     """Or it is a command only whoever wrote it knows is there."""
-    from hmz.tui.app import _OWN
-    from hmz.tui.complete import about, offered, takes
+    from hmz.tui.app import _BY_NAME, _COMMANDS
+    from hmz.tui.complete import offered
 
-    assert "/resume" in offered("/", _OWN)
-    assert about("resume")
-    assert takes("resume") == ""  # the last run is not something to name
+    assert "/resume" in offered("/", _COMMANDS)
+    assert _BY_NAME["resume"].about
+    assert _BY_NAME["resume"].takes == ""  # the last run is not something to name


### PR DESCRIPTION
Four asks that all live in the app chrome.

## One table for the commands

The commands were declared in three unconnected places — `_OWN` in `app.py`, `_ABOUT`/`_TAKES` in `complete.py`, and a chain of `elif` in `Humanize._sent` — kept in step by a test rather than by construction. They are now one `Command` row apiece (`name`, `about`, `does`, `takes`), declared once in `_COMMANDS` at the bottom of `app.py` (it names the methods, so it has to follow the class) and read by everything: the offers list, the hint line under the editor, and the dispatch. `complete.offered`/`hinted` take the rows rather than a tuple of names, and `complete.about`/`takes` are gone — a command cannot now be offered and do nothing.

The old test that asserted `_OWN` and `_ABOUT` agree is replaced by one that asserts the offers *are* the table, that `_BY_NAME` covers it, and that every row has a line said about it.

Side effect: `_offer_of` only looks a command up for an offer that starts with `/`, so a flow called `monitor` no longer picks up a command's description.

## `/detach` goes; `/exit` absorbs it

The behaviour stays — `DETACHES` on the `Leaves` popup still lets go of the terminal, via `Humanize._detach` (was `action_detach`; nothing binds it any more, so it is private). The unreachable "this run is in the terminal it was opened in" branch went with the command: that answer is only offered where a session holds the run. What the list says about `/exit` now reads **"Leave; a flow that is running can be left running"**.

## `/export` goes entirely

`Humanize._export` and `Humanize._epic` are gone. Exporting is what `/epics` offers about the run under its cursor — the `Epics`/`Does` sheets are untouched, and so is `hmz.runtime.exporting`. The only edits outside the TUI are docstrings in `runtime/exporting.py` and `sdk/epics.py` that still claimed the interface fills `transcript=` in; no code path does now, so they say who can.

## AFK gets a marker

`afk` (in `$warning`, i.e. yellow) and `details` (muted) are prepended to the **left** of the status line, ahead of the flow and the directory, before the room-for-keys calculation. The right-hand keys are clipped from the front when the terminal is narrow and the flow plus the directory can fill a small screen on their own, so the front of the row is the only place a marker always survives.

**I marked `/details` too.** Both are modes that silently change what you see, both are announced by one transcript line that scrolls away, and neither changes anything else drawn — the argument for marking one is the argument for marking the other.

## Verified

- `uv run pytest` — 2860 passed, 72 skipped.
- `uv run pre-commit run --all-files` — ruff, ruff-format, pyright strict all pass.
- New headless pilots: `/detach` and `/export` are no longer offered and both say `no such command`; `/exit`'s line says a flow can be left running; the markers appear and disappear in `#status`; the marker is still first on the row at 40 columns. Letting go where nothing is reading is now driven through the popup rather than a command.
- **A real interactive run** on a pseudoterminal in a temp directory: `/afk` on drew `afk · ◉ chat · /tmp/… / commands · …` with the marker in SGR 33 (yellow); narrowed to 46 columns it drew `afk · ◉ chat · /tmp/… ctrl+c` — the keys gave way and the marker did not; `/afk off` cleared it; `/exit` closed cleanly (status 0).

## For the coordinator

- `tests/tui/test_export.py` and the `/epics` export clause in `specs/tui.md` are shared with the unit reworking the epics menu: I removed only the four app-level `/export` tests and left `test_a_run_out_of_the_list_is_exported_from_the_menu_under_it` alone, and my spec edit to that clause only drops its reference to the command that no longer exists (plus keeps the "says where it landed, does not block" requirement that the `/export` clause used to carry).
- Docs updated: `specs/tui.md`, `docs/reference/tui.md`, `docs/reference/daemon.md`, `docs/reference/cli.md`, `docs/user/{afk,details,export,questions,index,history,conversations,reporting,tracing}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
