### PR TITLE
feat: what a turn costs, counted kind by kind and marked where it is short

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -219,6 +219,13 @@ of it can be gathered afterwards, and a branch in `tui/tally.py`'s `_spent` wher
 says what one request cost, which is what a tally moving during a turn is read out of. A
 backend that writes neither gets neither, and says so rather than being left out.
 
+Its usage goes under the names in `coganchor/agents/event.py`'s `KINDS` and no others — the
+prices are per kind, so a driver writing its CLI's own spelling down reports a lump nothing can
+price — and which of them it reports is declared on the agent class as `counts`, read off the
+same table the driver parses with rather than written down twice. A backend that reports
+nothing declares nothing; what draws a run then marks its figures as floors rather than leaving
+that backend out of them.
+
 And the documentation. Several pages count the backends and several tables name every one of
 them, so one added without them is a site that says there are fewer than there are.
 

--- a/docs/features/budgets.md
+++ b/docs/features/budgets.md
@@ -38,6 +38,12 @@ The three that state a whole turn's cost only at the end — Antigravity, Grok B
 Code — can only be held to a token budget at the end of a turn, which is the same thing their
 [rate](/reference/agents#what-it-has-cost-and-how-fast) already reads as.
 
+A token budget is **output tokens**, read off `session.spent().output`, so it depends on the
+backend counting them under that name. Every backend humanize drives does; which kinds each
+reports is declared as `counts` — see [Cost and rate](/user/tally) — and served by the
+catalogue as `counts:output`, so a flow can be refused an agent that would read nought and
+never be cut off at all.
+
 A cap on the clock has no such gap: it bites whether or not anything is arriving, which is what
 makes it the one that catches a turn that has gone quiet, and the one to reach for on a backend
 that does not count as it goes.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1288,6 +1288,24 @@ spent.get("cache_read", 0)                   # for a backend that counts one
 dict(spent)                                  # everything it does count
 ```
 
+The five names are `hmz.coganchor.agents.KINDS`, and every driver reports under them rather
+than under its own CLI's spelling — a kind is the same thing whichever CLI counted it, and the
+prices are per kind. They add up to the whole of what crossed the wire and never to more: a
+backend counting its reasoning inside the output does not also carry it beside the output.
+
+**Which kinds a backend reports is declared rather than inferred**, on the agent class as
+`counts`, because a turn that spent nothing on a cache write is missing that kind exactly as a
+CLI that never counts one is:
+
+```python
+ClaudeCodeAgent.counts    # frozenset({"input", "output", "cache_read", "cache_write"})
+CodexAgent.counts         # frozenset({"input", "output"}) — cached reads are inside the input
+CursorAgent.counts        # frozenset() — a duration and no tokens
+```
+
+The catalogue serves each of them as `counts:<kind>`, so a place whose flow steers by one can
+say so with `Needs` and be refused an agent that would answer nought forever.
+
 **A rate is tokens a second over seconds on the clock**, not seconds an agent was talking: a
 flow sleeps between rounds, commits, reads what the last turn wrote, and that time is time the
 tokens were spent over. The window defaults to five minutes — `hmz.coganchor.agents.WINDOW`, the

--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -428,6 +428,7 @@ class Agents(NamedTuple):
 | `shape` | a turn *held* to a schema rather than asked to keep to one |
 | `tools` | the flow's own callbacks put in front of the agent, `session.offers([...])` |
 | `fork` | one conversation carried into a second going its own way |
+| `counts:<kind>` | the backend says what a turn spent on that kind of token — `input`, `output`, `cache_read`, `cache_write`, `reasoning` — so a loop bounded by one is not bounded by a nought |
 | `search` / `swarm` / `resume` | facts about the CLI itself, out of its own profile |
 | `moment:<name>` | a moment only some backends reach, written out rather than as the enum |
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -15,7 +15,8 @@ agent — a transcript, a multi-line editor under it, and a status line under th
 ├──────────────────────────────────────────────────────────────────────┤
 │              builder · claude/claude-opus-4-8:high · ● 2 · reading   │  ← what each agent runs
 │              reviewer · codex/gpt-5.6-sol:high · ○ 3 · unread        │
-│                    48.2k tokens · $1.34 · 91/s                       │
+│   input 12.4k · output 2.1k · cache_read 1.02M+ · cache_write 48.2k+ │
+│                          $1.34 · 91 out/s                            │
 │ ❯ type here                                                          │  ← the editor
 ├──────────────────────────────────────────────────────────────────────┤
 │ ·|· builder… (73s · ctrl+c twice to stop)   esc status · tab agent  │  ← the status line
@@ -38,13 +39,17 @@ it runs as `cli/model:effort`, then the machine its turns land on where that is 
 [account](#which-cli-and-which-account) it runs as where that is not this machine's own, and
 finally what it is holding — `●` or `○` for whether it is working, how many conversations it
 has open, `reading` on the agent whose transcript is on the screen, and `unread` on one that
-has said something since you last looked at it. Under them, what the run has cost so far — in
-tokens, in money, and the rate it is costing it at — per model, since two agents at one model
-are one bill, and over a recent window only, so a flow that has stopped reads as stopped. The
-money comes from [OpenLLMPrices](https://openllmprices.com/), fetched once as the interface
-opens and kept under `~/.humanize/prices.json`; a model nobody lists shows its tokens with
-nothing beside them rather than `$0.00`, and a run mixing a priced model with an unpriced one
-marks its total `$1.34+`. See [Cost and rate](/user/tally).
+has said something since you last looked at it. Under them, what the run has cost so far — one
+figure per kind of token rather than one over the lot of them, then the money and the rate.
+A `+` on a kind means some agent of the run drives a CLI that does not report it at all, so
+that figure is a floor rather than the total; with one agent running nothing is marked. The rate is
+**output tokens** a second, over a recent window only, so a flow that has stopped reads as
+stopped — and the whole readout is worked out again every five seconds and whenever an agent
+does anything, rather than only when a count lands. The money is per model, since two agents at
+one model are one bill; it comes from [OpenLLMPrices](https://openllmprices.com/), fetched once
+as the interface opens and kept under `~/.humanize/prices.json`; a model nobody lists shows its
+tokens with nothing beside them rather than `$0.00`, and a run mixing a priced model with an
+unpriced one marks its total `$1.34+`. See [Cost and rate](/user/tally).
 
 **The status line, left:** what is running, if anything is — whose turn it is and how long it
 has been going. Between two turns it names the flow and how long the run has been going, since
@@ -341,8 +346,12 @@ neighbours as the arrows joining them:
 
    Flow:             chat
    Also:             builder → reporter · ×2
-   Tokens:           claude-opus-5                48.2k    $1.34    91/s
-                     some-local-model             9.1k              12/s
+   Tokens:           claude-opus-5                48.2k    $1.34  91 out/s
+                     some-local-model             9.1k            12 out/s
+   Kinds:            input                         1.2k
+                     output                          980
+                     cache_read                   46.0k
+                     cache_write                   9.1k
 ```
 
 **Each box says what its agent is on the left and what it is doing on the right.** What it runs
@@ -360,8 +369,13 @@ under the diagram as `Also` rather than drawn — a line crossing the page from 
 the fourth is a line nothing in a terminal draws readably.
 
 **`Tokens` is one row per model**, biggest spender first, with what it has cost in tokens, what
-that came to in money, and the rate. The blank in the money column is a model nobody prices —
-never a bill of `$0.00`, which would be a claim about what was spent. See [Cost and
+that came to in money, and the rate in output tokens a second. The blank in the money column is
+a model nobody prices — never a bill of `$0.00`, which would be a claim about what was spent.
+
+**`Kinds` is one row per kind of token**, over every model: a bill is made of the kinds
+whichever model bought them, so this is the run's rather than any one model's. A figure marked
+`+` is a floor — some agent here drives a CLI that does not report that kind, or something was
+counted without its kind being said — with a line under the block saying so. See [Cost and
 rate](/user/tally).
 
 **A box appears as its agent takes its first turn**, and not before. A flow may declare ten
@@ -407,8 +421,9 @@ what the run is running as, and the two are read from the bottom up — the last
 the running total end on the same row:
 
 ```
-❯ and fix the tests too                    assistant · claude-opus-5:high
-❯ then push                             12.3k tokens · $0.31 · 84/s
+                                           assistant · claude-opus-5:high
+❯ and fix the tests too            input 11.2k · output 1.1k · cache_read 0
+❯ then push                                           $0.31 · 84 out/s
 ────────────────────────────────────────────────────────────────────────
 ❯ █
 ```

--- a/docs/user/monitor.md
+++ b/docs/user/monitor.md
@@ -92,7 +92,8 @@ Only what the boxes cannot carry, so that the picture is what your eye lands on:
 | **Flow** | every flow running — the one that was started and whatever it called, innermost last |
 | **Set** | the flow's own settings, where any were changed from what it declares |
 | **Also** | the handovers no arrow could be drawn for |
-| **Tokens** | what each model has cost, and the rate it is costing it at |
+| **Tokens** | what each model has cost, and the output tokens a second it is coming out with |
+| **Kinds** | what the run spent on each kind of token, a `+` marking a figure some agent's CLI does not report and which is therefore a floor |
 
 Who is working, what each agent runs and how long it has been at it are on the boxes, and are
 not said twice.

--- a/docs/user/steering.md
+++ b/docs/user/steering.md
@@ -23,8 +23,9 @@ dropped. A held line is pinned onto the editor rather than written into the tran
 behind the same `❯`:
 
 ```
-❯ and fix the tests too                    assistant · claude-opus-5:high
-❯ then push                                     12.3k tokens · 84/s
+                                           assistant · claude-opus-5:high
+❯ and fix the tests too            input 11.2k · output 1.1k · cache_read 0
+❯ then push                                                    84 out/s
 ────────────────────────────────────────────────────────────────────────
 ❯ █
 ```

--- a/docs/user/tally.md
+++ b/docs/user/tally.md
@@ -11,12 +11,47 @@ The readout sits under the agent lines, above the editor:
 ```
               builder · claude/claude-opus-5:high · ● 2 · reading
               reviewer · codex/gpt-5.6-sol:high · ○ 3 · unread
-                    48.2k tokens · $1.34 · 91/s
+    input 12.4k · output 2.1k · cache_read 1.02M+ · cache_write 48.2k+
+                              $1.34 · 91 out/s
 ```
 
-It is **per model**, since two agents at one model are one bill, and it covers **a recent
-window only**, so a flow that has stopped reads as stopped. [`/monitor`](/user/monitor) is the
-fuller version, with the handover graph beside it.
+**Each kind of token is counted on its own**, never as one total over the lot of them. An
+input token, an output token, a cached read and a cached write are four different things
+bought at four different prices, and a single figure over all of them cannot tell a long
+conversation from a lot of work.
+
+The money is **per model**, since two agents at one model are one bill, and the rate covers **a
+recent window only**, so a flow that has stopped reads as stopped.
+[`/monitor`](/user/monitor) is the fuller version, with the handover graph beside it.
+
+## The `+` on a kind
+
+A `+` means *at least this much*. It is there when **some agent of the run drives a CLI that
+does not report that kind at all** — Codex says nothing about a cache write, so a run mixing
+Codex with Claude Code has a `cache_write` column made of Claude's writes alone. The union of
+two backends is still the right figure to show; what would be wrong is showing it as though it
+were the whole.
+
+With **one** agent running there is nothing for a figure to be short of, so nothing is marked
+and what you see is that backend's own reckoning — every kind it counts, whether or not
+anything has gone on it yet. A column that appeared the first time a cache was written to
+would be a readout that shuffles sideways while you are reading it.
+
+A `+` is also there when **something was counted without its kind being said** — a backend that
+reports a lump, a turn that spanned two models and named the kinds of neither. Those tokens
+went on some kind and there is nothing to say which, so every column is short by part of them.
+
+Which kinds each backend reports is a capability like any other: `counts:cache_read` and its
+four siblings say who serves each one, and `hmz.flows.briefed()` lists them.
+
+## What refreshes it, and when
+
+Every **five seconds**, and again the moment an agent does anything at all — a tool call, a
+word, an answer. Not only when a count arrives: a turn is minutes long and spends most of them
+between the moments it reports one, and a rate is tokens over *seconds on the clock*. A figure
+that moved only when a count landed would stand still through every tool call of a turn and
+then jump as the turn ended, which reads as a run that stalled and recovered rather than as one
+working.
 
 ## The money
 
@@ -32,8 +67,13 @@ humanize drives whatever CLI you have installed. So the unlisted model is the or
 not the broken one:
 
 ```
-   Tokens:   claude-opus-5              48.2k    $1.34     91/s
-             some-local-model            9.1k              12/s
+   Tokens:   claude-opus-5              48.2k    $1.34     91 out/s
+             some-local-model            9.1k              12 out/s
+   Kinds:    input                       1.2k
+             output                        980
+             cache_read                 46.0k+
+             cache_write                 9.1k+
+             + a floor: not every agent here reports that kind
 ```
 
 The blank is deliberate. `$0.00` beside a model nobody priced would be a claim about a bill,
@@ -130,8 +170,12 @@ spells another is two lines. Each line's money is that line's.
 
 `input` and `output` are the two that every backend counts, and they sit on the mapping as
 attributes. The rest differ from CLI to CLI: a cache read, a cache write, or the reasoning a
-backend counts beside the output rather than inside it. So **a kind that is not there is one
-that backend does not report**:
+backend counts beside the output rather than inside it. The five names are
+`hmz.coganchor.agents.KINDS`, and every driver reports under them — a kind is the same word
+whichever CLI counted it, because the prices are per kind and a usage written down under one
+CLI's own spelling is a lump nothing can price.
+
+So **a kind that is not there is one that backend does not report**:
 
 ```python
 spent = session.spent()
@@ -144,6 +188,36 @@ The kinds are also what a bill is made of. A reasoning count kept beside the out
 as output. A backend that says what a turn cost without saying which kinds it went on gets no
 bill at all — the tokens are counted and nothing is claimed about them.
 
+They add up to the whole of what crossed the wire, and never to more. A backend that counts its
+reasoning inside the output does not also carry it beside the output, and one that counts a
+cached read inside the input has the read taken back out: a token counted twice is a token
+billed twice.
+
+**Which kinds a backend reports is a fact about the backend, not about the turn**, and it is
+declared rather than guessed: a turn that spent nothing on a cache write is missing that kind
+exactly as a CLI that never counts one is. `AgentBase.counts` says it, the catalogue serves it
+as `counts:<kind>`, and a flow can be refused an agent whose backend never reports what it
+means to steer by:
+
+| Backend | Counts |
+| --- | --- |
+| Claude Code, Kimi Code, pi, DeepSeek Harness, Grok Build, Qwen Code | `input`, `output`, `cache_read`, `cache_write` |
+| opencode, mimocode | those four and `reasoning` |
+| Antigravity | `input`, `output`, `cache_read`, `reasoning` |
+| Codex, ZCode | `input`, `output` — each counts its cached reads inside the input |
+| Cursor | nothing: it reports a duration and no tokens |
+
+`reasoning` is only there for the backends that count it **beside** the output. Grok Build
+reports a `reasoning_tokens` and it is deliberately not among its kinds: one measured turn,
+asked to think at length and answer in one word, came back with `output_tokens: 1141` and
+`reasoning_tokens: 1140`, so counting it separately would count those tokens twice and — the
+prices billing reasoning as output — bill for them twice.
+
+The interface reads the CLIs' own logs as well as their drivers, and a kind either of them
+names counts as reported — Codex's server never names a cached read, and the rollout it writes
+does. Only once that log has actually been read here, though: an agent whose turns land on
+another machine writes its rollout there, and nothing on this one can show a kind out of it.
+
 The `result` event a turn ends on carries the same reckoning, beside the per-model `tokens` it
 already carried. `result.spent.total` is what `result.tokens` comes to.
 
@@ -152,6 +226,13 @@ already carried. `result.spent.total` is what `result.tokens` comes to.
 **A rate is tokens a second over seconds on the clock**, not seconds an agent was talking. A
 flow sleeps between rounds, commits and reads what the last turn wrote. That time is time the
 tokens were spent over, and it is the honest reading of what a run costs per hour.
+
+**The one the interface draws is output tokens a second, and says so.** The input of a turn is
+the conversation so far, sent again at every request and mostly served out of a cache: it grows
+with the length of the transcript rather than with the work, so a rate counting it says how
+long the conversation has got — and doubles the moment a backend starts reporting what it read
+back out of its cache. `session.rate()` itself is per kind, so a flow can read whichever it
+means.
 
 The window defaults to five minutes — `hmz.flows.WINDOW`, the same window the interface's
 readout uses. A run younger than the window is measured **over the run**, so a rate read a

--- a/docs/weaver/loops.md
+++ b/docs/weaver/loops.md
@@ -97,8 +97,9 @@ happened, and what each model has cost. On a one-agent flow the graph is dull. O
 Above the editor, continuously:
 
 ```
-   assistant · claude/claude-opus-4-8:high · ● 1
-                       48.2k tokens · 91/s
+        assistant · claude/claude-opus-4-8:high · ● 1
+   input 1.2k · output 980 · cache_read 46.0k · cache_write 9.1k
+                          $1.34 · 91 out/s
 ```
 
 `●` is an agent with a turn open, and `1` is how many conversations it has open **right now**.

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -28,17 +28,22 @@
 
 ## `__init__.py`
 
-Expose `AgentConfig`, `AgentBase`, `Event`, `Question`, `Saying`, `Stopped`, `Failed`,
-`Unrecoverable`, `Usage`, `SessionBase`, `CommandSessionBase`, `StreamSessionBase`, `Tool`,
-`Toolbox`, `Gate`, `Board`, `Item`, and all agent and session classes.
+Expose `KINDS`, `AgentConfig`, `AgentBase`, `Event`, `Question`, `Saying`, `Stopped`,
+`Failed`, `Unrecoverable`, `Usage`, `SessionBase`, `CommandSessionBase`,
+`StreamSessionBase`, `Tool`, `Toolbox`, `Gate`, `Board`, `Item`, and all agent and session
+classes.
 
 ## `event.py`
 
-`Event`, `Question`, `Stopped`, `Usage`, `Failed`, `Unrecoverable`, `Saying` and `say`: what a
-turn says while it runs, what it asks, what it cost, how it failed, and how the fragments it
-arrives in are put back together -- with no behaviour on the values themselves.
+`KINDS`, `Event`, `Question`, `Stopped`, `Usage`, `Failed`, `Unrecoverable`, `Saying` and
+`say`: the kinds of token there are, what a turn says while it runs, what it asks, what it
+cost, how it failed, and how the fragments it arrives in are put back together -- with no
+behaviour on the values themselves.
 
 ```python
+KINDS = ("input", "output", "cache_read", "cache_write", "reasoning")
+
+
 class Failed(subprocess.CalledProcessError):
     def __init__(
         self,
@@ -124,6 +129,24 @@ class Saying:
   tool call. A backend that says only one of the two halves would be one whose subagents never
   finish, so it MUST say both or neither.
 
+- `Usage` MUST be a mapping from kind of token to how many went on it, and the kinds MUST be
+  named out of `KINDS` -- `input`, `output`, `cache_read`, `cache_write`, `reasoning` --
+  wherever one is counted. A kind is the same thing whichever CLI counted it, the prices are
+  per kind, and a driver that wrote its backend's own spelling down would be reporting a lump
+  nothing can price and no `Usage.input` anybody can read. A kind no backend here has is
+  allowed, but it MUST be the same word in every driver that has it.
+- A kind that is not on a `Usage` MUST mean the backend did not report it, which is not the
+  same as reporting nothing on it. Which of the two it is MUST be answerable of the backend
+  rather than of the turn -- see `counts` -- because nothing about a turn that spent nothing
+  on a kind distinguishes it afterwards from a backend that never counts that kind at all.
+- The kinds MUST be counted so that adding them up is the whole of what crossed the wire, and
+  so no kind reported here may hold tokens another one here already holds. A backend that
+  counts its reasoning inside the output MUST NOT carry a `reasoning` beside the output as
+  well, and one that reports a cached read it also counts inside its input MUST have the read
+  taken back out of the input. A token counted twice is a token billed twice, and every figure
+  read off these is then wrong upwards, which is the one direction none of them may be wrong
+  in. Leaving a kind unreported is always allowed and is what a driver MUST do where it cannot
+  tell whether the count it is given overlaps another.
 - These MUST NOT name the base classes. Every backend needs them and none of them needs the
   base classes to say one, so a reader of somebody else's stream format imports this alone.
 
@@ -508,6 +531,9 @@ A turn that has stopped saying anything, noticed and dealt with rather than wait
 
 ```python
 class AgentBase(ABC):
+    #: Which kinds of token this backend reports, out of `KINDS`.
+    counts: ClassVar[frozenset[str]] = frozenset()
+
     def __init__(self, config: AgentConfig, *, name: str | None = None): ...
 
     @property
@@ -574,6 +600,17 @@ class AgentBase(ABC):
 - `id` MUST be the given name, or a codename from `codenames.py` when no name is given, so that
   two agents of the same config are two agents. `rename` MUST take a name from a flow only for
   an agent that was not named where it was made: a name given is a name kept.
+- Which kinds of token a backend reports MUST be declared on its driver as `counts`, out of
+  `KINDS`, and MUST be read off the same table the driver parses a usage with rather than
+  written down a second time beside it. It is a fact about the driver and not about the CLI,
+  so it belongs here with `moments` and `pursues` rather than in `hmz.coganchor.backends`; and
+  it MUST be answerable before the first turn, since what it is for is telling a kind nothing
+  was spent on from a kind nothing counts. A driver that reports nothing MUST declare nothing,
+  and whatever draws a run MUST then say its figures are a floor rather than leave that
+  backend out of them.
+- `counts` MUST be what the catalogue reads to say which backends serve each kind, under
+  `counts:<kind>`, so that a flow steering by what a turn cost can be refused an agent whose
+  backend never says it rather than reading nought and believing it.
 - `clone` MUST answer with another agent of this one's backend, differing in what the call
   names and in nothing else -- its config, its name, and the flow's skills it carries. It is
   the one way to have an agent that is not the one you were handed, and there MUST be nowhere

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -686,6 +686,25 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   from. Nobody is watching a token count for its own sake. Where the money is not known the
   tokens MUST stand alone, and where only some of the models running are priced the figure
   MUST say that it is a floor rather than pass for the whole bill.
+- What has been spent MUST be said kind by kind and MUST NOT be said as one total over the
+  kinds, wherever the tokens are said. An input token, an output token, a cached read and a
+  cached write are four different things bought at four different prices, and one number over
+  the lot of them answers no question anybody has: a run that reads as a million tokens is a
+  run nobody can tell a long conversation from a lot of work.
+- Every kind an agent of the run reports MUST be drawn whether or not anything has gone on it
+  yet, and the order MUST NOT change as a run goes. A column that appeared the first time a
+  cache was written to is a readout that shuffles sideways while it is being read.
+- With one agent running, what is drawn MUST be that agent's own kinds. With several it MUST
+  be the union of theirs, and a kind some of their backends do not report at all MUST be
+  marked as a floor rather than passed off for what the run spent on it: the figure is short
+  by whatever the backends that do not count it spent there, and one drawn as though it were
+  the total is a claim about the run that nothing here can make. The same MUST hold where some
+  of what was spent was counted without saying what kind it went on -- those tokens went on
+  some kind, and there is nothing to say which.
+- The rate MUST be output tokens a second and MUST say so. The input of a turn is the
+  conversation so far, sent again at every request and mostly served out of a cache: a rate
+  counting it says how long the transcript has got rather than how fast the model is writing,
+  and doubles the moment a backend starts reporting what it read back out of its cache.
 
 ### The board
 
@@ -751,6 +770,14 @@ class Spend:
     tokens: int
     rate: float
     dollars: float | None = None
+    kinds: Mapping[str, float] = ...
+
+
+@dataclass(frozen=True, slots=True)
+class Counted:
+    kind: str
+    tokens: float
+    whole: bool
 
 
 def lasting(seconds: float) -> str: ...
@@ -769,6 +796,9 @@ class Monitor:
         kinds: Mapping[str, float] | None = None,
     ) -> None: ...
     def spending(self, now: float | None = None) -> list[Spend]: ...
+    def reckoning(self, now: float | None = None) -> list[Counted]: ...
+    def reporting(self, agent: str, kinds: Iterable[str]) -> None: ...
+    def stirring(self) -> None: ...
     def now_working(self) -> list[str]: ...
     def shape(self) -> Shape: ...
 ```
@@ -790,6 +820,32 @@ a flow being a Python file that may branch any way it likes.
 - `spending` MUST be per model rather than per agent, since two agents at one model are one
   bill, and MUST report a rate over a recent window only -- a flow that has stopped reads as
   stopped rather than as whatever it once averaged.
+- It MUST also report what each model spent by kind of token, from the same reckoning the
+  money is worked out from, so that whatever draws it draws the kinds rather than a lump. The
+  kinds were already parsed to work out the money; a `Spend` that carried only their sum would
+  be a breakdown thrown away between the two places that want it.
+- The rate MUST be output tokens a second. What a model is doing is what it writes: the input
+  of a turn is the conversation so far, sent again at every request and mostly served out of a
+  cache, so a rate over every kind measures the length of the transcript and jumps the moment
+  a backend starts reporting its cached reads.
+- `reckoning` MUST answer what the run spent on each kind, over every model, and MUST say of
+  each figure whether it is the whole of it. A figure MUST NOT be whole where an agent of the
+  run drives a backend that does not report that kind, nor where anything was counted without
+  its kind being said. Nothing MUST be marked where one agent is running, nor where nothing
+  has said what it reports: a mark against every figure of a run that is counting everything
+  is a warning nobody can act on.
+- Which kinds a backend reports MUST be said of the backend rather than read off what a turn
+  happened to spend. A kind nothing went on this turn is missing from that turn's reckoning
+  exactly as a kind the CLI never counts is, and nothing afterwards can tell the two apart.
+  `reporting` is what says it, and what it is told MUST be what the driver declares, together
+  with what that backend's own log says once such a log has actually been read here. Not
+  before: a rollout written on another machine is one nothing here reads, and a kind claimed
+  off a log nobody read would be a nought drawn as a fact.
+- What has been spent MUST be worked out again at least every five seconds, and again whenever
+  an agent does anything at all -- a tool, a word, an answer -- rather than only when a count
+  arrives. A turn is minutes long and spends most of them between the counts it reports, and a
+  rate is tokens over seconds on the clock: a figure moved only by a count stands still through
+  every tool call and then jumps, which reads as a run that stalled and recovered.
 - A backend that says what a turn cost MUST be believed over what its agent was configured
   with: a turn that reached for a sub-agent spent it on that model.
 - What has been spent MUST be reported in money as well as in tokens, from `hmz.coganchor.prices`. A
@@ -799,6 +855,11 @@ a flow being a Python file that may branch any way it likes.
   source has seen the most of them -- the same source the count itself is taken from, since
   two sources counting one spend are one bill. A source that reported no kinds MUST leave the
   money unanswered: a lump of tokens is a lump nobody can price.
+- That one source MUST be taken entire rather than the largest figure for each kind being
+  taken from whichever source gave it. Two sources differ in which kinds they name as well as
+  in how far each has read, so a cached read taken from the log beside an input taken from the
+  backend's own report is the same tokens counted twice -- and overstating a bill is the one
+  thing none of this may do.
 - `dollars` MUST be None rather than nought for a model nobody lists and for a spend nobody
   broke down, and whatever draws it MUST show the tokens alone. `$0.00` is a claim about a
   bill, and against an unpriced model it is a false one.
@@ -878,3 +939,12 @@ What a run has cost, read from the logs the agents keep for themselves.
   taken back out rather than billed as both.
 - A row that says what it cost without saying what kinds it went on MUST still be counted and
   MUST NOT be priced. Tokens with no bill beside them is the honest reading of it.
+- Which kinds each log here is read for MUST be answerable, so that what the interface says
+  it can show of a backend is what it can in fact show. A driver and the log its CLI keeps are
+  two sources and one may name a kind the other does not -- Codex's server counts its cached
+  reads inside the input and never names them, while the rollout it writes does name them --
+  and a figure marked as short of a kind the interface can see would be a warning about
+  nothing. What is said of a log MUST be said once that log has been read rather than when the
+  run started, a log this machine has none of being one nothing here can show anything from.
+- A backend whose logs are not read here MUST answer nothing rather than an empty reckoning,
+  and reads the same way: nothing claimed of it, so nothing of it passed off as counted.

--- a/src/hmz/cli/output.py
+++ b/src/hmz/cli/output.py
@@ -491,12 +491,23 @@ class Shown:
         installed: `$0.00` beside a turn that cost something would be a claim about a bill,
         and a wrong one.
         """
+        from hmz.coganchor.agents import KINDS
         from hmz.coganchor.prices import cost, money
 
         if not event.spent:
             return
+        # In the one order every reader of these is shown them: what went in, what came out,
+        # then the cache kinds and the reasoning. A footer whose columns came out in whatever
+        # order the backend happened to write them is one nobody can read two turns of.
         counted = _DOT.join(
-            f"{kind} {_counted(tokens)}" for kind, tokens in event.spent.items()
+            f"{kind} {_counted(event.spent[kind])}"
+            for kind in sorted(
+                event.spent,
+                key=lambda kind: (
+                    KINDS.index(kind) if kind in KINDS else len(KINDS),
+                    kind,
+                ),
+            )
         )
         bill = cost(event.spent, agent.config.model)
         priced = f"{money(bill)}{_DOT}" if bill is not None else ""

--- a/src/hmz/coganchor/agents/__init__.py
+++ b/src/hmz/coganchor/agents/__init__.py
@@ -36,7 +36,16 @@ from .config import (
 )
 from .cursor import CursorAgent, CursorAgentConfig, CursorSession
 from .dsh import DshAgent, DshAgentConfig, DshSession
-from .event import Event, Failed, Question, Saying, Stopped, Unrecoverable, Usage
+from .event import (
+    KINDS,
+    Event,
+    Failed,
+    Question,
+    Saying,
+    Stopped,
+    Unrecoverable,
+    Usage,
+)
 from .grok import GrokBuildAgent, GrokBuildAgentConfig, GrokBuildSession
 from .hooks import (
     EVERYWHERE,
@@ -109,6 +118,7 @@ __all__ = [
     "DRIVEN",
     "EVERYWHERE",
     "FLOW",
+    "KINDS",
     "OUTCOMES",
     "PERMISSIONS",
     "SERVICE_TIERS",

--- a/src/hmz/coganchor/agents/agy.py
+++ b/src/hmz/coganchor/agents/agy.py
@@ -38,6 +38,19 @@ _TAKES = ("auto", "bypass")
 #: What a step says it is doing, as the one line a row of a transcript has room for.
 _THINKING = "THINKING"
 
+#: What each kind of token is called in the counts Antigravity states, and what each of
+#: them is here. Humanize's own names rather than the CLI's, as everywhere else a kind is
+#: counted: the prices are per kind, so a usage written down under a spelling nothing else
+#: knows is a lump nobody can put a figure on -- which is what these were until this table.
+#: The thinking is counted beside the output rather than inside it, as its model family
+#: counts it, so it is a kind of its own.
+_KINDS = {
+    "input": "input_tokens",
+    "output": "output_tokens",
+    "reasoning": "thinking_tokens",
+    "cache_read": "cache_read_tokens",
+}
+
 #: How a local command is written: one name, under a plugin's where it has one. A first word
 #: carrying a directory of its own is a path rather than a name, which is the whole of the
 #: difference the CLI itself can see -- so `/tmp` alone still reads as a command here, and
@@ -415,14 +428,9 @@ class AntigravityCLISession(StreamSessionBase):
         """
         return Usage(
             {
-                name: float(counted.get(name) or 0)
-                for name in (
-                    "input_tokens",
-                    "output_tokens",
-                    "thinking_tokens",
-                    "cache_read_tokens",
-                )
-                if counted.get(name)
+                kind: float(counted.get(named) or 0)
+                for kind, named in _KINDS.items()
+                if counted.get(named)
             }
         )
 
@@ -494,6 +502,10 @@ class AntigravityCLIAgentConfig(AgentConfig):
 
 class AntigravityCLIAgent(AgentBase):
     """Antigravity CLI, driven through its own persistent stream-json protocol."""
+
+    #: What it counts, read off the same table its driver reads a usage with, so that what
+    #: a run is told this backend reports is what its driver actually parses.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
 
     def _serves(self, config: AgentConfig) -> None:
         """Refuses a rung this backend has no way of running at, wherever the config arrives.

--- a/src/hmz/coganchor/agents/base.py
+++ b/src/hmz/coganchor/agents/base.py
@@ -3043,6 +3043,20 @@ class AgentBase(ABC):
     #: the first provider turn.
     service_tiers: ClassVar[tuple[str, ...]] = ("default",)
 
+    #: Which kinds of token this backend reports, out of :data:`hmz.coganchor.agents.KINDS`.
+    #: Declared here rather than worked out from what a turn happened to say: a kind nothing
+    #: was spent on this turn is missing from that turn's `Usage` exactly as a kind the CLI
+    #: never counts is, and a reader cannot tell the two apart afterwards. What a driver reads
+    #: out of its backend's own counters is what it says here, which is why each of them says
+    #: it off the same table it parses with.
+    #:
+    #: Empty for a CLI that reports nothing at all -- Cursor says a duration and no tokens, an
+    #: ACP peer says whatever its own protocol says, which is nothing agreed. A run that mixes
+    #: one of those with a CLI that counts everything MUST say that the figures it draws are a
+    #: floor rather than pass them off for the whole of what was spent: a column quietly short
+    #: of one agent's tokens is worse than a column marked as short of them.
+    counts: ClassVar[frozenset[str]] = frozenset()
+
     def __init__(self, config: AgentConfig, *, name: str | None = None) -> None:
         """Initializes an agent that has opened nothing yet.
 

--- a/src/hmz/coganchor/agents/claude.py
+++ b/src/hmz/coganchor/agents/claude.py
@@ -714,6 +714,10 @@ class ClaudeCodeAgent(AgentBase):
     #: Claude keeps itself going toward an objective, which is what `pursue` reaches for.
     pursues: ClassVar[bool] = True
 
+    #: What it counts, read off the same table its driver reads a usage with, so that
+    #: what a run is told this backend reports is what its driver actually parses.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
+
     def new(self, cwd: str | os.PathLike[str] | None = None) -> ClaudeCodeSession:
         """Opens a new Claude Code session, in the directory it is given or in this one."""
         return ClaudeCodeSession(self, cwd)

--- a/src/hmz/coganchor/agents/codex.py
+++ b/src/hmz/coganchor/agents/codex.py
@@ -1374,6 +1374,11 @@ class CodexAgent(AgentBase):
     #: codex keeps itself going toward an objective, which is what `pursue` reaches for.
     pursues: ClassVar[bool] = True
 
+    #: What it counts, read off the same table its driver reads a usage with. Two kinds
+    #: and no more: Codex counts its cached reads inside the input rather than beside it,
+    #: so there is no cache kind here to report.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
+
     def __init__(self, config: AgentConfig, *, name: str | None = None) -> None:
         """Initializes an agent whose app server is not running yet.
 

--- a/src/hmz/coganchor/agents/dsh.py
+++ b/src/hmz/coganchor/agents/dsh.py
@@ -121,6 +121,12 @@ class DshAgent(AgentBase):
     #: The official goal service keeps the session working until its objective is complete.
     pursues: ClassVar[bool] = True
 
+    #: What it counts. Its reasoning is already inside the output on the dsh contract, so
+    #: it is not a kind of its own here.
+    counts: ClassVar[frozenset[str]] = frozenset(
+        {"input", "output", "cache_read", "cache_write"}
+    )
+
     def __init__(self, config: DshAgentConfig, *, name: str | None = None) -> None:
         super().__init__(config, name=name)
 

--- a/src/hmz/coganchor/agents/event.py
+++ b/src/hmz/coganchor/agents/event.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
 __all__ = [
+    "KINDS",
     "Event",
     "Failed",
     "Question",
@@ -26,6 +27,18 @@ __all__ = [
     "Usage",
     "say",
 ]
+
+#: Every kind of token humanize counts, in the order a reader is shown them: what went in,
+#: what came out, the two cache kinds, and the reasoning some backends count beside the output
+#: rather than inside it. One vocabulary rather than each CLI's own, so that a run driving two
+#: backends reads one word for one thing and the prices -- which are per kind -- can be put
+#: against any of them. A backend counts some of these and not others; what it counts is what
+#: it says, and a kind missing from a `Usage` is one it does not report rather than one it
+#: reports as nothing.
+#:
+#: The order is what everything that draws them draws them in. A run whose columns reordered
+#: themselves as a cache write first appeared would be a figure nobody could read at a glance.
+KINDS = ("input", "output", "cache_read", "cache_write", "reasoning")
 
 
 class Usage(Mapping[str, float]):

--- a/src/hmz/coganchor/agents/grok.py
+++ b/src/hmz/coganchor/agents/grok.py
@@ -69,6 +69,26 @@ _WEB_TOOLS = ("web_search", "web_fetch")
 #: again: it was shown when it started, and a row per status is a transcript of statuses.
 _SAYS = {"text": "text", "thought": "reasoning"}
 
+#: What each kind of token is called in the counts Grok Build states, and what each of them
+#: is here. Humanize's own names rather than the CLI's, as everywhere else a kind is
+#: counted: the prices are per kind, so a usage written down under a spelling nothing else
+#: knows is a lump nobody can put a figure on -- which is what these were until this table.
+#: The input count is the uncached part alone, which is why the two cache counts stand beside
+#: it rather than being folded into it, so the four added up are the whole of what crossed
+#: the wire.
+#:
+#: Its `reasoning_tokens` is deliberately not among them. It is counted *inside* the output
+#: rather than beside it -- a turn asked to think at length and answer in one word came back
+#: with `output_tokens: 1141` and `reasoning_tokens: 1140` -- so a kind of its own here would
+#: count those tokens twice and, the prices billing reasoning as output, charge for them
+#: twice as well.
+_KINDS = {
+    "input": "input_tokens",
+    "output": "output_tokens",
+    "cache_read": "cache_read_input_tokens",
+    "cache_write": "cache_creation_input_tokens",
+}
+
 #: `grok -p` writes the protocol's own `session/update` with `sessionUpdate` flattened onto
 #: `type` and the words moved onto `data`: the two transports are one stream said twice, which
 #: is why a turn reads the same on either and why `_TOLD` above is the protocol's own table.
@@ -658,15 +678,9 @@ class GrokBuildSession(StreamSessionBase):
         """
         return Usage(
             {
-                name: float(counted.get(name) or 0)
-                for name in (
-                    "input_tokens",
-                    "output_tokens",
-                    "cache_read_input_tokens",
-                    "cache_creation_input_tokens",
-                    "reasoning_tokens",
-                )
-                if counted.get(name)
+                kind: float(counted.get(named) or 0)
+                for kind, named in _KINDS.items()
+                if counted.get(named)
             }
         )
 
@@ -843,6 +857,10 @@ class GrokBuildAgentConfig(AgentConfig):
 
 class GrokBuildAgent(AgentBase):
     """Grok Build, driven through the protocol it serves, one process per conversation."""
+
+    #: What it counts, read off the same table its driver reads a usage with, so that what
+    #: a run is told this backend reports is what its driver actually parses.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
 
     def new(self, cwd: str | os.PathLike[str] | None = None) -> GrokBuildSession:
         """Opens a new Grok Build session, in the directory it is given or in this one."""

--- a/src/hmz/coganchor/agents/kimi.py
+++ b/src/hmz/coganchor/agents/kimi.py
@@ -1050,6 +1050,10 @@ class KimiCodeCLIAgent(AgentBase):
     #: Kimi keeps itself going toward an objective, which is what `pursue` reaches for.
     pursues: ClassVar[bool] = True
 
+    #: What it counts, read off the same table its driver reads a usage with, so that
+    #: what a run is told this backend reports is what its driver actually parses.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
+
     def __init__(self, config: AgentConfig, *, name: str | None = None) -> None:
         """Initializes an agent whose server is not running yet.
 

--- a/src/hmz/coganchor/agents/opencode.py
+++ b/src/hmz/coganchor/agents/opencode.py
@@ -314,6 +314,13 @@ class OpencodeAgentConfig(AgentConfig):
 class OpencodeAgent(AgentBase):
     """opencode, driven through its own command line, one run per turn."""
 
+    #: What it counts, read off the same tables its driver reads a step's usage with. Every
+    #: kind there is: opencode counts its reasoning beside the output rather than inside it,
+    #: and says what a cache read and a cache write came to on their own.
+    counts: ClassVar[frozenset[str]] = frozenset(_COUNTED) | {
+        f"cache_{named}" for named in _CACHED
+    }
+
     def new(self, cwd: str | os.PathLike[str] | None = None) -> OpencodeSession:
         """Opens a new opencode session, in the directory it is given or in this one."""
         return OpencodeSession(self, cwd)

--- a/src/hmz/coganchor/agents/pi.py
+++ b/src/hmz/coganchor/agents/pi.py
@@ -443,6 +443,10 @@ class PiAgent(AgentBase):
     reaches for a tool, so there is no permission for a hook to be hung on.
     """
 
+    #: What it counts, read off the same table its driver reads a usage with. Its reasoning
+    #: is counted inside the output rather than beside it, so it is not a kind of its own.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
+
     def new(self, cwd: str | os.PathLike[str] | None = None) -> PiSession:
         """Opens a new pi session, in the directory it is given or in this one."""
         return PiSession(self, cwd)

--- a/src/hmz/coganchor/agents/qwen.py
+++ b/src/hmz/coganchor/agents/qwen.py
@@ -110,6 +110,24 @@ _REFUSED = re.compile(r"^\[API Error:(?P<said>.*)\]$", re.DOTALL)
 #: it cost rather than shown twice.
 _SAYS = {"text": "text", "thinking": "reasoning"}
 
+#: What each kind of token is called in the counts Qwen Code states, and what each of them
+#: is here. Humanize's own names rather than the CLI's, as everywhere else a kind is
+#: counted: the prices are per kind, so a usage written down under a spelling nothing else
+#: knows is a lump nobody can put a figure on -- which is what these were until this table.
+#: The cached counts sit beside the input rather than inside it, so the four added up are the
+#: whole of what crossed the wire.
+#:
+#: Its thinking is not a kind of its own. Qwen Code states no count for it on the protocol
+#: read here, and what it does state has the thinking inside it -- a turn asked to think at
+#: length and answer in one word came back with `output_tokens: 926` -- so a kind for it would
+#: be a column of noughts at best and the same tokens counted twice at worst.
+_KINDS = {
+    "input": "input_tokens",
+    "output": "output_tokens",
+    "cache_read": "cache_read_input_tokens",
+    "cache_write": "cache_creation_input_tokens",
+}
+
 #: How many milliseconds a second is, for the one field of Qwen Code's that is counted in
 #: them: it took the `timeout` of Claude Code's hook table and not the unit under it.
 _A_SECOND = 1000
@@ -592,15 +610,9 @@ class QwenCodeSession(StreamSessionBase):
         """
         return Usage(
             {
-                name: float(counted.get(name) or 0)
-                for name in (
-                    "input_tokens",
-                    "output_tokens",
-                    "cache_read_input_tokens",
-                    "cache_creation_input_tokens",
-                    "thoughts_tokens",
-                )
-                if counted.get(name) is not None
+                kind: float(counted.get(named) or 0)
+                for kind, named in _KINDS.items()
+                if counted.get(named) is not None
             }
         )
 
@@ -693,6 +705,10 @@ class QwenCodeAgentConfig(AgentConfig):
 
 class QwenCodeAgent(AgentBase):
     """Qwen Code, driven through its own command line, one run per turn."""
+
+    #: What it counts, read off the same table its driver reads a usage with, so that what
+    #: a run is told this backend reports is what its driver actually parses.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
 
     def new(self, cwd: str | os.PathLike[str] | None = None) -> QwenCodeSession:
         """Opens a new Qwen Code session, in the directory it is given or in this one."""

--- a/src/hmz/coganchor/agents/zcode.py
+++ b/src/hmz/coganchor/agents/zcode.py
@@ -1120,6 +1120,11 @@ class ZcodeAgent(AgentBase):
     #: ZCode keeps itself going toward an objective, which is what `pursue` reaches for.
     pursues: ClassVar[bool] = True
 
+    #: What it counts, read off the same table its driver reads a usage with. Two kinds
+    #: and no more: ZCode counts its reasoning and its cached reads inside these, so a
+    #: third here would be reporting some of the same tokens twice.
+    counts: ClassVar[frozenset[str]] = frozenset(_KINDS)
+
     def __init__(self, config: AgentConfig, *, name: str | None = None) -> None:
         """Initializes an agent whose app server is not running yet.
 

--- a/src/hmz/flows/checking.py
+++ b/src/hmz/flows/checking.py
@@ -2195,14 +2195,14 @@ def catalogue() -> tuple[Capability, ...]:
     Returns:
       One capability apiece: the primitives every backend serves, then what only some do
       -- each moment outside `EVERYWHERE`, the shape a turn can be held to, the tools a
-      flow may offer, a turn that can be steered while it runs, the goal feature and the
-      fork -- and then where an agent's turns may land and how a turn's own commands are
-      reached there.
+      flow may offer, a turn that can be steered while it runs, the goal feature, the
+      fork and each kind of token a backend says what it spent on -- and then where an
+      agent's turns may land and how a turn's own commands are reached there.
     """
     import inspect
     import sys as running
 
-    from hmz.coganchor.agents import DRIVEN, EVERYWHERE, Moment
+    from hmz.coganchor.agents import DRIVEN, EVERYWHERE, KINDS, Moment
 
     agents = {name: held[0] for name, held in DRIVEN.items()}
     sessions: dict[str, type] = {}
@@ -2381,6 +2381,17 @@ def catalogue() -> tuple[Capability, ...]:
             "child = session.fork() -- which costs nothing until the child is used, and "
             "which session.forks says of a backend beforehand",
         )
+    )
+    held.extend(
+        Capability(
+            f"counts:{kind}",
+            frozenset(name for name, cls in agents.items() if kind in cls.counts),
+            f"the backend says what a turn spent on {kind} tokens -- "
+            f"agent.spent()['{kind}'] and session.rate()['{kind}'] answer for it, and a "
+            "backend not among these reports the kind not at all rather than as nothing, so "
+            "a run that mixes one in reads its figure for this kind as a floor",
+        )
+        for kind in KINDS
     )
     held.extend(_places())
     held.extend(_anchors(agents))

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -1559,6 +1559,11 @@ class Humanize(App[None]):
         spending = self._monitor.spending()
         spent = sum(spend.tokens for spend in spending)
         rate = sum(spend.rate for spend in spending)
+        # What went on each kind of token, which is the reading anybody has a use for: an
+        # input token, an output token and a cached read are three different things bought at
+        # three different prices, and one number over the lot of them answers no question.
+        # Marked where a figure is short of what an agent of this run spends without counting.
+        counted = self._monitor.reckoning()
         # What the run has cost in money, and whether that is the whole of it: a model
         # nobody prices adds tokens to the count and nothing to the bill, so the figure is
         # marked as a floor rather than quietly reported as the total.
@@ -1611,7 +1616,19 @@ class Humanize(App[None]):
         ]
         if spent:
             costing = f"{money(bill)}{floor}{_DOT}" if bill is not None else ""
-            lines.append(f"{thousands(spent)} tokens{_DOT}{costing}{rate:.0f}/s")
+            # Two lines rather than one: five kinds, a bill and a rate on one row come to a
+            # row wider than the terminal, and what sits above the editor is read at a glance.
+            lines.append(
+                _DOT.join(
+                    f"{one.kind} {thousands(one.tokens)}{'' if one.whole else '+'}"
+                    for one in counted
+                )
+                or f"{thousands(spent)} tokens"
+            )
+            # Output alone, and said so: the input of a turn is the conversation so far, sent
+            # again at every request and mostly served out of a cache, so a rate counting it
+            # says how long the transcript has got rather than how fast the model is writing.
+            lines.append(f"{costing}{rate:.0f} out/s")
         # Beside it, and cut to what it leaves: the two are one block, and a pinned line
         # the width of the screen would push what the run is running as off the side of it.
         waiting = self._waiting_lines(max(len(line) for line in lines) + 2)
@@ -2104,6 +2121,13 @@ class Humanize(App[None]):
             (entry.model, entry.tokens, entry.rate, entry.dollars)
             for entry in self._monitor.spending(now=ended or moment)
         )
+        # Beside it rather than inside it: the kinds are the run's rather than any one
+        # model's, a bill being made of them whichever model bought them, and each says
+        # whether the figure is the whole of what went on that kind or a floor under it.
+        counted = tuple(
+            (one.kind, one.tokens, one.whole)
+            for one in self._monitor.reckoning(now=ended or moment)
+        )
         # Keep the role separate from the stable id used by the monitor and handover records.
         labelled = tuple(
             AgentProgress(
@@ -2126,6 +2150,7 @@ class Humanize(App[None]):
             observations=observations,
             waiting=waiting,
             spent=spent,
+            kinds=counted,
             waiting_for_input=self._awaiting,
         )
 
@@ -3196,8 +3221,22 @@ class Humanize(App[None]):
         with self._saying:
             self._queued, self._given, self._handed = [], [], False
 
+        from hmz.coganchor.agents import HumanAgent
+
         for agent in agents:
             agent.watch(self._heard)
+            if not isinstance(agent, HumanAgent):
+                # What its backend counts, said before its first turn: a kind nothing was
+                # spent on this turn is missing from that turn's reckoning exactly as a kind
+                # the CLI never counts is, and what is drawn of a run driving two backends has
+                # to tell the two apart to say which of its figures are whole. The person is
+                # not one of these -- nobody counts what a person costs -- and counting them
+                # as a backend that reports nothing would mark every figure of a run they are
+                # in as short of tokens nobody ever spent. What the CLI's own log says is
+                # added to this by the tally, once it has actually read one: Codex's server
+                # never names a cached read and the rollout it writes does, but a rollout
+                # written on another machine is one nothing here reads.
+                self._monitor.reporting(agent.id, type(agent).counts)
             # Whichever turn starts next takes the oldest line that was held.
             agent.waiting = self._at_turn_start
             # Bound to the agent, so that each of these answers about the flow that is
@@ -3302,12 +3341,34 @@ class Humanize(App[None]):
         # First, whatever else happens: showing a line raises once the interface has gone, and
         # what a watcher raises is swallowed, so accounting after it would be lost.
         # The kinds go with the tokens where a turn spent them all on one model, which is the
-        # ordinary turn: `spent` is that whole turn's cost by kind, and there is no saying how
-        # one lot of kinds divides between two models. Without them there is no bill, only a
-        # count -- an input token and an output token differ in price several times over.
-        broken = dict(event.spent) if len(event.tokens) == 1 else None
+        # ordinary turn: `spent` is that whole turn's cost by kind. A turn that named two --
+        # an agent that reached for a cheaper model for a sub-turn -- says what each of them
+        # cost and says the kinds of the pair together, and nothing in it says which of the
+        # two a cached read was made against. So they are divided by what each model took,
+        # rather than dropped: a turn whose kinds are dropped is a turn counted as tokens of
+        # no kind at all, which is a turn missing from every per-kind figure and priced at
+        # nothing. Where the CLI's own log is read as well, the exact split is in it, and the
+        # fullest reckoning is the one the money and the kinds are both read off.
+        whole = sum(event.tokens.values())
         for model, tokens in event.tokens.items():
+            if not event.spent:
+                broken = None
+            elif len(event.tokens) == 1:
+                broken = dict(event.spent)  # the whole turn, on the one model it named
+            elif whole > 0:
+                broken = {
+                    kind: spent * tokens / whole for kind, spent in event.spent.items()
+                }
+            else:
+                # Two models and nothing on either. There is nothing to divide by and
+                # nothing to divide, and a turn whose accounting raised would lose the
+                # line it was about: what a watcher raises is swallowed.
+                broken = None
             self._monitor.spend(agent.id, tokens, model=model, kinds=broken)
+        # Anything at all the agent did, token or not: a tool, a word, an answer. A turn
+        # spends most of its minutes between the counts it reports, and a figure worked out
+        # only when one arrives stands still through all of them.
+        self._monitor.stirring()
         self._remember_btw(agent, event)
         if event.kind == "took":
             # The agent saying a word put into its turn is now in front of it, which is the

--- a/src/hmz/tui/btw.py
+++ b/src/hmz/tui/btw.py
@@ -62,6 +62,11 @@ class FlowSnapshot:
     observations: tuple[Observation, ...] = ()
     waiting: int = 0
     spent: tuple[tuple[str, int, float, float | None], ...] = ()
+    #: What went on each kind of token over the whole run, and whether each figure is the
+    #: whole of it. Beside the per-model spending rather than inside it: a bill is made of the
+    #: kinds whichever model bought them, and an agent answering about what a run has cost has
+    #: to be able to tell a figure that is the total from one that is a floor under it.
+    kinds: tuple[tuple[str, float, bool], ...] = ()
     waiting_for_input: bool = False
 
 
@@ -133,7 +138,7 @@ def format_snapshot(snapshot: FlowSnapshot, question: str) -> str:
         spent = snapshot.spent[:_MAX_SPENDING]
         lines.extend(
             f"- {compact(model, 240)}: {max(tokens, 0)} token(s), "
-            f"{max(rate, 0.0):.1f}/s"
+            f"{max(rate, 0.0):.1f} output token(s)/s"
             # Left off entirely for a model nobody prices, rather than said as nothing: an
             # agent answering a side question must not read a missing price as a free run.
             + (f", {money(max(dollars, 0.0))}" if dollars is not None else "")
@@ -143,6 +148,19 @@ def format_snapshot(snapshot: FlowSnapshot, question: str) -> str:
             lines.append(
                 f"- (spending entries omitted: {len(snapshot.spent) - len(spent)})"
             )
+    else:
+        lines.append("- none reported")
+
+    lines.append("tokens_by_kind:")
+    if snapshot.kinds:
+        # Said apart from the total, and each marked: a figure short of what one agent's CLI
+        # never counts is a floor, and an agent asked what the run has cost must not read one
+        # as the whole of it.
+        lines.extend(
+            f"- {compact(kind, 64)}: {max(tokens, 0.0):.0f}"
+            + ("" if whole else " (a floor: not every agent here reports this kind)")
+            for kind, tokens, whole in snapshot.kinds
+        )
     else:
         lines.append("- none reported")
 

--- a/src/hmz/tui/monitor.py
+++ b/src/hmz/tui/monitor.py
@@ -10,20 +10,47 @@ from __future__ import annotations
 import threading
 import time
 from collections import Counter, deque
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from hmz.coganchor import prices
+from hmz.coganchor.agents import KINDS
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable
 
-__all__ = ["Monitor", "Shape", "Spend", "Under", "lasting", "short", "thousands"]
+__all__ = [
+    "Counted",
+    "Monitor",
+    "Shape",
+    "Spend",
+    "Under",
+    "lasting",
+    "short",
+    "thousands",
+]
 
 #: How far back the rate is measured. Five minutes is long enough to carry across the gaps a
 #: flow leaves -- a turn that thinks, a round it sleeps off, a commit it makes -- and short
 #: enough that a run which has gone quiet reads as quiet.
 _WINDOW = 300.0
+
+#: How long what a run has spent may stand before it is worked out again, however quiet the
+#: run has been. It moves while nothing arrives: a rate is tokens over seconds on the clock,
+#: and the clock runs through the minutes a turn spends thinking. Worked out only when a
+#: count changed, the figure stood still through all of them and then jumped at the end of
+#: the turn, which reads as a run that stalled and recovered rather than as one working.
+#: Five seconds because that is as often as a running total is worth reading, and because
+#: putting a price on it reads a list off the disk -- which a screen drawn twice a second
+#: must not pay for twice a second.
+_FIGURED = 5.0
+
+#: Under how much of a token a difference is not a token. A turn spread over two models has
+#: its kinds divided between them by what each took, and a division leaves a remainder of a
+#: millionth of a token -- which, counted as spending nobody said the kind of, would mark
+#: every figure of an honest run as a floor. Nothing counts tokens in fractions.
+_DUST = 1.0
 
 #: Where a count stops fitting and starts being abbreviated.
 _THOUSAND = 1000
@@ -34,17 +61,18 @@ _MINUTE = 60.0
 _HOUR = 3600.0
 
 
-def thousands(count: int) -> str:
+def thousands(count: float) -> str:
     """Renders a token count short enough for a status line.
 
     Args:
-      count: How many tokens.
+      count: How many tokens. A float because a kind is counted as one -- what a backend
+        reports is what it reports -- and nothing here shows a fraction of a token.
 
     Returns:
       The count, abbreviated once it stops fitting.
     """
     if count < _THOUSAND:
-        return str(count)
+        return f"{count:.0f}"
     if count < _MILLION:
         return f"{count / _THOUSAND:.1f}k"
     return f"{count / _MILLION:.2f}M"
@@ -148,10 +176,20 @@ class Spend:
     Attributes:
       model: The model the tokens were spent on.
       tokens: Every token spent on it, in and out alike.
-      rate: Tokens a second over the last five minutes, or over the whole run while the run
-        is younger than that. Seconds on the clock, not seconds an agent was talking: a flow
-        sleeps between rounds, commits, reads what the last turn wrote, and that time is time
-        the tokens were spent over.
+      kinds: The same spending, by the kind each token went on, as the fullest source that
+        broke it down says. What a reader is shown: an input token, an output token and a
+        cached read are three different things bought at three different prices, and a lump
+        of them added together answers no question anybody has. The kind called `` is what a
+        source counted without saying what kind it was, which is the one part of a total that
+        cannot be priced -- and its being there at all is what makes every other figure a
+        floor. Empty for a model nobody broke down.
+      rate: Output tokens a second over the last five minutes, or over the whole run while the
+        run is younger than that. Output alone, because that is the work: the input of a turn
+        is the conversation so far, read again at every request and mostly out of a cache, so
+        a rate counting it says how long the transcript has got rather than how fast the model
+        is writing. Seconds on the clock, not seconds an agent was talking: a flow sleeps
+        between rounds, commits, reads what the last turn wrote, and that time is time the
+        tokens were spent over.
       dollars: What those tokens came to, or None where nobody prices this model or the
         source that counted them did not say which kind each was. None is not nothing spent:
         a reader MUST show the tokens alone rather than a bill of zero.
@@ -161,6 +199,26 @@ class Spend:
     tokens: int
     rate: float
     dollars: float | None = None
+    kinds: Mapping[str, float] = field(default_factory=dict[str, float])
+
+
+@dataclass(frozen=True, slots=True)
+class Counted:
+    """One kind of token a run has spent, over every model of it, as a reader is shown it.
+
+    Attributes:
+      kind: Which kind, out of :data:`hmz.coganchor.agents.KINDS`.
+      tokens: How many went on it, over every model anything was spent on.
+      whole: Whether that figure is the whole of what went on this kind. False where an agent
+        of the run drives a CLI that does not report this kind at all, and false where some of
+        what was spent was counted without saying which kind it went on -- either way the
+        figure is a floor, and one drawn as though it were the total would be a claim about
+        the run that nothing here can make.
+    """
+
+    kind: str
+    tokens: float
+    whole: bool
 
 
 @dataclass
@@ -207,11 +265,28 @@ class Monitor:
     kinds: dict[tuple[str, str], dict[str, float]] = field(
         default_factory=dict[tuple[str, str], dict[str, float]]
     )
-    #: Recent spending as (when, model, tokens), which is what the rate is measured over.
-    #: Bounded by the window rather than by the length of the run: a flow going for days
-    #: keeps five minutes of it.
-    recent: deque[tuple[float, str, int]] = field(
-        default_factory=deque[tuple[float, str, int]]
+    #: The breakdown each model's spending is read in: the fullest reckoning any one source
+    #: has given of it, which is what every per-kind figure and the money alike are worked out
+    #: from. One source rather than the best of each kind from all of them: two sources
+    #: counting the same tokens differ in which kinds they name, and a cached read taken from
+    #: one beside an input taken from another is the same tokens counted twice.
+    parts: dict[str, dict[str, float]] = field(
+        default_factory=dict[str, dict[str, float]]
+    )
+    #: Which kinds of token each agent's backend reports at all, said of the backend rather
+    #: than read off what a turn happened to spend -- a kind nothing went on this turn is
+    #: missing from that turn's reckoning exactly as a kind the CLI never counts is, and this
+    #: is what tells them apart. What makes a union over two backends honest: a figure drawn
+    #: beside a backend that never reports a kind is short by whatever that backend spent on
+    #: it, and says so rather than passing for the whole.
+    reports: dict[str, frozenset[str]] = field(
+        default_factory=dict[str, frozenset[str]]
+    )
+    #: Recent spending as (when, model, kinds risen), which is what the rate is measured over.
+    #: By kind, since the rate is output alone. Bounded by the window rather than by the
+    #: length of the run: a flow going for days keeps five minutes of it.
+    recent: deque[tuple[float, str, Mapping[str, float]]] = field(
+        default_factory=deque[tuple[float, str, Mapping[str, float]]]
     )
     #: The rate per model as it was last worked out, and what it was worked out from: the rate
     #: is worked out again when something it is made of moves, and not on any clock of its own.
@@ -219,6 +294,13 @@ class Monitor:
     #: And the money, worked out at the same moment and from the same tokens.
     money: dict[str, float | None] = field(default_factory=dict[str, float | None])
     figured: int | None = None
+    #: And when, so that figures which move on the clock alone -- a rate is tokens over
+    #: seconds, and the seconds pass whether or not a token does -- are worked out again
+    #: while a turn is still thinking rather than only once it has landed.
+    figured_at: float = 0.0
+    #: Set by anything an agent did that was not a token: a tool, a word, an answer. What has
+    #: been spent is then worked out again at the next draw rather than at the next count.
+    astir: bool = False
     #: How many times what has been spent has changed, which is what `figured` is against.
     changed: int = 0
     #: When the run began, which is when this was made: one of these is made for one flow.
@@ -340,7 +422,8 @@ class Monitor:
                 broken[kind] = broken.get(kind, 0.0) + spent
             # Whatever the kinds did not account for still cost something, and is put under
             # no kind at all rather than guessed at as one: what is priced is then a floor.
-            if (rest := tokens - sum((kinds or {}).values())) > 0:
+            # A whole token or nothing: see `_DUST`.
+            if (rest := tokens - sum((kinds or {}).values())) >= _DUST:
                 broken[""] = broken.get("", 0.0) + rest
             self._counted("told", model, running, now, broken or None)
 
@@ -400,13 +483,33 @@ class Monitor:
             else:
                 self.kinds[(source, model)] = broken
             self.changed += 1  # so that what it is worth is worked out again
+        # What every per-kind figure and the money are read off, kept here so that the rate --
+        # which is output alone -- has a rise per kind to be measured over. Clamped at
+        # nothing, because the fullest source may change from one reading to the next and a
+        # reckoning that went backwards is not tokens somebody got back.
+        fullest = self._fullest(model)
+        before = self.parts.get(model, {})
+        grown = {
+            kind: risen
+            for kind, tokens in (fullest or {}).items()
+            if (risen := tokens - before.get(kind, 0.0)) > 0
+        }
+        if fullest is None:
+            # Dropped rather than kept: a breakdown outliving the total it described would
+            # price a bigger total against a smaller reckoning of what went into it, and
+            # would draw kinds for a spend nobody has broken down since.
+            self.parts.pop(model, None)
+        elif fullest != before:
+            self.parts[model] = dict(fullest)
         # The most any source has seen, which is what has been spent: two sources counting
         # the same tokens are not two lots of tokens.
         seen = max(held for (_, named), held in self.totals.items() if named == model)
-        if (risen := seen - self.spent[model]) <= 0:
+        risen = seen - self.spent[model]
+        if risen <= 0 and not grown:
             return
-        self.spent[model] = seen
-        self.recent.append((time.monotonic() if now is None else now, model, risen))
+        if risen > 0:
+            self.spent[model] = seen
+        self.recent.append((time.monotonic() if now is None else now, model, grown))
         self.changed += 1
 
     def spending(self, now: float | None = None) -> list[Spend]:
@@ -430,40 +533,49 @@ class Monitor:
             while self.recent and self.recent[0][0] < moment - _WINDOW:
                 self.recent.popleft()
                 aged = True
-            if aged or self.figured != self.changed:
+            if (
+                aged
+                or self.astir
+                or self.figured != self.changed
+                or moment - self.figured_at >= _FIGURED
+            ):
                 # Seconds on the clock: the window holds the turns and the flow's own code
                 # alike, so what a flow spent between two turns -- sleeping off a round,
                 # committing, reading what the last turn wrote -- is time it is measured over.
                 # Under five minutes old, the run itself is the window it has had.
                 over = min(_WINDOW, moment - self.began)
-                lately: Counter[str] = Counter()
-                for _, model, tokens in self.recent:
-                    lately[model] += tokens
+                # Output alone. The input of a turn is the conversation so far, sent again at
+                # every request and mostly served out of a cache, so a rate counting it says
+                # how long the transcript has got rather than how fast the model is writing --
+                # and doubles the moment a backend starts reporting its cached reads.
+                lately: dict[str, float] = {}
+                for _, model, grown in self.recent:
+                    lately[model] = lately.get(model, 0.0) + grown.get("output", 0.0)
                 self.rates = {
-                    model: lately[model] / over if over > 0 else 0.0
+                    model: lately.get(model, 0.0) / over if over > 0 else 0.0
                     for model in self.spent
                 }
                 # Priced here rather than as it is drawn: the prices are read off the disk,
                 # and a screen redrawn twice a second must not pay for that twice a second.
                 self.money = {model: self._priced(model) for model in self.spent}
-                self.figured = self.changed
+                self.figured, self.astir, self.figured_at = (
+                    self.changed,
+                    False,
+                    moment,
+                )
             return [
                 Spend(
                     model=model,
                     tokens=tokens,
                     rate=self.rates.get(model, 0.0),
                     dollars=self.money.get(model),
+                    kinds=dict(self.parts.get(model, {})),
                 )
                 for model, tokens in self.spent.most_common()
             ]
 
     def _priced(self, model: str) -> float | None:
         """What has been spent on one model, in money. Held under the lock by its callers.
-
-        The kinds come from whichever source said the kind of the most tokens, and where two
-        said as much, from the one that has seen the most: two sources counting the same
-        tokens are one bill, so the fullest reckoning that can be priced is the one to price
-        -- and a total nobody broke down is no reckoning at all rather than the biggest one.
 
         Args:
           model: The model.
@@ -473,7 +585,31 @@ class Monitor:
           token was -- which a reader shows as tokens alone rather than as nothing spent.
           What comes back is a floor: tokens no source said the kind of are left out of it.
         """
-        fullest: Mapping[str, float] | None = None
+        broken = self.parts.get(model)
+        return prices.cost(broken, model) if broken else None
+
+    def _fullest(self, model: str) -> dict[str, float] | None:
+        """The reckoning of one model to read every figure off. Held under the caller's lock.
+
+        Whichever source said the kind of the most tokens, and where two said as much, the one
+        that has seen the most: two sources counting the same tokens are one bill, so the
+        fullest reckoning that can be priced is the one to price -- and a total nobody broke
+        down is no reckoning at all rather than the biggest one.
+
+        One source entire rather than the best figure for each kind out of all of them. Two
+        sources differ in which kinds they name as well as in how far they have read: a cached
+        read taken from the log beside an input taken from the backend's own report is the
+        same tokens counted twice, and a figure that overstates a bill is the one thing this
+        must never do.
+
+        Args:
+          model: The model.
+
+        Returns:
+          What that source says was spent on it, by kind, or None where no source broke it
+          down at all.
+        """
+        fullest: dict[str, float] | None = None
         best = (-1.0, -1.0)
         for (source, named), held in self.totals.items():
             if named != model:
@@ -488,7 +624,83 @@ class Monitor:
             told = sum(count for kind, count in broken.items() if kind)
             if (told, held) > best:
                 best, fullest = (told, held), broken
-        return prices.cost(fullest, model) if fullest else None
+        return dict(fullest) if fullest is not None else None
+
+    def reporting(self, agent: str, kinds: Iterable[str]) -> None:
+        """Notes which kinds of token one agent's backend reports at all.
+
+        Said of the backend rather than read off what a turn happened to spend: a kind nothing
+        went on this turn is missing from that turn's reckoning exactly as a kind the CLI never
+        counts is, and this is the only thing that tells the two apart afterwards.
+
+        Args:
+          agent: Whose backend it is.
+          kinds: What that backend counts, as `hmz.coganchor.agents.AgentBase.counts` says.
+        """
+        with self._lock:
+            self.reports[agent] = frozenset(kinds)
+
+    def stirring(self) -> None:
+        """Notes that an agent did something that was not a token: a tool, a word, an answer.
+
+        What a run has spent is then worked out again at the next draw rather than at the next
+        count. A turn spends most of its minutes between the moments it reports one, and a
+        figure that moved only on those stands still through every tool call and then jumps,
+        which reads as a run that stalled and recovered rather than as one working.
+        """
+        with self._lock:
+            self.astir = True
+
+    def reckoning(self, now: float | None = None) -> list[Counted]:
+        """What the run has spent kind by kind, and which of those figures are floors.
+
+        The union over every model rather than one agent's own, since a run driving two
+        backends is one bill and a kind only one of them counts is still a kind something was
+        spent on. Which is also why a kind is marked: drawn beside a backend that never
+        reports it, the union is short by whatever that backend spent on it, and a column
+        quietly short of one agent's tokens is worse than one marked as short of them.
+
+        With one agent it is that agent's own reckoning and nothing is marked. There is no
+        other backend for it to be short of, and a mark against every figure of a run that is
+        counting everything would be a warning nobody could act on.
+
+        Args:
+          now: The moment to read it at, defaulting to this one.
+
+        Returns:
+          One entry per kind: every kind an agent of the run reports, whether or not anything
+          has gone on it yet -- a column that appeared the first time a cache was written to
+          would be a readout that shuffles sideways while it is being read -- and every kind
+          anything was actually spent on, whoever reports it.
+        """
+        spending = self.spending(now)
+        counted: dict[str, float] = {}
+        # Whether any of what was spent was counted without saying what kind it went on: a
+        # backend that reports a lump, a turn that spanned two models and said the kinds of
+        # neither. It makes every figure here a floor, since the tokens it stands for went on
+        # some kind and there is nothing to say which.
+        unnamed = False
+        for spend in spending:
+            for kind, tokens in spend.kinds.items():
+                if kind:
+                    counted[kind] = counted.get(kind, 0.0) + tokens
+                elif tokens >= _DUST:
+                    unnamed = True
+            if spend.tokens - sum(spend.kinds.values()) >= _DUST:
+                unnamed = True
+        with self._lock:
+            told = list(self.reports.values())
+        # Nothing having said what it reports, there is nothing for a figure to be short of:
+        # what was counted is what was spent. This is a run watched before its agents were
+        # known, not a run of backends that report nothing.
+        every = told[0].intersection(*told[1:]) if told else frozenset(counted)
+        union = frozenset[str]().union(*told) if told else frozenset(counted)
+        held = [kind for kind in KINDS if kind in union or counted.get(kind)]
+        held += sorted(kind for kind in counted if kind not in KINDS)
+        return [
+            Counted(kind, counted.get(kind, 0.0), kind in every and not unnamed)
+            for kind in held
+        ]
 
     def now_working(self) -> list[str]:
         """Who has a turn open, taken whole so that a reader never sees it mid-change.

--- a/src/hmz/tui/pick.py
+++ b/src/hmz/tui/pick.py
@@ -56,7 +56,7 @@ from hmz.runtime.kept import Runs
 from hmz.runtime.telemetry import KEPT, SAYS, SENT
 
 from .discover import installed, machines, ready_to_open
-from .monitor import Shape, lasting, short, thousands
+from .monitor import Counted, Shape, lasting, short, thousands
 from .selecting import Choices
 
 if TYPE_CHECKING:
@@ -6726,6 +6726,28 @@ def elsewhere(drawn: Sequence[Drawn], shape: Shape) -> list[str]:
     ]
 
 
+def _kinds(counted: Sequence[Counted]) -> list[str]:
+    """What a run spent its tokens on, kind by kind, as the rows under the diagram say it.
+
+    Args:
+      counted: One entry per kind, as the monitor reckons them.
+
+    Returns:
+      A row per kind, and a last row saying what a `+` means where anything wears one. The
+      mark rather than a column of its own: it is on the figure it is about, and a legend
+      nobody has to read unless a figure has one.
+    """
+    if not counted:
+        return ["[$text-muted]nothing spent yet[/]"]
+    rows = [
+        f"{escape(one.kind):<26}{thousands(one.tokens):>8}{'' if one.whole else '+'}"
+        for one in counted
+    ]
+    if not all(one.whole for one in counted):
+        rows.append("[$text-muted]+ a floor: not every agent here reports that kind[/]")
+    return rows
+
+
 class Entry(Sheet[tuple[str, str]]):
     """One line of the board, typed: what it is called, and then what it says.
 
@@ -7079,6 +7101,7 @@ class Monitoring(Sheet[str]):
           shape: The run as a graph, taken at the same moment the boxes were.
         """
         spending = self._monitor.spending()
+        counted = self._monitor.reckoning()
         # Grouped as Claude Code groups its own: what is set up, what has happened that the
         # picture has no room for, what it has cost, a blank line between one and the next.
         groups: list[list[tuple[str, list[str]]]] = [
@@ -7107,11 +7130,21 @@ class Monitoring(Sheet[str]):
                         # bill is not known has still cost something, and `$0.00` would say
                         # it had not.
                         f"{money(spend.dollars) if spend.dollars is not None else '':>10}"
-                        f"   [$text-muted]{spend.rate:.0f}/s[/]"
+                        # Output alone: the input of a turn is the conversation so far, sent
+                        # again at every request, so a rate counting it says how long the
+                        # transcript has got rather than how fast the model is writing.
+                        f"   [$text-muted]{spend.rate:.0f} out/s[/]"
                         for spend in spending
                     ]
                     or ["[$text-muted]nothing spent yet[/]"],
                 ),
+                # Under the models rather than beside them, because it is a different
+                # question: what a model cost is per model, and what a run spent its tokens
+                # *on* is the run's, a cached read being the same thing whichever model made
+                # it. A `+` is a figure some agent of this run does not report and which is
+                # therefore a floor -- one drawn as though it were the total would be a claim
+                # about the run that nothing here can make.
+                ("Kinds", _kinds(counted)),
             ],
         ]
         lines: list[str] = []

--- a/src/hmz/tui/tally.py
+++ b/src/hmz/tui/tally.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
     from .monitor import Monitor
 
-__all__ = ["Tally"]
+__all__ = ["Tally", "reported"]
 
 #: How often the logs are looked at. Often enough that a turn's spending shows while the turn
 #: is still running, and cheap because only what has been appended since is ever read.
@@ -67,6 +67,30 @@ _KINDS: dict[str, tuple[tuple[str, str], ...]] = {
         ("cache_write", "inputCacheCreation"),
     ),
 }
+
+
+def reported(backend: str) -> frozenset[str]:
+    """Which kinds of token this backend's own log says, out of the logs read here.
+
+    Beside what its driver reports rather than instead of it: the two are read from two
+    places and one may say what the other does not -- Codex's server counts its cached reads
+    inside the input and never names them, while the rollout it writes does name them. What
+    the interface can show of a backend is what either of them says, and a figure marked as
+    short of a kind it can in fact see would be a warning about nothing.
+
+    What this answers is what such a log holds, not that there is one to read. A rollout is
+    written wherever the turn ran, so an agent working on another machine leaves none here --
+    which is why what is said of an agent is said once one of its logs has actually been
+    opened, and not when the run started.
+
+    Args:
+      backend: Whose logs.
+
+    Returns:
+      The kinds, empty for a backend whose logs are not read here at all -- which is not
+      the same as one whose logs say nothing, and reads the same way: nothing claimed.
+    """
+    return frozenset(kind for kind, _ in _KINDS.get(backend, ()))
 
 
 def _kinds(backend: str, usage: dict[str, Any]) -> dict[str, float]:
@@ -191,6 +215,11 @@ class Tally:
         self._agents = list(agents)
         self._monitor = monitor
         self._read: dict[Path, _Reading] = {}
+        #: Which agents this has actually opened a log of, so that what the monitor is told a
+        #: backend reports is what the interface can in fact see. A rollout written on another
+        #: machine, or in a container, is one nothing here reads -- and a kind claimed off a
+        #: log nobody read would be a nought drawn as a fact.
+        self._reading: set[str] = set()
         self._stop = threading.Event()
 
     def watch(self) -> None:
@@ -229,10 +258,19 @@ class Tally:
             idents = {
                 session.named for session in agent.sessions if session.named is not None
             } | set(agent.opened)
+            opened = False
             for ident in sorted(idents):
                 for pattern in profile.logs:
                     for path in sorted(home.glob(pattern.format(ident=ident))):
-                        self._take(path, profile.name, agent.config.model)
+                        opened |= self._take(path, profile.name, agent.config.model)
+            if opened and agent.id not in self._reading:
+                # Said once a log has been read rather than when the run started: what this
+                # reads is beside what the driver says, and only a log that is actually being
+                # read is a kind the interface can show.
+                self._reading.add(agent.id)
+                self._monitor.reporting(
+                    agent.id, type(agent).counts | reported(profile.name)
+                )
         totals: dict[str, Counter[str]] = {}
         for reading in self._read.values():
             for model, broken in reading.spent.items():
@@ -246,13 +284,17 @@ class Tally:
                 "read", model, sum(broken.values()), kinds=kinds or None
             )
 
-    def _take(self, path: Path, backend: str, model: str) -> None:
+    def _take(self, path: Path, backend: str, model: str) -> bool:
         """Reads one log on from wherever this last left it.
 
         Args:
           path: The log.
           backend: Whose it is, which is how its rows are read.
           model: What to count a row against when the row does not say for itself.
+
+        Returns:
+          Whether the log was there to be read, which is what says this backend's own
+          reckoning is one the interface can show.
         """
         reading = self._read.setdefault(path, _Reading())
         try:
@@ -260,7 +302,7 @@ class Tally:
                 stream.seek(reading.at)
                 written = stream.read()
         except OSError:
-            return  # not there yet, or not ours to read
+            return False  # not there yet, or not ours to read
         # To the last full line: a row being written is a row to read next time round.
         written = written[: written.rfind(b"\n") + 1]
         reading.at += len(written)
@@ -279,3 +321,4 @@ class Tally:
                 # under no kind at all rather than guessed at as one.
                 if (rest := tokens - int(sum(broken.values()))) > 0:
                     counted[""] += rest
+        return True

--- a/tests/agents/test_agy_stream.py
+++ b/tests/agents/test_agy_stream.py
@@ -212,8 +212,8 @@ def test_local_slash_command_preserves_conversation_usage_baseline(agy: _Agy) ->
         dict(first.spent)
         == dict(third.spent)
         == {
-            "input_tokens": 2,
-            "output_tokens": 3,
+            "input": 2,
+            "output": 3,
         }
     )
     assert {call["session"] for call in agy.calls()} == {session.id}
@@ -427,17 +427,17 @@ def test_a_backwards_native_counter_charges_the_whole_turn(agy: _Agy) -> None:
     assert list(session.stream("second"))[-1].spent.total == 5
     # The counter is back to what one turn costs: what this turn spent is all of it.
     assert dict(list(session.stream("recount"))[-1].spent) == {
-        "input_tokens": 2,
-        "output_tokens": 3,
+        "input": 2,
+        "output": 3,
     }
 
 
 def test_one_counter_going_backwards_starts_the_whole_count_again(agy: _Agy) -> None:
     """A restart is the count's, not one column's: kinds still above their old total are new."""
     session = agy.agent.new()
-    session._previous = Usage({"input_tokens": 100.0, "output_tokens": 50.0})
-    fresh = Usage({"input_tokens": 120.0, "output_tokens": 40.0})
-    assert dict(session._delta(fresh)) == {"input_tokens": 120.0, "output_tokens": 40.0}
+    session._previous = Usage({"input": 100.0, "output": 50.0})
+    fresh = Usage({"input": 120.0, "output": 40.0})
+    assert dict(session._delta(fresh)) == {"input": 120.0, "output": 40.0}
 
 
 def test_a_native_home_flag_naming_nothing_leaves_the_default_home(

--- a/tests/agents/test_qwen_stream.py
+++ b/tests/agents/test_qwen_stream.py
@@ -128,7 +128,7 @@ def test_plain_turns_reuse_process_without_reusing_usage_or_display_state(
     second = list(session.stream("second"))
     assert [event.kind for event in second] == ["text", "result"]
     assert first[-1].spent.total == second[-1].spent.total == 5
-    assert dict(second[-1].spent) == {"input_tokens": 2, "output_tokens": 3}
+    assert dict(second[-1].spent) == {"input": 2, "output": 3}
     calls = qwen.calls()
     assert calls[0]["pid"] == calls[1]["pid"]
     assert calls[0]["session"] == calls[1]["session"] == session.id
@@ -430,7 +430,7 @@ def test_usage_counts_each_model_request_once_across_warm_turns(qwen: _Qwen) -> 
     session = qwen.agent.new()
     for _ in range(2):
         events = list(session.stream("many"))
-        assert dict(events[-1].spent) == {"input_tokens": 4000, "output_tokens": 160}
+        assert dict(events[-1].spent) == {"input": 4000, "output": 160}
         assert events[-1].tokens == {"test-model": 4160}
 
 
@@ -442,7 +442,7 @@ def test_repeated_message_id_is_not_metered_twice(qwen: _Qwen) -> None:
 
 def test_explicit_zero_message_counters_override_terminal_usage(qwen: _Qwen) -> None:
     events = list(qwen.agent.new().stream("zero"))
-    assert dict(events[-1].spent) == {"input_tokens": 0, "output_tokens": 0}
+    assert dict(events[-1].spent) == {"input": 0, "output": 0}
 
 
 def test_result_only_counters_survive_shaped_turns_and_process_restarts(
@@ -451,7 +451,7 @@ def test_result_only_counters_survive_shaped_turns_and_process_restarts(
     session = qwen.agent.new()
     for schema in (None, _Answer, None):
         events = list(session.stream("result-only", schema=schema))
-        assert dict(events[-1].spent) == {"input_tokens": 2, "output_tokens": 3}
+        assert dict(events[-1].spent) == {"input": 2, "output": 3}
     assert len({call["pid"] for call in qwen.calls()}) == 3
 
 
@@ -474,7 +474,7 @@ def test_error_usage_is_not_charged_to_the_next_success(
     with pytest.raises(Failed, match="turn refused"):
         session("fail")
     events = list(session.stream("result-only"))
-    assert dict(events[-1].spent) == {"input_tokens": 2, "output_tokens": 3}
+    assert dict(events[-1].spent) == {"input": 2, "output": 3}
 
 
 @pytest.mark.parametrize("opened", [False, True])
@@ -487,7 +487,7 @@ def test_failed_shaped_process_does_not_recharge_its_terminal_usage(
     with pytest.raises(Failed):
         session("bad-exit", schema=_Answer)
     events = list(session.stream("result-only"))
-    assert dict(events[-1].spent) == {"input_tokens": 2, "output_tokens": 3}
+    assert dict(events[-1].spent) == {"input": 2, "output": 3}
 
 
 def test_concurrent_first_turns_keep_one_effort_file_and_each_process_warm(

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -18,7 +18,7 @@ import inspect
 import sys
 from typing import TYPE_CHECKING
 
-from hmz.coganchor.agents import DRIVEN, EVERYWHERE, Moment
+from hmz.coganchor.agents import DRIVEN, EVERYWHERE, KINDS, Moment
 from hmz.coganchor.backends import PROFILES, Bundled, Hooked, Profile, named
 from hmz.flows import Agent, Person, Session
 from hmz.flows.checking import briefed, catalogue, offered, surface
@@ -235,3 +235,50 @@ def test_an_anchor_nothing_serves_is_left_out_rather_than_read_as_everybodys() -
     assert told["anchor:preloaded"].backends == frozenset(
         {"kimi", "mimo", "pi", "qwen"}
     )
+
+
+#: What each backend's driver reports of what a turn cost, written out rather than read off
+#: the drivers -- what the drivers say is what is on trial. `reasoning` is there only for the
+#: three that count it beside the output rather than inside it; two say the input and the
+#: output alone, each of them counting its cached reads inside the input; and Cursor reports
+#: a duration and no tokens at all, which is a run whose every figure is a floor and which
+#: says so.
+_COUNTING: dict[str, set[str]] = {
+    "agy": {"input", "output", "cache_read", "reasoning"},
+    "claude": {"input", "output", "cache_read", "cache_write"},
+    "codex": {"input", "output"},
+    "cursor": set[str](),
+    "dsh": {"input", "output", "cache_read", "cache_write"},
+    "grok": {"input", "output", "cache_read", "cache_write"},
+    "kimi": {"input", "output", "cache_read", "cache_write"},
+    "mimo": {"input", "output", "cache_read", "cache_write", "reasoning"},
+    "opencode": {"input", "output", "cache_read", "cache_write", "reasoning"},
+    "pi": {"input", "output", "cache_read", "cache_write"},
+    "qwen": {"input", "output", "cache_read", "cache_write"},
+    "zcode": {"input", "output"},
+}
+
+
+def test_what_each_backend_counts_is_what_its_driver_says_it_counts() -> None:
+    """And every word of it is a kind humanize has, rather than one CLI's own spelling."""
+    assert {name: set(cls.counts) for name, (cls, _) in DRIVEN.items()} == _COUNTING
+    for name, (cls, _) in DRIVEN.items():
+        assert cls.counts <= set(KINDS), name
+
+
+def test_each_kind_of_token_is_a_capability_and_whose_is_the_drivers_own() -> None:
+    """A flow steering by what a turn cost has to be able to ask before it starts.
+
+    A backend that never counts a kind answers nought for it exactly as one that spent
+    nothing does, and a loop bounded by an output count on a backend that reports none is a
+    loop that never ends.
+    """
+    told = {one.name: one for one in catalogue() if one.name.startswith("counts:")}
+    assert set(told) == {f"counts:{kind}" for kind in KINDS}
+    for kind in KINDS:
+        assert told[f"counts:{kind}"].backends == frozenset(
+            name for name, (cls, _) in DRIVEN.items() if kind in cls.counts
+        )
+    # The one that reports nothing is in none of them rather than quietly in all of them.
+    for one in told.values():
+        assert "cursor" not in one.backends

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -902,8 +902,12 @@ async def test_the_readout_says_what_a_run_cost_in_money_as_well_as_in_tokens(
 
         above = str(app.query_one("#above", Static).content)
 
-    assert "1.0k tokens" in above
+    # Kind by kind rather than as one total over them: an input token and an output token
+    # are two different things bought at two different prices.
+    assert "input 1.0k" in above
+    assert "output 40" in above
     assert "$0.0012" in above  # a thousand in at $1/M and forty out at $5/M
+    assert "out/s" in above  # and the rate is the output alone, which it says
 
 
 @pytest.mark.timeout(60)
@@ -935,10 +939,16 @@ async def test_a_turn_that_lands_carries_the_kinds_its_bill_is_made_of(
 
 
 @pytest.mark.timeout(60)
-async def test_a_turn_spread_over_two_models_is_counted_and_not_priced(
+async def test_a_turn_spread_over_two_models_keeps_the_kinds_it_was_made_of(
     priced: str,
 ) -> None:
-    """One turn's kinds do not divide between two models, and nobody said how they would."""
+    """A turn that reached for a cheaper model for a sub-turn says the kinds of the pair.
+
+    Nothing in it says which of the two a cached read was made against, so they are divided
+    by what each model took. Dropped instead -- which is what happened before -- the whole
+    turn counted as tokens of no kind at all: missing from every per-kind figure and priced
+    at nothing, which is a worse answer than an apportioned one.
+    """
     from hmz.coganchor.agents import Event, Usage
     from hmz.coganchor.agents.claude import ClaudeCodeAgent, ClaudeCodeAgentConfig
 
@@ -956,10 +966,16 @@ async def test_a_turn_spread_over_two_models_is_counted_and_not_priced(
             ),
         )
 
-        spending = app._monitor.spending()
+        spending = {one.model: one for one in app._monitor.spending()}
 
-    assert sum(one.tokens for one in spending) == 1040
-    assert all(one.dollars is None for one in spending)
+    assert sum(one.tokens for one in spending.values()) == 1040
+    # Each model's share of each kind, which comes to the turn's own reckoning again.
+    assert spending[priced].kinds["input"] == pytest.approx(1000 * 1000 / 1040)
+    assert spending["some-lite-model"].kinds["input"] == pytest.approx(1000 * 40 / 1040)
+    assert sum(one.kinds["output"] for one in spending.values()) == pytest.approx(40)
+    # And the one that is priced has a bill, where before neither of them had one.
+    assert spending[priced].dollars is not None
+    assert spending["some-lite-model"].dollars is None  # nobody lists it
 
 
 @pytest.mark.timeout(60)
@@ -982,6 +998,97 @@ async def test_the_tokens_group_on_the_monitor_carries_the_bill_beside_the_count
 
 
 @pytest.mark.timeout(60)
+async def test_the_remainder_of_dividing_a_turn_between_models_marks_nothing(
+    priced: str,
+) -> None:
+    """A millionth of a token is not spending nobody said the kind of.
+
+    Dividing a turn's kinds between the two models it named leaves a remainder in the last
+    bit of a float. Counted as tokens of no named kind, it would mark every figure of a run
+    that is counting everything as a floor -- a warning about arithmetic, on the commonest
+    turn Claude Code takes, since a turn that reached for a sub-agent names two models.
+    """
+    from hmz.coganchor.agents import Event, Usage
+    from hmz.coganchor.agents.claude import ClaudeCodeAgent, ClaudeCodeAgentConfig
+
+    agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model=priced, effort="high"))
+    app = Humanize()
+    async with app.run_test():
+        app._monitor.reporting(agent.id, {"input", "output", "cache_read"})
+        app._heard(
+            agent,
+            agent.new(),
+            Event(
+                kind="result",
+                text="done",
+                tokens={priced: 201_391, "some-lite-model": 1755},
+                spent=Usage(input=1663, output=410, cache_read=201_073),
+            ),
+        )
+
+        counted = app._monitor.reckoning()
+
+    assert [one.kind for one in counted] == ["input", "output", "cache_read"]
+    assert all(one.whole for one in counted), counted
+
+
+@pytest.mark.timeout(60)
+async def test_the_readout_marks_a_kind_one_of_the_backends_running_does_not_report(
+    priced: str,
+) -> None:
+    """The union over two backends is short by whatever the one that never counts it spent.
+
+    Claude Code says what a cache write cost; Codex counts its cached reads inside the input
+    and never names a write at all. So a run driving both has a `cache_write` column made of
+    Claude's writes alone, and drawn as though it were the total it would be a claim about
+    the run that nothing here can make.
+    """
+    app = Humanize()
+    async with app.run_test() as driver:
+        app._monitor.reporting(
+            "builder", {"input", "output", "cache_read", "cache_write"}
+        )
+        app._monitor.reporting("reviewer", {"input", "output", "cache_read"})
+        app._monitor.spend(
+            "builder", 1200, model=priced, kinds={"input": 1000, "cache_write": 200}
+        )
+        app._monitor.spend("reviewer", 40, model=priced, kinds={"output": 40})
+        app._draw()
+        await driver.pause()
+
+        above = str(app.query_one("#above", Static).content)
+
+    (counted,) = [line for line in above.splitlines() if "input" in line]
+    assert "input 1.0k·" in counted.replace(" · ", "·")  # both count it: whole
+    assert "cache_write 200+" in counted  # one of them never does: a floor
+
+
+@pytest.mark.timeout(60)
+async def test_the_kinds_group_on_the_monitor_says_what_a_run_spent_its_tokens_on(
+    priced: str,
+) -> None:
+    """Under the models, since a cached read is the same thing whichever model made it."""
+    app = Humanize()
+    async with app.run_test() as driver:
+        app._monitor.reporting("actor", {"input", "output", "cache_read"})
+        app._monitor.reporting("other", {"input", "output"})
+        app._monitor.spend(
+            "actor",
+            1140,
+            model=priced,
+            kinds={"input": 1000, "cache_read": 100, "output": 40},
+        )
+        app.action_monitor()
+        await until(lambda: isinstance(app.screen, Monitoring), driver)
+
+        said = str(app.screen.query_one("#tuning", Label).content)
+
+    assert "Kinds" in said
+    assert "cache_read" in said
+    assert "a floor: not every agent here reports that kind" in said
+
+
+@pytest.mark.timeout(60)
 async def test_a_model_nobody_prices_is_a_token_count_with_no_dollars_beside_it() -> (
     None
 ):
@@ -998,9 +1105,10 @@ async def test_a_model_nobody_prices_is_a_token_count_with_no_dollars_beside_it(
 
         above = str(app.query_one("#above", Static).content)
 
-    (counted,) = [line for line in above.splitlines() if "tokens" in line]
-    assert "4.0k tokens" in counted
-    assert "$" not in counted.replace("$text-muted", "")  # a colour is not a currency
+    (counted,) = [line for line in above.splitlines() if "input" in line]
+    assert "input 3.0k" in counted
+    assert "output 1.0k" in counted
+    assert "$" not in above.replace("$text-muted", "")  # a colour is not a currency
 
 
 @pytest.mark.timeout(60)

--- a/tests/tui/test_monitor.py
+++ b/tests/tui/test_monitor.py
@@ -101,7 +101,7 @@ def test_the_rate_is_the_last_five_minutes_of_the_clock() -> None:
     monitor = Monitor()
     monitor.began = 1000.0
     monitor.begins("actor", "opus")
-    monitor.spend("actor", 3000, now=1030.0)
+    monitor.spend("actor", 3000, now=1030.0, kinds={"output": 3000})
 
     (spending,) = monitor.spending(now=1060.0)
 
@@ -109,33 +109,79 @@ def test_the_rate_is_the_last_five_minutes_of_the_clock() -> None:
     assert spending.rate == 50.0  # over the minute the run has had, turn or no turn
 
 
-def test_the_rate_is_worked_out_again_when_what_it_is_made_of_moves() -> None:
-    """Adaptively rather than on a clock of its own.
+def test_the_rate_is_output_alone_and_not_every_token_that_crossed_the_wire() -> None:
+    """The input of a turn is the conversation so far, sent again at every request.
 
-    What moves it is tokens counted, or tokens ageing out of the window. A screen redrawn
-    twice a second against numbers that have not changed is a number nobody can read.
+    Mostly out of a cache, and growing with the transcript rather than with the work. A rate
+    counting it says how long the conversation has got, not how fast the model is writing --
+    and doubles the moment a backend starts reporting what it read back out of the cache.
     """
     monitor = Monitor()
     monitor.began = 1000.0
-    monitor.spend("actor", 3000, now=1030.0)
+    monitor.spend(
+        "actor",
+        102_000,
+        now=1030.0,
+        kinds={"input": 2000, "output": 1000, "cache_read": 99_000},
+    )
+
+    (spending,) = monitor.spending(now=1060.0)
+
+    assert spending.tokens == 102_000  # every token, for the count
+    assert spending.rate == pytest.approx(1000 / 60.0)  # the output alone, for the rate
+
+
+def test_the_rate_is_worked_out_again_when_what_it_is_made_of_moves() -> None:
+    """What moves it is tokens counted, or tokens ageing out of the window."""
+    monitor = Monitor()
+    monitor.began = 1000.0
+    monitor.spend("actor", 3000, now=1030.0, kinds={"output": 3000})
 
     (first,) = monitor.spending(now=1060.0)
 
     assert first.rate == 50.0
 
-    (again,) = monitor.spending(
-        now=1070.0
-    )  # nothing new counted, so nothing new worked out
-
-    assert again.rate == 50.0
-
     monitor.spend(
-        "actor", 3000, now=1071.0
-    )  # and something new counted is worked out at once
-    (moved,) = monitor.spending(now=1071.0)
+        "actor", 3000, now=1061.0, kinds={"output": 3000}
+    )  # something new counted is worked out at once
+    (moved,) = monitor.spending(now=1061.0)
 
     assert moved.tokens == 6000
-    assert moved.rate == 6000 / 71.0
+    assert moved.rate == 6000 / 61.0
+
+
+def test_what_has_been_spent_is_worked_out_again_on_the_clock_as_well() -> None:
+    """A rate is tokens over seconds, and the seconds pass whether or not a token does.
+
+    A turn spends most of its minutes between the counts it reports. Worked out only when one
+    arrives, the figure stands still through every tool call the turn makes and then jumps as
+    the turn lands, which reads as a run that stalled and recovered rather than as one working.
+    """
+    monitor = Monitor()
+    monitor.began = 1000.0
+    monitor.spend("actor", 3000, now=1030.0, kinds={"output": 3000})
+
+    assert monitor.spending(now=1060.0)[0].rate == 50.0
+
+    # A second later, with nothing at all having arrived: the run has had a second longer to
+    # have spent the same tokens over, so the rate has come down rather than standing still.
+    assert monitor.spending(now=1061.0)[0].rate == 50.0  # under five seconds, it stands
+    assert (
+        monitor.spending(now=1070.0)[0].rate == 3000 / 70.0
+    )  # and then it is read again
+
+
+def test_anything_the_agent_did_at_all_has_the_figures_read_again() -> None:
+    """A tool, a word, an answer: a turn is alive between the counts it reports."""
+    monitor = Monitor()
+    monitor.began = 1000.0
+    monitor.spend("actor", 3000, now=1030.0, kinds={"output": 3000})
+
+    assert monitor.spending(now=1060.0)[0].rate == 50.0
+
+    monitor.stirring()
+
+    assert monitor.spending(now=1061.0)[0].rate == 3000 / 61.0
 
 
 def test_two_sources_counting_the_same_tokens_are_not_two_lots_of_tokens() -> None:
@@ -167,8 +213,8 @@ def test_what_falls_out_of_the_window_stops_counting() -> None:
     """A flow that has gone quiet reads as quiet, which is what a window is for."""
     monitor = Monitor()
     monitor.began = 1000.0
-    monitor.spend("actor", 6000, now=1030.0)
-    monitor.spend("actor", 30000, now=4000.0)
+    monitor.spend("actor", 6000, now=1030.0, kinds={"output": 6000})
+    monitor.spend("actor", 30000, now=4000.0, kinds={"output": 30000})
 
     (windowed,) = monitor.spending(now=4090.0)
 
@@ -360,3 +406,115 @@ def test_a_breakdown_does_not_outlive_the_total_it_was_of(priced: str) -> None:
 
     assert spending.tokens == 9000
     assert spending.dollars is None  # rather than nine thousand priced as one thousand
+
+
+def test_the_breakdown_reaches_whatever_draws_it(priced: str) -> None:
+    """The kinds were parsed and then thrown away: only the money ever saw them.
+
+    An input token, an output token and a cached read are three different things bought at
+    three different prices, and one number over the lot of them answers no question anybody
+    has. So what a model has spent comes back as what it spent it *on*.
+    """
+    monitor = Monitor()
+    monitor.spend(
+        "actor",
+        1040,
+        model=priced,
+        kinds={"input": 900, "output": 40, "cache_read": 100},
+    )
+
+    (spending,) = monitor.spending()
+
+    assert spending.kinds == {"input": 900, "output": 40, "cache_read": 100}
+
+
+def test_one_agent_is_shown_its_own_kinds_and_nothing_is_marked() -> None:
+    """With one backend there is nothing for a figure to be short of."""
+    monitor = Monitor()
+    monitor.reporting("actor", {"input", "output", "cache_read", "cache_write"})
+    monitor.spend("actor", 1040, model="opus", kinds={"input": 1000, "output": 40})
+
+    counted = monitor.reckoning()
+
+    # Every kind that backend reports, in the one order they are ever drawn in -- a column
+    # appearing the first time a cache is written to would shuffle the readout sideways.
+    assert [one.kind for one in counted] == [
+        "input",
+        "output",
+        "cache_read",
+        "cache_write",
+    ]
+    assert [one.tokens for one in counted] == [1000, 40, 0, 0]
+    assert all(one.whole for one in counted)
+
+
+def test_a_kind_one_backend_does_not_report_is_marked_where_two_are_running() -> None:
+    """The union is short by whatever the backend that never counts it spent on it.
+
+    A run driving Claude beside Codex has a cache column made of Claude's reads alone, since
+    Codex counts its cached reads inside the input and never names them. Drawn as the total
+    it would be a claim about the run; drawn marked it is what it is, which is a floor.
+    """
+    monitor = Monitor()
+    monitor.reporting("writer", {"input", "output", "cache_read", "cache_write"})
+    monitor.reporting("reader", {"input", "output"})
+    monitor.spend(
+        "writer",
+        1100,
+        model="opus",
+        kinds={"input": 900, "output": 40, "cache_read": 160},
+    )
+    monitor.spend("reader", 500, model="gpt", kinds={"input": 400, "output": 100})
+
+    counted = {one.kind: one for one in monitor.reckoning()}
+
+    assert counted["input"].tokens == 1300
+    assert counted["input"].whole  # both of them count it
+    assert counted["output"].whole
+    assert counted["cache_read"].tokens == 160
+    assert not counted["cache_read"].whole  # one of them never says
+    assert not counted["cache_write"].whole
+
+
+def test_tokens_of_no_kind_at_all_make_every_figure_a_floor() -> None:
+    """A backend that reports a lump is a backend whose kinds nothing can say.
+
+    Its tokens went on some kind, and there is nothing to say which -- so every column is
+    short by some part of them, and says so rather than passing for the whole.
+    """
+    monitor = Monitor()
+    monitor.reporting("actor", {"input", "output"})
+    monitor.spend("actor", 1040, model="opus", kinds={"input": 1000, "output": 40})
+    monitor.spend(
+        "actor", 500, model="opus"
+    )  # and a turn that said only what it came to
+
+    counted = monitor.reckoning()
+
+    assert [one.kind for one in counted] == ["input", "output"]
+    assert not any(one.whole for one in counted)
+
+
+def test_a_kind_nobody_declared_but_something_spent_is_still_drawn() -> None:
+    """What was spent is what was spent, whoever said beforehand that they would count it."""
+    monitor = Monitor()
+    monitor.reporting("actor", {"input", "output"})
+    monitor.spend(
+        "actor",
+        1040,
+        model="opus",
+        kinds={"input": 900, "output": 40, "reasoning": 100},
+    )
+
+    counted = {one.kind: one for one in monitor.reckoning()}
+
+    assert counted["reasoning"].tokens == 100
+    assert not counted["reasoning"].whole
+
+
+def test_nothing_having_said_what_it_counts_marks_nothing() -> None:
+    """A run watched before its agents were known is not a run of backends counting nothing."""
+    monitor = Monitor()
+    monitor.spend("actor", 1040, model="opus", kinds={"input": 1000, "output": 40})
+
+    assert all(one.whole for one in monitor.reckoning())

--- a/tests/tui/test_tally.py
+++ b/tests/tui/test_tally.py
@@ -447,3 +447,51 @@ def test_a_prompt_that_was_wholly_cached_has_no_plain_input_rather_than_none_of_
     Tally([agent], monitor).read()
 
     assert monitor.kinds[("read", "gpt-5.6-sol")] == {"cache_read": 800, "output": 100}
+
+
+def test_a_backend_reports_what_its_log_says_once_that_log_has_been_read(
+    home: Path,
+) -> None:
+    """Not before: a rollout written on another machine is one nothing here reads.
+
+    Codex's own server counts its cached reads inside the input and never names one, while
+    the rollout it writes does name them. So what the interface can show of a Codex run is
+    wider than what its driver reports -- but only where the rollout is in fact on this
+    machine, and a kind claimed off a log nobody read would be a nought drawn as a fact.
+    """
+    agent = CodexAgent(CodexAgentConfig(model="gpt-5.6-sol", effort="low"))
+    agent.new()._adopt("t1")
+    monitor = Monitor()
+    tally = Tally([agent], monitor)
+
+    tally.read()  # nothing written yet, so nothing claimed
+
+    assert monitor.reports == {}
+
+    _rows(
+        home
+        / "codex_home"
+        / "sessions"
+        / "2026"
+        / "08"
+        / "rollout-2026-08-06T07-14-14-t1.jsonl",
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 900,
+                        "output_tokens": 40,
+                        "cached_input_tokens": 400,
+                        "total_tokens": 940,
+                    },
+                    "total_token_usage": {"total_tokens": 940},
+                },
+            },
+        },
+    )
+    tally.read()
+
+    # The driver's two, and the cached read only the rollout names.
+    assert monitor.reports[agent.id] == frozenset({"input", "output", "cache_read"})


### PR DESCRIPTION
What a run has spent is now said kind by kind, refreshed on a clock as well as on a count,
and marked where the figure is short of what some agent's CLI never counts.

## What changed

**The kinds reach the interface.** The breakdown was already parsed — the money is worked out
from it — and then dropped before anything drew it, so the readout above the editor was one
lump of tokens and `/monitor` was one figure per model. Both say the kinds now, in one settled
order, and the single grand total is gone from the line above the editor:

```
          builder · claude/azure/anthropic/claude-haiku-4-5:high · nvidia
          reviewer · codex/azure/openai/gpt-5.4-mini:low · nvidia · ○ 1
input 2.2k · output 1.3k · cache_read 125.3k · cache_write 139.3k+
$0.19+ · 106 out/s
```

**The rate is output alone, and says so.** The input of a turn is the conversation so far, sent
again at every request and mostly served out of a cache: a rate over every kind measures the
length of the transcript rather than the speed of the model, and doubles the moment a backend
starts reporting its cached reads.

**Refreshed every five seconds and on anything an agent does** — a tool, a word, an answer —
rather than only when a count arrives. A turn is minutes long and spends most of them between
the counts it reports, so a figure moved only by a count stood still through every tool call
and then jumped at the end of the turn.

**Which kinds a backend reports is a capability.** Declared on the driver as `counts`, read off
the same table the driver parses a usage with rather than written down twice, and served by the
catalogue as `counts:<kind>` so a flow steering by one can be refused an agent that would
answer nought forever. With one agent the readout is that agent's own kinds and nothing is
marked; with several it is the union of theirs, and a kind some of them never report wears a
`+` — a floor, since the figure is short by whatever those backends spent on it. Same mark when
anything was counted without its kind being said.

## Two bugs underneath

**`agy`, `qwen` and `grok` reported their CLI's own field names.** `input_tokens`,
`thoughts_tokens`, `cache_read_input_tokens` — so `Usage.input` and `.output` read 0 for all
three, `prices.cost` found no kind it knew and left the bill blank, `Meter.juice` read nothing,
and an output token budget on one of them could never bite. A live Grok Build turn went from a
blank bill to `$0.03`.

**A turn that named two models dropped the kinds of both**, so the whole turn counted as tokens
of no kind at all: absent from every per-kind figure and priced at nothing. They are divided
between the models by what each took instead; where the CLI's own log is read as well, the
exact split is in it and is what wins.

## Measured against live turns

- Grok Build's `reasoning_tokens` is **not** a kind of its own: a turn asked to think at length
  and answer in one word came back with `output_tokens: 1141` and `reasoning_tokens: 1140`, so
  counting it beside the output counted those tokens twice and — the prices billing reasoning
  as output — billed for them twice. Qwen Code's thinking is inside its output too, and it
  reports no count of its own on the protocol read here.
- What a log says counts as reported, but only once that log has actually been read here: a
  rollout is written wherever the turn ran, so an agent working on another machine leaves none
  on this one, and a kind claimed off a log nobody read would be a nought drawn as a fact.

## Verification

- `uv run pre-commit run --all-files` — passed.
- `uv run pytest` — 2877 passed, 72 skipped.
- **One agent live in the interface** (Claude Code on the gateway): the kinds drawn apart, the
  rate on output alone, and the figures moving eleven times over a twenty-second turn — between
  counts as well as on them.
- **Two backends live** (Claude Code beside Codex): `cache_write` marked `+` because Codex never
  reports one, `input`/`output`/`cache_read` unmarked because both do, and the bill marked `+`
  because one of the two models is unpriced.
- **Grok Build and Qwen Code live**: canonical kinds, and a bill where there was none.
- **`/monitor` live**: the `Kinds` block under the per-model rows.

## Specs and docs

`specs/tui.md` (the `/monitor` section, `monitor.py`, `tally.py`) and `specs/agents.md` (`KINDS`,
`counts`, and what a driver must report) were changed under explicit instruction.
`docs/user/tally.md`, `docs/features/budgets.md`, `docs/reference/{tui,agents,flows}.md`,
`docs/user/{monitor,steering}.md`, `docs/weaver/loops.md` and
`docs/contributing/architecture.md` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
