### PR TITLE
feat(tui)!: a flow is opened to reach its agents, and esc is the way back

### DIFF
--- a/docs/.vitepress/theme/flows.ts
+++ b/docs/.vitepress/theme/flows.ts
@@ -33,7 +33,7 @@ export interface Flow {
   name: string
   /** The page under /flows/. */
   link: string
-  /** How many agents it drives, in the words the Agents page of `/flow` would use. */
+  /** How many agents it drives, in the words `/flow` uses inside a flow. */
   agents: string
   /** One line: what it does. */
   said: string

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,11 +54,11 @@ do, on one line:
 $ralph_loop Fix the bug in calc.py.
 ```
 
-`$` names a flow, and this directory has never run that one, so `/flow` opens with the cursor
-already on it and your line held. Two pages answer what runs it: which flow, and then what its
-one agent is — the CLI you are already logged into, which of its models, and how hard it should
-think. The models offered are the ones **your account** may name, asked of the CLI itself
-rather than written into humanize. `save` on the last row starts the flow, on the line you
+`$` names a flow, and this directory has never run that one, so `/flow` opens inside it with
+your line held. Two questions answer what runs it: which flow — which the line already named —
+and then what its one agent is: the CLI you are already logged into, which of its models, and
+how hard it should think. The models offered are the ones **your account** may name, asked of
+the CLI itself rather than written into humanize. `save` on the last row starts the flow, on the line you
 typed.
 
 You answer that once. What you chose is remembered for this directory, so the next `hmz` here

--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -206,7 +206,7 @@ def run(agents: Agents, task: str) -> None:
 The names are not only for the flow's own readability. Everything that has to talk about an
 agent uses them:
 
-- The agents page of `/flow` asks what *the reviewer* runs, rather than what agent 2 of 2 runs.
+- Opening the flow in `/flow` asks what *the reviewer* runs, rather than what agent 2 of 2 runs.
 - The line above the prompt says `reviewer · claude/claude-opus-4-8:high`.
 - A [trace](/reference/tracing) groups that agent's sessions under `reviewer`.
 - What each agent was set to run is [remembered per role](/reference/tui#what-it-remembers), so a flow
@@ -403,8 +403,8 @@ $ hmz exec -f pursuing -a pi/openai-codex/gpt-5.5:high "fix the build"
 hmz exec: error: pursuing: worker is run under a goal, which pi has no feature for
 ```
 
-and the agents page of `/flow` offers only the CLIs that would work for that place, so it cannot
-be chosen wrong there at all.
+and opening that flow in `/flow` offers only the CLIs that would work for that place, so it
+cannot be chosen wrong there at all.
 
 **And anything else only some backends serve, the same way.** `Needs` beside the place names
 what the backend filling it has to serve, by the names
@@ -718,7 +718,7 @@ def engine(agents: Agents, task: str) -> None:
 
 It remains directly callable by `<flow>:engine`; `selectable=False` changes discovery only.
 
-Each of them declares its own agents and its own settings, so the agents page asks two questions
+Each of them declares its own agents and its own settings, so opening one asks about two agents
 rather than five and setting one up shows one phase's flags rather than three phases' at once. What
 passes between them is whatever they write — a file, usually.
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -148,8 +148,8 @@ list appears under the editor with a line about each.
 
 | Command | Takes | What it does |
 | --- | --- | --- |
-| `/flow` | `[flow]` | The menu of two pages: [which flow runs](#choosing-a-flow) and [what each of its agents is](#what-each-agent-is). With a name or a path, opens already holding that one — and is refused outright while a flow is running, since that name would be choosing one. Without a name it opens on the agents page, which is never shut. Its Agents page saves the complete setup; esc remains the way to save or discard on the way out. |
-| `/flowverses` | | [Where flows come from](/weaver/flowverses): what places there are, what one of them holds, and one added, fetched again or taken away. Not which flow to run — that is `/flow`, where the arrows step between the same places. |
+| `/flow` | `[flow]` | The menu that is [which flow runs](#choosing-a-flow) and, inside the flow you open, [what each of its agents is](#what-each-agent-is). With a name or a path, opens already inside that one — and is refused outright while a flow is running, since that name would be choosing one. Without a name it opens on the flows, or inside the agents of the flow that is going. `save`, the last row inside a flow, saves the complete setup; esc is one step back, and then the way to save or discard on the way out. |
+| `/flowverses` | | [Where flows come from](/weaver/flowverses): what places there are, what one of them holds, and one added, fetched again or taken away. The same menu **v** opens on the flows; a command as well, because there are no flows to press it on while one is running. Not which flow to run — that is `/flow`, where the arrows step between the same places. |
 | `/epics` | | The runs of this directory, newest first: what each was, how it went, and what there is to do with one — gather its [trace](/user/tracing), [export it](/user/export), say where it is written, and carry it on where its flow says it can be picked up. |
 | `/resume` | | Carries [the last run here](#carrying-the-last-one-on-outright) on: that run's own flow, on its own agents, with what it was asked to do, and on what it left behind. The same thing `/epics` offers of the run under its cursor, without the list — there is only ever one last run. Where there is nothing to carry on from it says which reason that is. |
 | `/providers` | | [The accounts](#the-accounts-themselves) an agent may be run as: what there is, and what can happen to one — made, taken away, and, on enter, corrected, signed in again, or pointed at what it falls back to. How often a failed turn is taken again is not here: that is said of a [place](#where-a-turn-goes-when-it-cannot-be-taken) rather than of an account. |
@@ -185,8 +185,8 @@ What happens next depends on whether this directory has run that flow before:
 
 | | |
 | --- | --- |
-| **Set up here already** | It runs, now. No menu: two pages of answers already given are not two pages to answer again. |
-| **Never set up here** | [`/flow`](#choosing-a-flow) opens with the cursor on that flow. The line you typed is held; the flow runs on it the moment the menu is saved. Walk out without saving and nothing starts, and it says so. |
+| **Set up here already** | It runs, now. No menu: a menu of answers already given is not a menu to answer again. |
+| **Never set up here** | [`/flow`](#choosing-a-flow) opens inside that flow, on what drives it. The line you typed is held; the flow runs on it the moment the menu is saved. Walk out without saving and nothing starts, and it says so. |
 | **No such flow** | A line to correct, the way `/nosuchcommand` is. The interface stays up. |
 
 **Set up here** means a remembered agent for every place the flow declares *now* — under the
@@ -209,7 +209,7 @@ the prompt rather than part of it. A `$` naming a flow and saying nothing after 
 `$ralph_loop` — chooses that flow and stops there: there is nothing to start it on.
 
 Two things it will not do. It is **refused while a flow is running**, and leaves that run
-exactly as it was: it is choosing a flow, and [the page that chooses one is shut while one
+exactly as it was: it is choosing a flow, and [there are no flows to choose from while one
 runs](#choosing-a-flow). And it is **not read as a flow while an agent is waiting on an
 answer** — the next line you type is that answer, whatever it begins with.
 
@@ -524,29 +524,35 @@ true of all of them:
   a modifier held down.
 - **Typing does not search.** Every letter is a key, so a search is asked for with **s** and
   left with **esc**, which clears what was typed. While one is running the letters go into it.
-- **Nothing lands until you save.** `/flow` has a `save` row on its Agents page for the
-  complete flow setup. Esc remains available on every menu: it asks in a box in the middle of
-  the screen, over the menu rather than instead of it, whether to save and close or discard
-  and close. Esc on the box is the way back to the menu. A menu you only looked at asks
+- **Nothing lands until you save.** `/flow` has a `save` row inside the flow it opened, for the
+  complete flow setup. Esc remains available on every menu: it asks in a box in the middle of the
+  screen, over the menu rather than instead of it, whether to save and close or discard and
+  close. Esc on the box is the way back to the menu. A menu you only looked at asks
   nothing.
 
 `/epics` and `/flowverses` are lists of the same kind, and the first two are true of them as
 well. The third is not: neither holds a draft of anything, so what is asked for there happens
 as it is asked for and esc asks nothing on the way out.
 
-A menu of several pages shows their titles across the top, and **tab** / **shift+tab** turn
-between them. A page that cannot be opened right now is still a title, struck through. A page
-made of several lists names them under the titles, and `←` / `→` step between those.
+Pages are parallel — two views of one question, either of which you might read first. A menu
+of several shows their titles across the top, and **tab** / **shift+tab** turn between them; a
+page that cannot be opened right now is still a title, struck through. A menu of one page draws
+no strip at all, one title being nowhere to turn to.
+
+What you reach by picking something is not a page. **Enter** opens it and **esc** comes back,
+which is one step rather than the way out of the menu — the same two keys they are everywhere
+else here. A tab between two views of one question is orientation; a tab between a list and the
+thing you picked out of it hides the fact that you picked anything, so it is not offered. A page
+made of several lists names them where the titles go, and `←` / `→` step between those.
 
 ## Choosing a flow
 
-`/flow` opens on two pages — **Flow** and **Agents** — and the first of them puts up the flows
-of one place at a time, with `←` and `→` stepping between the places: every
-[flowverse](/reference/flows#flowverses) — `builtin`, which is the package's own, `official`, which is
-where the rest come from, whatever else has been added, and last `local`, this project's flows
-under `.humanize/flows`, and `user`, yours under `~/.humanize/flows`, each where there are any.
-The strip above the list is the places, with the one being read marked; the list is that
-place's flows and nothing else.
+`/flow` puts up the flows of one place at a time, with `←` and `→` stepping between the
+places: every [flowverse](/reference/flows#flowverses) — `builtin`, which is the package's own,
+`official`, which is where the rest come from, whatever else has been added, and last `local`,
+this project's flows under `.humanize/flows`, and `user`, yours under `~/.humanize/flows`, each
+where there are any. The strip above the list is the places, with the one being read marked;
+the list is that place's flows and nothing else.
 
 ```
   Flow
@@ -554,41 +560,44 @@ place's flows and nothing else.
   Which flow the agents are driven through. The first thing you say once it is chosen is what
   it is to do. A flow anywhere else is a path you type.
 
-  Flow · Agents   tab/shift+tab to switch
   builtin · official · local   ←/→ to switch
 
 ❯ 1. chat                    Chat — one agent, one session, and every line typed between…
   2. ralph_loop              Ralph loop (flowbench: ralph_loop) — a fresh session every…
   3. stateful_ralph          Stateful ralph (flowbench: stateful_ralph) — one session, re-…
 
-  Enter to choose · f copies it here · Esc to close · s to search
+  Enter opens what drives it · f copies it here · v the flowverses · Esc to close · s to search
 ```
 
 | Key | |
 | --- | --- |
+| **enter** | Open that flow: what drives it, which is the next thing to answer. |
 | `←` `→` | Read the place before or after this one, wrapping round. |
 | `f` | Copy the flow under the cursor into `.humanize/flows/`, whole — what it imports and the skills it brings — to change. Your own are looked in first, so from then on that name means your copy. |
+| `v` | [Where flows come from](#where-flows-come-from): the places themselves, and what can happen to one. |
 
-The page opens on the place the flow in force came from. **A flowverse that has never been
+The list opens on the place the flow in force came from. **A flowverse that has never been
 fetched is fetched as the menu opens** — which in practice is `official`, the one every flow
 that is not in the package is in — in the background, once per opening however it goes, and
 without moving what you are reading: this is the place nobody fetched being fetched because
 its flows are wanted, not somebody asking to be taken to it. It runs off the interface's own
 loop — the menu keeps drawing while it clones — and what became of it is said under the list
 rather than thrown at you. A place with nothing in it says so where its flows would be, and
-one that has never been fetched says which menu fetches it: adding a place, fetching one again
-and taking one away are [`/flowverses`](#where-flows-come-from).
+one that has never been fetched says which key opens the menu that fetches it: adding a place,
+fetching one again and taking one away are [**v**](#where-flows-come-from).
 
-Choosing a flow reads back what that flow was last set up with here, asks
-[what the flow itself takes](#setting-a-flow-up) where it takes anything, and lands on the
-**Agents** page, which is the next thing to answer. Its last row, `save`, validates every
-agent and applies the flow and all its agents together.
+Enter on a flow opens it: what that flow was last set up with here is read back,
+[what the flow itself takes](#setting-a-flow-up) is asked where it takes anything, and what
+drives it is what you land in — which is the next thing to answer. **Esc comes back to the
+flows**, one step, and esc again leaves the menu. The last row inside a flow, `save`, validates
+every agent and applies the flow and all its agents together.
 
-**The Flow page is shut while a flow is running** — a flow is chosen in order to be started,
-and there is one going. The Agents page never is: an agent thinking too little, on the wrong
-account or allowed too much is something you find out halfway through a run. What you save then
-reaches the agents that are running, each of them from its next turn on. A CLI you changed is
-the one thing that cannot be swapped under a flow already holding that agent, and says so.
+**There are no flows to choose from while one is running** — a flow is chosen in order to be
+started, and there is one going. So `/flow` opens inside the agents of the flow that is going,
+and esc there leaves: an agent thinking too little, on the wrong account or allowed too much is
+something you find out halfway through a run. What you save then reaches the agents that are
+running, each of them from its next turn on. A CLI you changed is the one thing that cannot be
+swapped under a flow already holding that agent, and says so.
 
 This menu is the only way in that is typed. A machine being set up or a script reaches the
 same places through [`Hmz().verses`](/reference/sdk) — `add`, `fetch`, `remove` and `holds`,
@@ -601,11 +610,11 @@ them, so what you type finds a flow without your having to remember which flowve
 
 ## Where flows come from
 
-`/flowverses` is the places themselves — a git repository with a `flows/` directory apiece,
-cloned under humanize's home, and the flows of your own read where they lie. Each is offered
-under the name it is listed under. A place that has never been fetched is listed all the same,
-with its URL and `not fetched yet` beside it: what there is to run is not the same question as
-what has been downloaded.
+**v** in `/flow`, and `/flowverses`, open the places themselves — a git repository with a
+`flows/` directory apiece, cloned under humanize's home, and the flows of your own read where
+they lie. Each is offered under the name it is listed under. A place that has never been
+fetched is listed all the same, with its URL and `not fetched yet` beside it: what there is to
+run is not the same question as what has been downloaded.
 
 ![The /flowverses list: builtin, which holds the flows humanize ships, and official, a GitHub
 URL marked as not fetched yet](/demo/flowverses.png)
@@ -617,10 +626,19 @@ URL marked as not fetched yet](/demo/flowverses.png)
 | **r** | Fetch the one under the cursor again, or for the first time. `builtin` came with humanize, and `local` and `user` are directories of your own: all three say there is nothing to fetch. |
 | **d** **d** | Take an added one away, flows and all. `builtin`, `official`, `local` and `user` are always here, and say so. |
 
-Its own menu rather than three more keys on `/flow`, because they are about something else:
+Its own menu rather than three more keys on the flows, because they are about something else:
 adding a repository, fetching one again and taking one away are done to the list of places,
-while the page they were on is asking which flow to run — and a sheet that asks one question
-with three keys about another is a sheet asking two.
+while the list they would be keys of is asking which flow to run — and a sheet that asks one
+question with three keys about another is a sheet asking two. Its own menu rather than a deeper
+view of `/flow` for a second reason: that menu holds everything until you save it, and each of
+these runs git as you ask for it.
+
+`/flowverses` stays a command as well as a key, because the key belongs to the flows and there
+are none to choose from while a flow is running. Either way in is the same sheet.
+
+**v** is refused while `/flow` is still fetching the place it opened on, and says so under the
+list: two clones of one place land in one directory, and the one that loses takes the other's
+work with it.
 
 **What happens here happens as it is asked for** rather than when the menu is saved: each of
 these runs git, and something that has already been cloned is not a draft. A clone runs off
@@ -629,7 +647,7 @@ said under the list and again in the transcript on the way out. Nothing here is 
 a flow is running: a place fetched now is one the next run may reach for, and none of it
 touches the flow that is going.
 
-`/flow` kept the two keys that are about flows rather than about places: `←` and `→`, which
+The flows kept the two keys that are about flows rather than about places: `←` and `→`, which
 step between these same places because that is which list of flows is being read, and `f`,
 which copies the flow under the cursor into this project.
 
@@ -639,8 +657,8 @@ the cursor with enter meaning it.
 
 ## What each agent is
 
-The **Agents** page of `/flow` lists what the flow drives, by the name the flow calls each, and
-enter opens one. Everything that agent is is a row of one sheet:
+Opening a flow in `/flow` lists what it drives, by the name the flow calls each, and enter
+opens one. Everything that agent is is a row of one sheet:
 
 ```
   Set up builder
@@ -677,8 +695,8 @@ for an agent [the flow says may be pointed at a machine](#where-each-agent-works
 flow put in a container it is read rather than opened, and for one that works here it is not
 there at all.
 
-`save` accepts this agent and returns straight to the flow's Agents page. It changes only the
-flow draft; the complete setup is written down when `save` is chosen on that outer page. Esc
+`save` accepts this agent and returns straight to the flow's agents. It changes only the flow
+draft; the complete setup is written down when `save` is chosen there. Esc
 off the agent sheet remains a fallback: it asks whether to accept or discard changes.
 
 ## Which CLI, and which account
@@ -1032,7 +1050,7 @@ over the headings.
 | **esc** | Back to the menu, changing nothing |
 
 It opens as the flow is chosen — enter on a flow that takes settings puts it up, and answering
-it lands on the Agents page — and what it answers is held with the rest of that menu until the
+it lands inside that flow's agents — and what it answers is held with the rest of that menu until the
 menu is saved: setting a flow up is a thing about the flow rather than about what runs it. A
 flow that takes no settings is not asked, so the walk is the same either way. There is no
 command for it, here or on a line: choosing the flow again is how you answer it again, and
@@ -1076,9 +1094,9 @@ the terminal's colours; a name no theme answers to is ignored rather than refuse
 
 - **Open twice.** `hmz` with no command is the only way in — with or without `-f`, `-c` and
   `-a`, which say how it opens rather than opening a second one.
-- **Run two flows at once.** The Flow page of `/flow` is shut while one is running, and
-  what the flow itself takes is not asked. What each agent is stays open: that is the half
-  worth changing mid-run.
+- **Run two flows at once.** There are no flows to choose from in `/flow` while one is
+  running, and what the flow itself takes is not asked. What each agent is stays open: that is
+  the half worth changing mid-run.
 - **Guess at a bad line.** A line it cannot carry out is shown and the interface stays up. Only
   `/exit` closes it — and `/detach`, which closes this terminal and not the run.
 - **Ask the flow anything.** What is drawn beside and under the transcript is kept from the

--- a/docs/tapes/flowverses.tape
+++ b/docs/tapes/flowverses.tape
@@ -1,5 +1,8 @@
 # `/flowverses`: the places flows come from, and what one of them holds.
 #
+# The same menu `v` opens from `/flow`. Recorded from the command because opening the flows
+# fetches whatever has never been fetched, and nothing here reaches the network.
+#
 # Nothing is fetched here. The two that are always listed are the package's own flows and
 # humanize's repository of the rest; asking what one holds reads the flows already on this
 # container's disk, and no turn is taken.

--- a/docs/user/completion.md
+++ b/docs/user/completion.md
@@ -48,8 +48,8 @@ between keystrokes.
 /flow ./flows/mine
 ```
 
-Nothing else completes either. Model ids are chosen where an agent is set up, which is the
-agents page of `/flow`, and you choose from the list the CLI itself said it runs. There is no
+Nothing else completes either. Model ids are chosen where an agent is set up, which is inside
+a flow in `/flow`, and you choose from the list the CLI itself said it runs. There is no
 completion for a task, because a task is prose.
 
 ## Searching on a sheet

--- a/docs/user/containers.md
+++ b/docs/user/containers.md
@@ -104,7 +104,7 @@ anywhere.
 **For the weaver.** `Annotated[Agent, Isolated("python:3.12")]` beside the place, as in [Try
 it](#try-it) above, is the usual way for one agent. The image is the flow's, and the workspace
 is the directory the flow is running in; nothing can point that agent anywhere else, including
-you. The agents page of `/flow` reads it back on that agent's `where` row as `in a container of
+you. Opening that flow in `/flow` reads it back on that agent's `where` row as `in a container of
 python:3.12`, with `the flow settled this` beside it — a row to read rather than one to open.
 
 ## From Python

--- a/docs/user/remote-execution.md
+++ b/docs/user/remote-execution.md
@@ -168,8 +168,8 @@ def run(agents: Agents, task: str) -> None:
                 suppress=True)
 ```
 
-Whoever runs that flow then picks the machine on the `where` row of the agent's own sheet, on
-the agents page of `/flow`. The row appears only for a `Remote` place. It lists the containers
+Whoever runs that flow then picks the machine on the `where` row of the agent's own sheet,
+reached by opening that flow in `/flow`. The row appears only for a `Remote` place. It lists the containers
 running and the hosts in your `~/.ssh/config`, and anything else is typed:
 
 | Typed | Where the work goes |

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -94,8 +94,8 @@ What is sampled, what that costs while the flow runs, and what a trace then make
 ## Changing what it opens on
 
 It is changed where it was set in the first place. [`/flow`](/reference/tui#choosing-a-flow)
-chooses the flow; its **Agents** page says what each of that flow's agents runs, where its
-turns land and which account it runs as; and a flow with
+chooses the flow; opening that flow says what each of its agents runs, where its turns land
+and which account it runs as; and a flow with
 [settings of its own](/reference/tui#setting-a-flow-up) asks them as it is chosen. Saving that
 menu is what gets written down, so the next `hmz` in this directory opens on exactly what you
 left — and opening is all it does. The interface comes up ready and the first thing you say is

--- a/docs/weaver/calling-flows.md
+++ b/docs/weaver/calling-flows.md
@@ -221,7 +221,7 @@ hmz exec -f official/humanize1:gen-idea -a claude/claude-opus-5:max "add undo to
 hmz exec -f official/humanize1:gen-plan -a claude/claude-opus-5:max -a codex/gpt-5.6-sol:max ""
 ```
 
-Each declares its own agents and its own settings: the agents page asks two questions rather
+Each declares its own agents and its own settings: opening one asks about two agents rather
 than five, and setting one up shows one phase's flags rather than three phases' at once. What
 passes between them is whatever they write, usually a file.
 

--- a/docs/weaver/flow-settings.md
+++ b/docs/weaver/flow-settings.md
@@ -57,9 +57,9 @@ A setting that is **written** carries a caret under the cursor, where the next l
 land. A setting that is **stepped** does not, so a blank setting does not read as one nothing
 can be typed into.
 
-`/flow` walks through this between choosing the flow and landing on its agents page. That is
-the only place it can: only the flow just chosen says what there is to set. The two pages are
-halves of one question, and each asks only its own.
+`/flow` walks through this between choosing the flow and landing inside its agents. That is
+the only place it can: only the flow just chosen says what there is to set. The flow and what
+drives it are halves of one question, and each asks only its own.
 
 ## Set it from a file
 

--- a/docs/weaver/flowverses.md
+++ b/docs/weaver/flowverses.md
@@ -50,9 +50,10 @@ git remote add origin git@github.com:you/my-flowverse.git
 git push -u origin main
 ```
 
-3. **Add it.** At the prompt, `/flowverses` and **a**: a URL or an `owner/repo`, and `yours` as
-   the name to keep it under. That clones the repository into `~/.humanize/flowverses/yours/`,
-   and **enter** on it reads back what it holds by the name `-f` takes. From a script the same
+3. **Add it.** At the prompt, **v** in `/flow` — or `/flowverses` — and then **a**: a URL or
+   an `owner/repo`, and `yours` as the name to keep it under. That clones the repository into
+   `~/.humanize/flowverses/yours/`, and **enter** on it reads back what it holds by the name
+   `-f` takes. From a script the same
    two are [`Hmz().verses`](/reference/sdk#flowverses):
 
 ```python
@@ -130,7 +131,7 @@ See [SDK reference](/reference/sdk#flowverses).
 
 ### At the prompt
 
-`/flowverses` is the places themselves:
+**v** in `/flow` opens the places themselves, and `/flowverses` opens the same menu:
 
 ![/flowverses: the places flows come from, and what one of them holds](/demo/flowverses.gif)
 
@@ -159,15 +160,20 @@ Which flow to run is `/flow`'s question, and it steps between the same places:
 | --- | --- |
 | **←** **→** | Step between the places flows come from, a list apiece — every flowverse, ending with `local` and `user` where either holds anything |
 | **f** | Copy the flow under the cursor into `.humanize/flows/`, to change |
+| **v** | The places themselves, which is this menu; **esc** comes back to the flows |
 
 A flow whose file will not import is still listed there, under the name it would have had and
 with nothing beside it. It is a flow somebody named. Saying so where it is chosen beats leaving
 it off the list and letting you wonder where it went.
 
-The two pages are apart because they are two questions: which flow to run, and what places
-there are. What stays on `/flow` is **f**, which is about the flow you are looking at — the
-moment you find out it is *nearly* what you want. A flow is a directory, so the copy is the
-whole of it, skills and all, and it lands under the name it already had. Yours are looked in
+The two are apart because they are two questions: which flow to run, and what places there
+are. Walked to rather than turned to, and a sheet of its own rather than a deeper view of the
+flow menu: that menu holds everything until you save it, and adding a place, fetching one and
+taking one away each run git the moment you ask. `/flowverses` stays a command as well, since
+the key belongs to the flows and there are none to choose from while a flow is running. What
+stays on the flows is **f**, which is about the flow you are looking at — the moment you find
+out it is *nearly* what you want. A flow is a directory, so the copy is the whole of it, skills
+and all, and it lands under the name it already had. Yours are looked in
 first, so from then on that name means your copy. Editing a flowverse's own copy would not
 keep, since fetching it again takes what that repository says now.
 

--- a/docs/weaver/goals.md
+++ b/docs/weaver/goals.md
@@ -102,7 +102,7 @@ $ hmz exec -f pursuing -a pi/openai-codex/gpt-5.5:high "fix the build"
 hmz exec: error: pursuing: worker is run under a goal, which pi has no feature for
 ```
 
-The agents page of `/flow` then offers only the CLIs that have one, so there is no wrong choice
+Opening that flow in `/flow` then offers only the CLIs that have one, so there is no wrong choice
 to make.
 
 ## A goal by hand: refusing `STOP`

--- a/docs/weaver/hooks.md
+++ b/docs/weaver/hooks.md
@@ -198,7 +198,7 @@ $ hmz exec -f gated -a kimi/kimi-code/k3:high -a kimi/kimi-code/k3:high "fix the
 hmz exec: error: gated: builder has to run PermissionRequest, which kimi does not
 ```
 
-The agents page of `/flow` then offers only the CLIs that would work for that place.
+Opening that flow in `/flow` then offers only the CLIs that would work for that place.
 
 ## Two rules
 

--- a/docs/weaver/loops.md
+++ b/docs/weaver/loops.md
@@ -60,8 +60,9 @@ The flows appear one place at a time, one list each. **←** and **→** step be
 /flow ralph_loop
 ```
 
-`/flow` is **refused while a flow is running**. You get `no choosing a flow while a flow is
-running: ctrl+c twice stops it first`. Looking and leaving without choosing changes nothing.
+There are **no flows to choose from while a flow is running**: `/flow` opens inside the agents
+of the one that is going, and `/flow ralph_loop` is refused outright with `hmz: a flow is
+running; no choosing a flow`. Looking and leaving without choosing changes nothing.
 
 ::: details What the three built-in flows are
 | Flow | Agents | |
@@ -142,7 +143,7 @@ sessions and its own record. `/epics` is where both of them are.
 **Hold the conversation instead of dropping it.** `/flow stateful_ralph`, same task. Compare
 how often it re-reads files it has already read.
 
-**Move the effort.** Open the Agents page of `/flow`, choose the agent, find the `effort` row,
+**Move the effort.** Open the flow in `/flow`, choose the agent, find the `effort` row,
 and press **←/→**. A Ralph loop of `low` turns is a different animal from one of `max` turns.
 See [Efforts](/user/efforts).
 

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -67,10 +67,10 @@ line, with what the flow is doing beside the transcript.
 - `$<flow> <prompt>` MUST be the flow said outright: choose that flow, and say that to it. The
   two answers before a run -- which flow, and what to do -- are one line then, and the first of
   them is the same answer every morning. Where this workspace has already set that flow up it
-  MUST run on the spot: a menu of two pages of answers already given is a menu nobody would
-  open. Where it has not, the flow menu MUST open on that flow with the line held, and the
-  flow MUST run on it the moment the menu is saved -- a flow with no agents answered for is a
-  flow that stops on its first turn, and a prompt held is a prompt not typed twice.
+  MUST run on the spot: a menu of answers already given is a menu nobody would open. Where it
+  has not, the flow menu MUST open inside that flow with the line held, and the flow MUST run
+  on it the moment the menu is saved -- a flow with no agents answered for is a flow that stops
+  on its first turn, and a prompt held is a prompt not typed twice.
 - Set up here MUST mean a remembered agent for every place the flow declares now, under the
   name the flow calls that place and in the flow's own order -- so a flow that has grown,
   lost or renamed an agent since is one to be asked about rather than one whose reviewer
@@ -94,8 +94,8 @@ line, with what the flow is doing beside the transcript.
   next line typed is that answer, whatever it begins with, and a turn left waiting while a
   flow started elsewhere is a turn nobody ended.
 - A `$` line MUST be refused while a flow is running, and MUST leave that run exactly as it
-  was. It is choosing a flow, and the page that chooses one is shut while one runs; two ways
-  of saying the same thing that did opposite things would be one of them ending a day's work
+  was. It is choosing a flow, and choosing one is not offered while one runs; two ways of
+  saying the same thing that did opposite things would be one of them ending a day's work
   on a line meant to queue the next one up. It MUST NOT quietly become a word put into the
   running conversation either.
 - A `$` naming a flow and saying nothing after it MUST choose that flow and no more: there is
@@ -352,9 +352,19 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   search MUST be asked for -- on `s` -- and MUST be left on esc, which clears what was typed
   before it goes. While one is running the letters MUST reach it rather than the keys they
   otherwise are, and esc MUST come out of the search before it leaves the sheet.
-- A menu of several pages MUST show their titles, and tab and shift+tab MUST turn between
-  them: that is the one pair of keys a terminal has for exactly this. A page that may not be
-  opened MUST still be a title, struck through, and MUST be stepped over rather than opened.
+- Pages MUST be parallel: two views of one question, either of which may be read first. A
+  menu of several MUST show their titles, and tab and shift+tab MUST turn between them, that
+  being the one pair of keys a terminal has for exactly this. A page that may not be opened
+  MUST still be a title, struck through, and MUST be stepped over rather than opened. A menu
+  of one page MUST NOT draw a strip of titles at all: one title is nowhere to turn to, and a
+  row that offers nothing is a row taken off a terminal that has only so many.
+- What is reached by picking something MUST NOT be a page. It MUST be opened with enter on the
+  thing it is about and left on esc, which is one step back rather than a way out of the menu.
+  The distinction is what the keys say about what happened: a tab between two views of one
+  question is orientation, while a tab between a list and the thing picked out of it reads as
+  a view that was there all along -- so which thing was picked is a thing nobody can see they
+  chose, and turning back to the list looks like changing views rather than the way back out
+  of what they opened.
 - A page made of several lists MUST show what they are called, and the left and right arrows
   MUST step between them: the list itself is walked up and down, so across is what is left,
   and the titles are read the same way the pages' are.
@@ -370,9 +380,9 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 ### What lands, and when
 
 - A menu MUST hold everything changed in it until it is left and saving is confirmed. Turning
-  a page MUST apply nothing: what is read on the second page is what the first is holding, and
-  a menu that applied each page as it was left would be one where walking out changed things
-  nobody confirmed.
+  a page or walking into what was picked MUST apply nothing: what is read deeper in is what the
+  menu is holding, and a menu that applied each part as it was left would be one where walking
+  out changed things nobody confirmed.
 - Esc on a menu holding changes MUST ask whether to save them, and esc on that question MUST
   be the way back to the menu. Esc on a menu holding none MUST just leave: a walk in to look
   and out again is not a question anybody wants asked of them.
@@ -385,12 +395,20 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 
 ### Which flow, and what drives it
 
-- The flow menu MUST be two pages: which flow to run, and what each of its agents is. Two
-  because they are two questions about one thing and are not open at the same moments.
-- The page that chooses a flow MUST be shut while a flow is running: a flow is chosen in order
-  to be started, and there is one going. The page its agents are set up on MUST never be shut
-  -- an agent thinking too little, on the wrong account or allowed too much is found out
-  halfway through a run.
+- The flow menu MUST be the flows, and the agents of the one that was opened: a walk in, and
+  not two pages. A flow is picked out of a list and its agents are that flow's own, so enter
+  MUST open what drives the flow under the cursor, and esc MUST come back to the flows.
+- Choosing a flow MUST NOT be offered while a flow is running: a flow is chosen in order to be
+  started, and there is one going. The menu MUST open inside the agents then, and esc there
+  MUST leave, there being no list of flows behind it to step back to. The agents MUST be
+  reachable whatever is happening -- an agent thinking too little, on the wrong account or
+  allowed too much is found out halfway through a run.
+- A menu opened already naming a flow -- `/flow` given one, and a `$` naming one this
+  workspace has never set up -- MUST open inside that flow's agents. The flow has been named,
+  so what is left to answer is what drives it, and one named as a path is not in the list to
+  be chosen from at all. Esc there MUST leave, as it does while a flow runs: a step back to a
+  list nobody walked through is a step nobody took, and on a `$` it would swallow the line
+  that was typed to start something.
 - What is saved while a flow runs MUST reach the agents that are running, as far as it can:
   each of them MUST be set up as it now stands from its next turn on. A CLI that has changed
   MUST NOT be swapped under the flow holding that agent -- a backend is the class the agent is
@@ -418,12 +436,15 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   background: it is here because its flows are wanted, and a list with nothing in it and a
   key to press about it is a step nobody would choose to take. It MUST NOT hold the menu up,
   MUST NOT move what is being read, and MUST be tried once per opening however it goes -- a
-  machine with no network says so once rather than on every keystroke.
-- Adding a flowverse, fetching one again and taking one away MUST NOT be keys of this page.
+  machine with no network says so once rather than on every keystroke. While it runs, the menu
+  where flows come from MUST NOT be opened from here, and the key MUST say why: two clones of
+  one place land in one directory, and the one that loses takes the other's work with it.
+- Adding a flowverse, fetching one again and taking one away MUST NOT be keys of the flows.
   They are things done to the list of places rather than to the flow under the cursor, and a
   sheet that asks `which flow` with three keys on it about something else is a sheet asking
-  two questions. `/flowverses` is where they are, and stepping between the places stays here:
-  that is about which list of flows is being read.
+  two questions. The menu where flows come from is where they are, reached on a key of the
+  flows, and stepping between the places stays here: that is about which list of flows is
+  being read.
 - Setting the flow itself up MUST be asked as the flow is chosen, between the flow and its
   agents, rather than being a key or a page of its own: a flow that takes settings is chosen
   in order to be run with settings, and that is the one moment somebody is thinking about the
@@ -433,8 +454,8 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 - Each flow MUST say what it does beside its name, which is the line the flow itself says. What
   is typed MUST narrow the list by name and not by that line: a subsequence of a sentence is a
   match nobody typed.
-- Choosing a flow MUST read back what that flow was last set up with here, and MUST end on the
-  page its agents are on: that is the next thing to answer.
+- Choosing a flow MUST read back what that flow was last set up with here, and MUST end inside
+  its agents: that is the next thing to answer.
 - The menu MUST be the one place a flow is set up, however it was reached for: `/flow`, and a
   `$` naming a flow this workspace has never set up. Two screens asking which agents drive a
   flow would be two to answer differently.
@@ -493,11 +514,22 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 
 ### Where flows come from
 
-- `/flowverses` MUST list every place there is, saying where each came from and which have
-  not been fetched, and MUST be the four things there are to do with one: what it holds, one
-  added, one fetched again, one taken away. It MUST be the same store `/flow` reads the flows
-  out of and the same one :attr:`hmz.sdk.Hmz.verses` walks -- one place a thing is kept is
-  one place it is kept, whichever way somebody reached it.
+- The menu of places MUST list every place there is, saying where each came from and which
+  have not been fetched, and MUST be the four things there are to do with one: what it holds,
+  one added, one fetched again, one taken away. It MUST be the same store `/flow` reads the
+  flows out of and the same one :attr:`hmz.sdk.Hmz.verses` walks -- one place a thing is kept
+  is one place it is kept, whichever way somebody reached it.
+- It MUST be reachable from the flows, on a key of theirs: the places are where the flows
+  being read come from, so somebody looking for a flow that is not in the list is somebody
+  looking for the place it would come from, and sending them to a command they must first
+  know about loses the question they were answering. `/flowverses` MUST also open it, that
+  being the way in while a flow is running: choosing a flow is not offered then, so neither is
+  the list the key belongs to.
+- It MUST NOT be a deeper view of the flow menu, whatever it is reached from. That menu holds
+  everything until it is saved, and everything here happens as it is asked for, so a view of
+  it that ran git would be one part of a sheet breaking the contract the whole sheet
+  advertises -- and a menu that is honest about what it holds is the whole of why the menus
+  hold anything.
 - Enter MUST say what one holds, which MUST be read only of the flowverse it was asked of: a
   flow is read by running it, so what a place holds is the one question about it with no cheap
   answer. `a` MUST add one; `r` MUST fetch one again; `d` twice MUST take one away.

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -2,8 +2,8 @@
 
 Laid out the way Claude Code is, and no wider: a transcript the width of the terminal, an
 editor under it between two rules, and a status line under that. Nothing sits beside them --
-how the run is going is on `/monitor`, and `/flow` both chooses the loop and, a page along,
-sets what each of its agents runs.
+how the run is going is on `/monitor`, and `/flow` both chooses the loop and, inside the one
+it opens, sets what each of its agents runs.
 
 The transcript is a tab per agent, and one more where all of them appear together. A flow
 drives several agents and each of them holds as many conversations as it likes; every agent's
@@ -110,11 +110,11 @@ if TYPE_CHECKING:
 
 #: What the editor understands, named as opencode names them, one step along: what answers
 #: here is a flow rather than an agent, so opencode's `/agents` is `/flow`, and what a flow
-#: runs on is an agent apiece rather than one model, so its `/models` is the page along from
-#: it. There is no command for an agent on its own: an agent belongs to the flow that drives
-#: it, and is set up on the page of `/flow` its agents are on. `hmz anchor` is not here
-#: either: it is not a thing to do to a flow that is running, and it is a command line of its
-#: own. What a run left behind is `/epics`, which is where the runs of this directory are.
+#: runs on is an agent apiece rather than one model, so its `/models` is a walk into `/flow`.
+#: There is no command for an agent on its own: an agent belongs to the flow that drives it,
+#: and is set up inside the flow `/flow` opened. `hmz anchor` is not here either: it is not a
+#: thing to do to a flow that is running, and it is a command line of its own. What a run left
+#: behind is `/epics`, which is where the runs of this directory are.
 _OWN = (
     "flow",
     "btw",
@@ -2418,34 +2418,32 @@ class Humanize(App[None]):
         return found[-1] if found else None
 
     @work
-    async def action_flow(self, named: str = "", *, opening: int = 0) -> None:
+    async def action_flow(self, named: str = "") -> None:
         """Opens the flow menu: which flow runs, and what each of its agents is.
 
-        One menu of two pages rather than a walk of a sheet per question. Nothing in it is
-        applied until it is saved on the way out, so opening it to look at the flows and
-        walking back out again leaves the interface exactly as ready to be typed at as it was.
+        One menu walked into rather than a sheet per question: the flows, and the agents of
+        the one that is opened. Nothing in it is applied until it is saved on the way out, so
+        opening it to look at the flows and walking back out again leaves the interface
+        exactly as ready to be typed at as it was.
 
-        Not refused while a flow runs. The page that chooses one is shut then -- a flow is
-        chosen in order to be started, and there is one going -- but the page its agents are
-        set up on is open, that being where somebody halfway through a run finds out that an
+        Not refused while a flow runs. Choosing one is not offered then -- a flow is chosen in
+        order to be started, and there is one going -- so it opens inside the agents of the
+        flow that is going, that being where somebody halfway through a run finds out that an
         agent is thinking too little or is allowed too much.
 
         Args:
           named: A flow of your own, as a path, to open the menu already holding.
-          opening: Which page to open on, counting from zero.
         """
         running = bool(self._agents)
         if named and running:
             self.show("hmz: a flow is running; no choosing a flow", "red")
             return
-        chosen = await self._chooses(named, running=running, opening=opening)
+        chosen = await self._chooses(named, running=running)
         if chosen is None:
             return  # walked out without saving, which changes nothing at all
         self._took_flow(chosen, running=running)
 
-    async def _chooses(
-        self, named: str, *, running: bool, opening: int = 0
-    ) -> Chosen | None:
+    async def _chooses(self, named: str, *, running: bool) -> Chosen | None:
         """Puts the flow menu up and answers with whatever it was saved holding.
 
         Called from a worker, since it waits on a sheet: `/flow` opens it to be answered, and
@@ -2454,8 +2452,7 @@ class Humanize(App[None]):
 
         Args:
           named: A flow to open the menu already holding, or "" for the one in force.
-          running: Whether a flow is running, which is what shuts the page that chooses one.
-          opening: Which page to open on, counting from zero.
+          running: Whether a flow is running, which is what takes the flows away.
 
         Returns:
           The flow, its agents and how the flow itself is set up, or None for a menu walked
@@ -2480,7 +2477,10 @@ class Humanize(App[None]):
                 self.settings.flows(),
                 unavailable=frozenset(unavailable),
                 running=running,
-                opening=opening,
+                # A flow that was named has been chosen, so what is left to answer is what
+                # drives it -- and one named as a path is not in the list to choose from at
+                # all, so a menu that opened on that list would be offering to undo it.
+                inside=bool(named),
             )
         )
 
@@ -2489,10 +2489,10 @@ class Humanize(App[None]):
         """Starts one flow on what was typed after its name, setting it up first if it needs to.
 
         The whole of what `$ralph_loop fix the build` is: that flow, said that. A
-        flow this workspace has already set up runs on the spot -- the menu would be two pages
-        of answers already given -- and one it has not opens that menu on it, holding the line
-        that was typed until it is saved, since a flow nobody has answered for is a flow with
-        no agents to run on.
+        flow this workspace has already set up runs on the spot -- the menu would be answers
+        already given -- and one it has not opens that menu inside it, holding the line that
+        was typed until it is saved, since a flow nobody has answered for is a flow with no
+        agents to run on.
 
         Args:
           named: The flow, by the name it is offered under.
@@ -2778,13 +2778,14 @@ class Humanize(App[None]):
         """Opens the places flows come from, which is what `/flowverses` is for.
 
         Not which flow to run -- that is `/flow`, where the arrows step between these places
-        and the list holds the one being read. This is the other question: what places there
-        are, what one of them holds, and the three things that can happen to one. Not refused
-        while a flow runs: a flowverse fetched now is a flowverse the next run may reach for,
-        and nothing here touches the flow that is going.
+        and the list holds the one being read, and where `v` opens this same menu. A command
+        as well, because that is the way in while a flow runs: choosing a flow is not offered
+        then, so neither is the list `v` is a key of. Not refused while one is going either --
+        a flowverse fetched now is a flowverse the next run may reach for, and nothing here
+        touches the flow that is running.
         """
         for one in await self.push_screen_wait(Flowverses()) or ():
-            self.show(one)
+            self.show(f"[dim]{one}[/dim]")
 
     @work
     async def action_epics(self) -> None:

--- a/src/hmz/tui/pick.py
+++ b/src/hmz/tui/pick.py
@@ -313,8 +313,9 @@ Ways {
 #rule { height: 1; color: $primary; }
 #asked { padding: 0 0 0 3; text-style: bold; color: $primary; }
 #about { padding: 0 3 1 3; color: $text-muted; width: 1fr; }
-/* The tabs, for the one sheet that has any. A sheet with none says nothing here, and a
-   label with nothing in it is a row nobody paid for. */
+/* The row above the list: the titles of a sheet that is several pages, and the places a
+   list of flows is one of. A sheet with neither says nothing here, and a label with nothing
+   in it is a row nobody paid for. */
 #tabs { padding: 0 0 1 3; width: 1fr; }
 OptionList { border: none; background: $background; scrollbar-size: 0 0; padding: 0; }
 /* The marker says where the cursor is, so the row is not filled as well. */
@@ -394,17 +395,24 @@ class Sheet[T](ModalScreen[T | None]):
     and where, and walking out without answering is None wherever it is asked.
 
     A sheet of several pages says so: the titles are across the top and tab and shift+tab turn
-    between them, which is the one pair of keys a terminal has for exactly that. Nothing here
-    is a chord -- a sheet asks one thing and its keys are its own, so a key that needed ctrl
-    held down would be a key somebody had to already know.
+    between them, which is the one pair of keys a terminal has for exactly that. Pages are what
+    two views of one question are, either of which may be read first: turning between them is
+    orientation. What is reached by picking something is not a page and is not a tab -- it is
+    opened with enter on the thing it is about and left on esc, because a tab between a list
+    and the thing picked out of it reads as a view that was there all along, which hides that
+    anything was picked at all.
+
+    Nothing here is a chord -- a sheet asks one thing and its keys are its own, so a key that
+    needed ctrl held down would be a key somebody had to already know.
     """
 
     CSS = _SHEET
     BINDINGS: ClassVar = [("escape", "back", "back")]
 
-    #: The pages this sheet is, in the order they are turned between, or nothing at all for a
-    #: sheet that is one page. A sheet with tabs shows their titles whether or not there are
-    #: two: a page nobody can see the name of is a page nobody knows they are on.
+    #: The parallel pages this sheet is, in the order they are turned between: nothing at all
+    #: for a sheet that is one page, and for one whose deeper view is opened rather than
+    #: turned to. A sheet with tabs shows their titles whether or not there are two: a page
+    #: nobody can see the name of is a page nobody knows they are on.
     TABS: ClassVar[tuple[str, ...]] = ()
 
     #: Which row the marker was last drawn against. Putting the rows up moves the cursor,
@@ -484,11 +492,7 @@ class Sheet[T](ModalScreen[T | None]):
         self._typed, self._searching = "", False
         self.query_one("#choices", OptionList).highlighted = 0
         self._drawn = 0
-        self._turned()
         self._fill()
-
-    def _turned(self) -> None:
-        """What a sheet does as a page opens, which is nothing unless it says otherwise."""
 
     def _tab_line(self) -> str:
         """The titles, with the one being read marked and the shut ones struck through."""
@@ -607,10 +611,11 @@ class Sheet[T](ModalScreen[T | None]):
         self._ask()
 
     def tabbed(self, said: str) -> None:
-        """Puts a row of tabs above the choices, or takes the row back where there are none.
+        """Puts the row above the choices up, or takes it back where there is nothing for it.
 
         Args:
-          said: The tabs, as markup, or "" for a sheet that is one list.
+          said: The titles of the pages, or whatever else a sheet says the list is one of, as
+            markup -- and "" for a sheet that is one list of one thing.
         """
         showing = self.query_one("#tabs", Label)
         showing.display = bool(said)
@@ -1008,61 +1013,61 @@ def _complete(runs: Runs) -> bool:
     return bool(cli and model)
 
 
-#: What separates the two halves of a row's id on the flows page: which place it came from,
+#: What separates the two halves of a row's id among the flows: which place it came from,
 #: and which flow it is. A byte no name has in it, since the second half may hold anything --
 #: a flow is offered under the place it came from, and holds a slash and may hold a colon.
 _HALVES = "\x1f"
 
-#: The pages the flow menu is, in the order they are turned between.
-_FLOW_PAGE, _AGENT_PAGE = 0, 1
+#: The row the flow menu is saved from, which is the last of its agents'.
 _SAVE = "save"
 
 
 class Flows(Drafts[Chosen]):
-    """Which flow runs and what each of its agents is: one menu, a page apiece.
+    """Which flow runs and what each of its agents is: one menu, walked into.
 
-    Two pages because they are two questions about one thing, and because they are not open
-    at the same moments. A flow is chosen in order to be started, so choosing one while one is
-    running is not a thing to offer at all -- that page is shut while a flow runs, and says so
-    rather than going away. What its agents are is the other way round: an agent that is
-    thinking too little, on the wrong account, or allowed too much is found out halfway
-    through a run, so that page is never shut.
+    The flows, and then the agents of the one that was opened. Not two pages turned between:
+    a flow is picked out of a list and what drives it is that flow's own, so a tab between
+    them would read as a second view that had been there all along -- and which flow's agents
+    were being set up would be a thing nobody could see they had chosen. Enter opens a flow
+    and esc comes back to the flows, which is what those two keys mean everywhere else here.
+
+    Choosing a flow is not offered at all while one is running: a flow is chosen in order to
+    be started, and there is one going. The menu opens inside the agents then, and esc leaves
+    rather than stepping back to a list that is not there. Its agents are the other way
+    round -- an agent that is thinking too little, on the wrong account, or allowed too much
+    is found out halfway through a run -- so they are reachable whatever is happening.
 
     The flows are read a place at a time -- every flowverse there is, fetched or not, and then
     this project's flows and yours -- with the left and right arrows stepping between the
     places and the list holding only the one being read. All of them run together under
     headings was one list nobody could see the end of, and one where walking to a flow meant
     walking past every flow that came before it. Stepping between the places is about which
-    list of flows is being read; what can happen to a flowverse is `/flowverses`, which is a
-    question about the places rather than about which flow to run.
+    list of flows is being read; what can happen to a flowverse is the menu `v` opens, which
+    is a question about the places rather than about which flow to run.
 
-    Choosing a flow asks what that flow itself takes, where it takes anything, and then turns
-    to what will drive it. A key that set the flow up was a key nobody pressed: a flow with
+    Choosing a flow asks what that flow itself takes, where it takes anything, and then opens
+    what will drive it. A key that set the flow up was a key nobody pressed: a flow with
     settings is chosen in order to be run with settings, and the moment it is chosen is the
     one moment somebody is thinking about that flow rather than about its agents.
 
-    Nothing is applied by turning a page. What the menu holds is a draft of the whole of it,
-    and it lands together from the save row or when saving is confirmed on the way out.
+    Nothing is applied by walking in or back out. What the menu holds is a draft of the whole
+    of it, and it lands together from the save row or when saving is confirmed on the way out.
     """
 
-    TABS: ClassVar = ("Flow", "Agents")
-    LETTERS: ClassVar = frozenset({"search", "fork"})
+    LETTERS: ClassVar = frozenset({"search", "fork", "verses"})
 
     BINDINGS: ClassVar = [
         ("escape", "back", "back"),
-        # The pages, on the one pair of keys a terminal has for exactly that. Priority, or
-        # the list under the cursor would take them as moving the focus about.
-        Binding("tab", "next_tab", "next page", priority=True),
-        Binding("shift+tab", "prev_tab", "previous page", priority=True),
-        # The places the flows come from, on the other pair: the list walks up and down, so
-        # across is what is left for stepping between the lists there are. Priority, or the
-        # list under the cursor would take them as moving between columns it has none of.
+        # The places the flows come from: the list walks up and down, so across is what is
+        # left for stepping between the lists there are. Priority, or the list under the
+        # cursor would take them as moving between columns it has none of.
         Binding("left", "before", "the place before", priority=True),
         Binding("right", "after", "the place after", priority=True),
         # Letters rather than chords, and priority so they are the keys rather than the
         # search: a search is asked for, and while one is running these fall through to it.
         Binding("s", "search", "search", priority=True),
         Binding("f", "fork", "copy it here to change", priority=True),
+        Binding("v", "verses", "where flows come from", priority=True),
     ]
 
     def __init__(
@@ -1075,7 +1080,7 @@ class Flows(Drafts[Chosen]):
         *,
         unavailable: frozenset[str] = frozenset(),
         running: bool = False,
-        opening: int = 0,
+        inside: bool = False,
     ) -> None:
         """Initializes the menu on what is set up now.
 
@@ -1087,14 +1092,14 @@ class Flows(Drafts[Chosen]):
           kept: What each flow was last set up with here, by flow -- read when the draft flow
             changes, so that turning to a flow this workspace has run finds it as it was left.
           unavailable: The optional backends among them that still need installing.
-          running: Whether a flow is running, which is what shuts the first page.
-          opening: Which page to open on, for whoever opened the menu to reach one of them
-            directly. A page that is shut is not opened on whatever is asked for.
+          running: Whether a flow is running, which is what takes the flows away.
+          inside: Whether to open inside the flow's agents rather than on the flows, for a
+            menu opened already naming one -- a flow that was named has been chosen, so what
+            is left to answer is what drives it.
         """
         super().__init__()
         self._agents = dict(agents)
         self._unavailable = unavailable
-        self._underway = running
         self._kept = kept
         # Said outright, both of them: the flow is read where it is set, so what it is has to
         # be settled without reading what reads it.
@@ -1123,7 +1128,7 @@ class Flows(Drafts[Chosen]):
         #: not a flow. Kept whole so that it still says which list it was a row of.
         self._was = ""
         #: Which place's flows are being read, the arrows stepping between them. "" until the
-        #: page is first drawn: which place the flow in force came from is a thing only the
+        #: flows are first drawn: which place the flow in force came from is a thing only the
         #: list of every flow there is can say, and reading that list is running every file.
         self._where = ""
         #: What became of the last fetch, said under the list.
@@ -1131,12 +1136,15 @@ class Flows(Drafts[Chosen]):
         #: What is being fetched now, so that a second fetch is not started over it and so
         #: that what is said under the list is what is being fetched. "" for none.
         self._fetching = ""
-        # The flows are shut while one is running, so the menu opens on the page that is not.
-        self._tab = _AGENT_PAGE if running else opening % len(self.TABS)
-
-    def turnable(self) -> tuple[bool, ...]:
-        """Which pages may be opened: the agents always, and the flows while none runs."""
-        return (not self._underway, True)
+        #: Whether the agents are the whole of this menu, there being no flows behind them
+        #: to step back to: while a flow runs choosing one is not offered, and a flow that was
+        #: named was chosen on the line that named it rather than picked out of a list. Esc
+        #: reads off this -- a step back to a list nobody walked through is a step somebody
+        #: did not take, and on a `$` that named a flow it would swallow the line typed with
+        #: it.
+        self._only = running or inside
+        #: Whether what is open is the agents of the flow rather than the flows.
+        self._inside = self._only
 
     def _follows(self, listing: OptionList) -> None:
         """Takes which row the cursor is on off the list, rather than off a row number.
@@ -1147,6 +1155,11 @@ class Flows(Drafts[Chosen]):
         which flow it is -- so that a row remembered under one place cannot be taken for a
         row of the next.
 
+        Only a row that says where it came from, which is what a row of flows is: the list is
+        read as the flows are drawn, and coming back out of a flow draws them while its agents
+        are still the rows -- so an id with no place in it is a row of some other list, and
+        taking it would lose where the cursor was before the walk in.
+
         Args:
           listing: The list.
         """
@@ -1154,15 +1167,15 @@ class Flows(Drafts[Chosen]):
         if at is None or not 0 <= at < listing.option_count:
             return
         named = str(listing.get_option_at_index(at).id or "")
-        if named:
+        if _HALVES in named:
             self._was = named
 
     def _fitted(self, runs: Sequence[Runs]) -> list[Runs]:
         """One row per agent the flow drives, whatever there was to fill it with.
 
         A place nothing was remembered for and nothing falls back on still has a row here:
-        this is the page it is set up on, and a place with no row is a place nobody can
-        answer. What such a row says is that it has not been answered yet.
+        this is where it is set up, and a place with no row is a place nobody can answer. What
+        such a row says is that it has not been answered yet.
 
         Args:
           runs: What there is, in the order the flow takes them.
@@ -1203,8 +1216,7 @@ class Flows(Drafts[Chosen]):
         ]
 
     def _ask(self) -> None:
-        """Says what the menu is, puts up the page it opened on, and catches up on fetches."""
-        self.query_one("#asked", Label).update("Flow")
+        """Puts up whichever of the two it opened on, and catches up on fetches."""
         self._fill()
         self.query_one("#choices", OptionList).focus()
         self._catches_up()
@@ -1224,43 +1236,68 @@ class Flows(Drafts[Chosen]):
         per opening, however it goes, so that a machine with no network says so once rather
         than hammering a server on every keystroke.
         """
-        verses = _hmz().verses
+        import asyncio
 
+        verses = _hmz().verses
         for one in verses.all():
             if not one.url or one.fetched:
                 continue
-            name = one.name
+            self._fetching, self._said = one.name, ""
+            self._fill()
+            try:
+                await asyncio.to_thread(verses.fetch, one.name)
+            except (OSError, ValueError) as why:
+                # Said under the list rather than raised at whoever opened the menu: the
+                # question the menu is asking is still worth answering.
+                self._said = escape(str(why))
+            else:
+                self._offers = None  # a place that has flows in it now
+            self._fetching = ""
+            self._fill()
 
-            def fetching(named: str = name) -> str:
-                verses.fetch(named)
-                return named
+    def _walks(self, *, inside: bool) -> None:
+        """Opens what drives the flow, or comes back out to the flows.
 
-            await self._fetches(name, fetching)
+        What was typed and where the cursor was are left behind either way: the two are
+        different lists, so a search that narrowed one to a row would narrow the other to
+        none -- which reads as a list with nothing in it rather than as a search still on.
 
-    def _turned(self) -> None:
-        """Puts the cursor back on the flow being read when the flows page opens again."""
-        self._said = ""
+        Args:
+          inside: Whether to end up on the agents.
+        """
+        self._inside = inside
+        self._typed, self._searching = "", False
+        self._arming, self._said = "", ""
+        self.query_one("#choices", OptionList).highlighted = 0
+        self._drawn = 0
+        self._fill()
 
     def _fill(self) -> None:
-        """Puts up whichever page is open, and the titles above it."""
+        """Puts up whichever is open: the flows, or the agents of the one walked into."""
+        if self._inside:
+            # Which flow these drive, said where the menu says what it is asking: a list of
+            # agents that did not name its flow would be a list nobody could see they had
+            # opened.
+            self.query_one("#asked", Label).update(escape(self._flow))
+            self.query_one("#about", Label).update(
+                "What each agent it drives is: the CLI that takes its turns, the account "
+                "they run as, and the model at an effort. Enter opens one, and save applies "
+                "the complete flow setup."
+            )
+            self.tabbed("")
+            self._agents_page()
+            return
+        self.query_one("#asked", Label).update("Flow")
         self.query_one("#about", Label).update(
             "Which flow the agents are driven through. The first thing you say once it is "
             "chosen is what it is to do. A flow anywhere else is a path you type."
-            if self._tab == _FLOW_PAGE
-            else f"What each agent {escape(self._flow)} drives is: the CLI that takes its "
-            "turns, the account they run as, and the model at an effort. Enter opens one, "
-            "and save applies the complete flow setup."
         )
-        if self._tab != _FLOW_PAGE:
-            self.tabbed(self._tab_line())
-            self._agents_page()
-            return
-        # The places under the pages, since that is what the list under them is one of: which
-        # is settled before either is drawn, so that the strip and the list agree.
+        # The places, since that is what the list under them is one of: settled before either
+        # is drawn, so that the strip and the list agree.
         wheres = self._stepping()
         if self._where not in wheres:
             self._where = self._opens(wheres)
-        self.tabbed(f"{self._tab_line()}\n{self._where_line(wheres)}")
+        self.tabbed(self._where_line(wheres))
         self._flows_page()
 
     def _all(self) -> list[Offer]:
@@ -1308,13 +1345,13 @@ class Flows(Drafts[Chosen]):
         return found or wheres
 
     def _opens(self, wheres: list[str]) -> str:
-        """Which place is read when the page is drawn without one already being read.
+        """Which place is read when the flows are drawn without one already being read.
 
         Args:
           wheres: The places there are to step between.
 
         Returns:
-          The one the flow in force came from, that being the flow this page is about, and
+          The one the flow in force came from, that being the flow the menu is about, and
           otherwise the first there is.
         """
         return next(
@@ -1364,7 +1401,7 @@ class Flows(Drafts[Chosen]):
         Args:
           by: One place on or back.
         """
-        if self._tab != _FLOW_PAGE:
+        if self._inside:
             return  # the agents of one flow come from nowhere but that flow
         wheres = self._stepping()
         if len(wheres) < 2:  # noqa: PLR2004 -- one place is nowhere to step to
@@ -1425,20 +1462,24 @@ class Flows(Drafts[Chosen]):
             f"[$text-muted]{said}[/]" if said else ""
         )
         self.query_one("#keys", Label).update(
-            f"Enter to choose · f copies it here · Esc to close{self.searching()}"
+            "Enter opens what drives it · f copies it here · v the flowverses · "
+            f"Esc to close{self.searching()}"
         )
 
     def _empty(self, whose: str) -> str:
         """What a place with no flows in it says on the row where its flows would be."""
         verse = self._verse(whose)
         if verse is not None and not verse.fetched:
-            return "not fetched yet; /flowverses fetches it"
+            return "not fetched yet; v opens the flowverses, where r fetches it"
         return "nothing in it yet"
 
     def _nothing(self) -> str:
         """What to say under the flows: how a fetch went, or that a search found nothing."""
         if self._fetching:
-            return f"fetching {escape(self._fetching)}…"
+            said = f"fetching {escape(self._fetching)}…"
+            # And why a key was refused while it runs, where one was: a key that did nothing
+            # and said nothing is a key somebody presses again.
+            return f"{said}{_DOT}{self._said}" if self._said else said
         if self._said:
             return self._said
         if self._typed and not any(self.fits(one.name) for one in self._all()):
@@ -1487,10 +1528,13 @@ class Flows(Drafts[Chosen]):
         self.query_one("#tuning", Label).update(
             f"[$text-muted]{said}[/]" if said else ""
         )
+        # Esc is out of the menu only where there is no list of flows to step back to,
+        # which is while a flow is running: the row says what the key does here.
+        back = "Esc to close" if self._only else "Esc back to the flows"
         self.query_one("#keys", Label).update(
-            "Enter to save · Esc to close"
+            f"Enter to save · {back}"
             if at == len(self._places)
-            else "Enter to set one up · Esc to close"
+            else f"Enter to set one up · {back}"
         )
 
     def _noagents(self) -> str:
@@ -1526,8 +1570,7 @@ class Flows(Drafts[Chosen]):
                 self.changed()
             # And walking out of it leaves the flow set up as the draft has it, which is
             # still a flow to go on and answer the agents of.
-        self._said = ""
-        self._turn_page(1)
+        self._walks(inside=True)
 
     def action_fork(self) -> None:
         """Copies the flow under the cursor into this project's own, to be changed.
@@ -1542,7 +1585,7 @@ class Flows(Drafts[Chosen]):
         """
         from hmz.flows import LOCAL
 
-        if self._tab != _FLOW_PAGE:
+        if self._inside:
             return
         named = self._was.partition(_HALVES)[2]
         if not named:
@@ -1565,34 +1608,39 @@ class Flows(Drafts[Chosen]):
         )
         self._fill()
 
-    async def _fetches(self, named: str, doing: Callable[[], str]) -> None:
-        """Runs one git fetch off the event loop, and shows the list it left behind.
+    @work
+    async def action_verses(self) -> None:
+        """Opens where flows come from, which is a question about the places.
 
-        Off the loop because a clone is seconds of network: a menu that stopped redrawing
-        while it ran would be one that looked as though it had gone away. What is being read
-        is left where it is: this is the flowverse nobody has fetched being fetched because
-        its flows are wanted, rather than somebody asking to be taken to it.
+        A menu of its own rather than three more keys here, and reached from here rather than
+        from a command alone: adding a repository, fetching one again and taking one away are
+        done to the list of places rather than to the flow under the cursor. Its own menu for
+        a second reason as well -- each of those runs git as it is asked for, and something
+        that has already been cloned is not a draft this one could hold until it is saved.
 
-        Args:
-          named: What is being fetched, said under the list while it runs.
-          doing: What to do, answering with the flowverse it left behind.
+        What comes back is a different list of flows, so they are read again, and what
+        happened to the places is said under them.
         """
-        import asyncio
-
+        if self._inside:
+            return  # the agents of one flow come from nowhere but that flow
         if self._fetching:
-            return
-        self._fetching, self._said = named or "it", ""
-        self._fill()
-        try:
-            await asyncio.to_thread(doing)
-        except (OSError, ValueError) as why:
-            # Said under the list rather than raised at whoever opened the menu: the question
-            # this page is asking is still worth answering.
-            self._said = escape(str(why))
-            self._fetching = ""
+            # The menu fetches what has never been fetched as it opens, and the other menu
+            # fetches what it is asked to: two clones of one flowverse land in one directory,
+            # where the second finds the path taken and git's tidying up after itself takes
+            # the first one's work away with it.
+            self._said = "the places open once it is done"
             self._fill()
             return
-        self._fetching, self._offers = "", None
+        showing = cast(
+            "App[None]",
+            self.app,  # pyright: ignore[reportUnknownMemberType]
+        )
+        said = await showing.push_screen_wait(Flowverses())
+        self._offers = None
+        if said:
+            # What happened to the places, said under the flows. Only where something did:
+            # a walk in to look and out again must not wipe what the list was already saying.
+            self._said = said[-1]
         self._fill()
 
     @on(OptionList.OptionSelected)
@@ -1602,7 +1650,7 @@ class Flows(Drafts[Chosen]):
         Args:
           event: What was chosen.
         """
-        if self._tab == _FLOW_PAGE:
+        if not self._inside:
             _, _, name = str(event.option.id or "").partition(_HALVES)
             if name:
                 self._chose(name)
@@ -1670,12 +1718,25 @@ class Flows(Drafts[Chosen]):
         self.changed()
         self._fill()
 
+    def leaving(self) -> None:
+        """Comes back out to the flows, or asks about the draft once there is nowhere back.
+
+        Esc is one step back everywhere in this interface, and walking into a flow is a step:
+        leaving outright from the agents would throw away the walk in along with the menu.
+        There is no step back out of a menu that opened inside one -- while a flow runs, and
+        on a flow that was named rather than picked -- so esc there is esc on the menu.
+        """
+        if self._inside and not self._only:
+            self._walks(inside=False)
+            return
+        super().leaving()
+
     def applied(self) -> None:
         """Answers with the flow, its agents and how it is set up, all of it at once.
 
         Unless one of them has not been answered: a flow driven by an agent that names no
-        model is a flow that stops on its first turn, and the page it would be answered on is
-        the page to be looking at when that is said.
+        model is a flow that stops on its first turn, and where it would be answered is what
+        to be looking at when that is said.
         """
         missing = [
             called(self._places, at)
@@ -1683,8 +1744,11 @@ class Flows(Drafts[Chosen]):
             if not _complete(one)
         ]
         if missing:
-            self._tab = _AGENT_PAGE
             telemetry.snag("save-refused", missing=len(missing))
+            if not self._inside:
+                # Refused from the flows, on the way out: the agents are what is to be looked
+                # at, and the cursor was on a row of another list.
+                self._walks(inside=True)
             self._said = f"{escape(', '.join(missing))} has no model yet"
             self._fill()
             return
@@ -1799,14 +1863,17 @@ class Holds(Sheet[None]):
 class Flowverses(Sheet[list[str]]):
     """The places flows come from: what there is, what one holds, and what can happen to one.
 
-    Its own menu rather than keys on the one a flow is chosen at. Adding a repository,
-    fetching one again and taking one away are things done to the list of places rather than
-    to the flow under the cursor, and a sheet that asks `which flow` with three keys on it
-    about something else is a sheet asking two questions. `/flow` still steps between the
-    places with the arrows, that being about which list of flows is being read.
+    Walked to from the menu a flow is chosen at, on `v`, and opened by `/flowverses` -- which
+    is the way in while a flow is running, the flows not being offered then. Its own sheet
+    rather than a deeper view of that menu: adding a repository, fetching one again and taking
+    one away each run git as they are asked for, and something that has already been cloned is
+    not a draft the flow menu could hold until it is saved.
 
-    What happens here happens as it is asked for rather than being held until the menu is
-    saved: each of these runs git, and something that has already been cloned is not a draft.
+    Its own sheet rather than three more keys on the flows for the same reason it is a walk
+    away from them: what happens here happens to the list of places rather than to the flow
+    under the cursor, and a sheet that asks `which flow` with three keys on it about something
+    else is a sheet asking two questions. Stepping between the places stays with the flows,
+    that being about which list of flows is being read.
     """
 
     LETTERS: ClassVar = frozenset({"search", "adding", "refresh", "drop"})
@@ -1830,7 +1897,8 @@ class Flowverses(Sheet[list[str]]):
         self._said = ""
         #: What is being fetched now, so that a second fetch is not started over it.
         self._fetching = ""
-        #: What is worth saying in the transcript once this menu is done with.
+        #: What is worth saying again once this menu is done with, as the menu said it:
+        #: whoever opened it says it where they say things, which is not always a transcript.
         self._told: list[str] = []
 
     def _ask(self) -> None:
@@ -1980,7 +2048,7 @@ class Flowverses(Sheet[list[str]]):
             self._fill()
             return
         self._said = f"{escape(one.name)} is no longer here"
-        self._told.append(f"[dim]{escape(one.name)} is no longer here[/dim]")
+        self._told.append(self._said)
         self._was = ""
         self._read()
         self._fill()
@@ -2011,7 +2079,7 @@ class Flowverses(Sheet[list[str]]):
             return
         self._fetching = ""
         self._said = f"{escape(name)} is fetched"
-        self._told.append(f"[dim]{escape(name)} is fetched[/dim]")
+        self._told.append(self._said)
         self._read()
         self._was = name
         self._fill()
@@ -4947,7 +5015,6 @@ class Fallbacks(Drafts[list[str]]):
     said in `/providers` where the accounts are.
     """
 
-    TABS: ClassVar = ("Fallback",)
     LETTERS: ClassVar = frozenset({"search", "adding", "drop"})
 
     BINDINGS: ClassVar = [
@@ -5365,13 +5432,10 @@ class Providers(Drafts[list[str]]):
     never a value: this is drawn where somebody can read it.
     """
 
-    TABS: ClassVar = ("Providers",)
     LETTERS: ClassVar = frozenset({"search", "adding", "drop"})
 
     BINDINGS: ClassVar = [
         ("escape", "back", "back"),
-        Binding("tab", "next_tab", "next page", priority=True),
-        Binding("shift+tab", "prev_tab", "previous page", priority=True),
         Binding("s", "search", "search", priority=True),
         Binding("a", "adding", "make one", priority=True),
         Binding("d", "drop", "take one away", priority=True),

--- a/tests/tui/test_agent_sheet.py
+++ b/tests/tui/test_agent_sheet.py
@@ -145,7 +145,7 @@ def _value(app: Humanize, held: str) -> str:
 
 
 async def _open(app: Humanize, driver: Pilot[None], flow: str) -> None:
-    """Opens the flow menu already holding one flow, and turns to its agents."""
+    """Opens the flow menu on one flow -- which is inside it -- and then one of its agents."""
     await driver.press(*f"/flow {flow}")
     await driver.press("enter")
     await until(lambda: isinstance(app.screen, Flows), driver)
@@ -185,15 +185,16 @@ async def test_two_agents_are_two_rows_and_a_sheet_apiece(
     _installed: unittest.mock.MagicMock,  # noqa: PT019  -- `mock.patch` hands it over
     flows: Path,
 ) -> None:
-    """The page lists what the flow drives, by the name the flow calls each of them."""
+    """Opening a flow lists what it drives, by the name the flow calls each of them."""
     app = Humanize()
     async with app.run_test() as driver:
         await driver.press(*"/flow pair")
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Flows), driver)
         sheet = cast("Flows", app.screen)
-        await driver.press("tab")
-        await until(lambda: sheet._tab == 1, driver)
+        # A menu opened already naming a flow opens inside it: the flow has been named, so
+        # what is left to answer is what drives it.
+        await until(lambda: sheet._inside, driver)
         listing = sheet.query_one("#choices", OptionList)
         await until(lambda: len(listing.options) == 3, driver)
 
@@ -268,9 +269,9 @@ async def test_explicit_flow_save_refuses_an_agent_with_no_model(
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Flows), driver)
         sheet = cast("Flows", app.screen)
-        if sheet._tab != 1:
-            await driver.press("tab")
-            await until(lambda: sheet._tab == 1, driver)
+        if not sheet._inside:
+            await driver.press("enter")
+            await until(lambda: sheet._inside, driver)
 
         await onto(app, driver, "save")
         await driver.press("enter")

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -31,6 +31,7 @@ from hmz.tui.pick import (
     Alike,
     Catalogue,
     Clis,
+    Configures,
     Confirms,
     Flows,
     Monitoring,
@@ -196,10 +197,10 @@ async def onto(app: Humanize, driver: Pilot[None], held: str) -> None:
 
 
 async def into_agent(app: Humanize, driver: Pilot[None], at: int = 0) -> None:
-    """Turns the flow menu to its agents and opens one of them.
+    """Opens the flow the menu is on, and then one of the agents it drives.
 
     Which every test about what an agent is has to walk through: an agent of a flow is set up
-    from the flow that drives it, on the page of the menu that is about them.
+    from the flow that drives it, inside the flow it belongs to.
 
     Args:
       app: The interface.
@@ -208,9 +209,15 @@ async def into_agent(app: Humanize, driver: Pilot[None], at: int = 0) -> None:
     """
     await until(lambda: isinstance(app.screen, Flows), driver)
     sheet = cast("Flows", app.screen)
-    if sheet._tab != 1:
-        await driver.press("tab")
-        await until(lambda: sheet._tab == 1, driver)
+    if not sheet._inside:
+        await driver.press("enter")  # which opens what drives the flow under the cursor
+        # A flow that takes settings of its own puts them up on the way in, that being the
+        # moment it is chosen. Esc leaves them exactly as the draft has them, which is what a
+        # walk that is about the agents wants.
+        await until(lambda: sheet._inside or isinstance(app.screen, Configures), driver)
+        if isinstance(app.screen, Configures):
+            await driver.press("escape")
+        await until(lambda: sheet._inside, driver)
     await until(
         lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
     )
@@ -232,6 +239,30 @@ async def opens(app: Humanize, driver: Pilot[None], held: str) -> None:
     await driver.pause()
 
 
+async def _leaves(app: Humanize, driver: Pilot[None], *answer: str) -> None:
+    """Leaves the sheet on top, answering whatever it asks about what it is holding.
+
+    Esc twice where the first press was a step back rather than the way out: the flow menu is
+    walked into, so esc on the agents of a flow comes back to the flows and the press that
+    leaves the menu is the one after it.
+
+    Args:
+      app: The interface.
+      driver: What is pumping it.
+      answer: What to press on the question about what it is holding, where it asks one.
+    """
+    was = app.screen
+    inside = was._inside if isinstance(was, Flows) else False
+    await driver.press("escape")
+    await driver.pause()
+    if inside and isinstance(app.screen, Flows) and not app.screen._inside:
+        await driver.press("escape")
+        await driver.pause()
+    if isinstance(app.screen, Confirms):
+        await driver.press(*answer)
+    await until(lambda: app.screen is not was, driver)
+
+
 async def keeps(app: Humanize, driver: Pilot[None]) -> None:
     """Leaves the sheet on top, saving what it is holding when it asks.
 
@@ -242,12 +273,7 @@ async def keeps(app: Humanize, driver: Pilot[None]) -> None:
       app: The interface.
       driver: What is pumping it.
     """
-    was = app.screen
-    await driver.press("escape")
-    await driver.pause()
-    if isinstance(app.screen, Confirms):
-        await driver.press("enter")
-    await until(lambda: app.screen is not was, driver)
+    await _leaves(app, driver, "enter")
 
 
 async def drops(app: Humanize, driver: Pilot[None]) -> None:
@@ -257,13 +283,7 @@ async def drops(app: Humanize, driver: Pilot[None]) -> None:
       app: The interface.
       driver: What is pumping it.
     """
-    was = app.screen
-    await driver.press("escape")
-    await driver.pause()
-    if isinstance(app.screen, Confirms):
-        await driver.press("down")
-        await driver.press("enter")
-    await until(lambda: app.screen is not was, driver)
+    await _leaves(app, driver, "down", "enter")
 
 
 @pytest.mark.timeout(60)
@@ -621,11 +641,11 @@ async def test_the_offer_is_taken_from_the_commands_there_actually_are() -> None
 async def test_what_is_running_is_not_swapped_underneath_itself(
     workspace: Path,
 ) -> None:
-    """A flow is chosen in order to be started, so that page is shut while one is running.
+    """A flow is chosen in order to be started, so the flows are not offered while one runs.
 
-    Shut rather than gone: it says what it is and that it cannot be opened, which is what the
-    strike through its title is. The page its agents are set up on is never shut -- an agent
-    thinking too little is found out halfway through a run.
+    The menu opens inside the agents of the flow that is going -- an agent thinking too little
+    is found out halfway through a run -- and esc there leaves, there being no list of flows
+    behind it to step back to.
     """
     written(workspace, "flow", FLOW)
     app = Humanize()
@@ -643,12 +663,10 @@ async def test_what_is_running_is_not_swapped_underneath_itself(
         await until(lambda: isinstance(app.screen, Flows), driver)
         sheet = cast("Flows", app.screen)
 
-        assert sheet.turnable() == (False, True)
-        assert sheet._tab == 1  # it opens on the page that is not shut
-        assert "[s]Flow[/s]" in str(sheet.query_one("#tabs", Label).content)
-        await driver.press("shift+tab")  # and there is nowhere to turn to
-        await driver.pause()
-        assert sheet._tab == 1
+        assert sheet._inside  # it opens on the agents, the flows not being offered
+        # And nothing draws the places, which are about which list of flows is being read.
+        assert not str(sheet.query_one("#tabs", Label).content)
+        assert "Esc to close" in str(sheet.query_one("#keys", Label).content)
 
         await driver.press("escape")
         await until(lambda: not isinstance(app.screen, Flows), driver)
@@ -1024,11 +1042,11 @@ async def test_a_turn_that_has_gone_quiet_still_reads_as_one_that_is_running() -
 
 
 @pytest.mark.timeout(60)
-async def test_the_flow_and_its_agents_are_two_pages_of_one_menu() -> None:
-    """Two questions about one thing, turned between rather than walked through.
+async def test_a_flow_is_opened_to_reach_its_agents_and_esc_comes_back() -> None:
+    """One menu walked into, which is what enter and esc mean everywhere else here.
 
-    Esc off the second is out of the menu rather than back into the first: turning between
-    them is what tab and shift+tab are for.
+    Not two pages: a flow is picked out of a list and its agents are that flow's, so tab is
+    not what steps between them -- it would read as a view that had been there all along.
     """
     app = Humanize()
     # Whatever this machine has installed, since the menu is only put up if there is one.
@@ -1039,23 +1057,92 @@ async def test_the_flow_and_its_agents_are_two_pages_of_one_menu() -> None:
         async with app.run_test() as driver:
             await into_flows(app, driver)
             sheet = cast("Flows", app.screen)
-            tabs = str(sheet.query_one("#tabs", Label).content)
-            assert "Flow" in tabs
-            assert "Agents" in tabs
-            assert "tab/shift+tab to switch" in tabs
+            assert "chat" in rows(app)[0]  # the flows, one place at a time
+            assert "Enter opens what drives it" in str(
+                sheet.query_one("#keys", Label).content
+            )
 
+            # Tab is not a key of this menu at all: it turns nothing, and nothing moves.
             await driver.press("tab")
-            await until(lambda: sheet._tab == 1, driver)
-            assert "[b $primary]Agents" in str(sheet.query_one("#tabs", Label).content)
+            await driver.pause()
+            assert not sheet._inside
 
-            await driver.press("shift+tab")
-            await until(lambda: sheet._tab == 0, driver)
-            assert "[b $primary]Flow" in str(sheet.query_one("#tabs", Label).content)
+            await driver.press("enter")
+            await until(lambda: sheet._inside, driver)
+            assert rows(app) == [
+                "0",
+                "save",
+            ]  # what the flow drives, and saving the lot
+            assert "chat" in str(sheet.query_one("#asked", Label).content)
+            assert "Esc back to the flows" in str(
+                sheet.query_one("#keys", Label).content
+            )
+
+            await driver.press("escape")
+            await until(lambda: not sheet._inside, driver)
+            assert app.screen is sheet  # one step back, and not out of the menu
+            assert "chat" in rows(app)[0]
 
             await driver.press("escape")
             await until(lambda: not isinstance(app.screen, Flows), driver)
 
             assert app._models == []
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    ("said", "sheet"),
+    [
+        pytest.param("/fallback", "Fallbacks", id="fallback"),
+        pytest.param("/providers", "Providers", id="providers"),
+    ],
+)
+async def test_a_menu_of_one_page_draws_no_strip_of_titles(
+    said: str, sheet: str
+) -> None:
+    """One title is nowhere to turn to, so the row it would take is a row nobody paid for.
+
+    The strip is for pages that are turned between: a terminal has only so many rows, and the
+    keys are what falls off the bottom of a short one.
+    """
+    import hmz.tui.pick as sheets
+
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*said)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, getattr(sheets, sheet)), driver)
+
+        tabs = app.screen.query_one("#tabs", Label)
+
+        assert not str(tabs.content)
+        assert not tabs.display  # gone rather than blank: a blank row is still a row
+
+
+@pytest.mark.timeout(60)
+async def test_two_views_of_one_question_are_still_turned_between() -> None:
+    """What tab is for, which is why what is walked into does not take it.
+
+    `/settings` is two scopes of one question -- everywhere, and here -- and either may be
+    read first, so neither is reached by picking the other.
+    """
+    from hmz.tui.pick import Adjusts
+
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/settings")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Adjusts), driver)
+        sheet = app.screen
+        assert isinstance(sheet, Adjusts)
+        assert "tab/shift+tab to switch" in str(sheet.query_one("#tabs", Label).content)
+
+        await driver.press("tab")
+        await until(lambda: sheet._tab == 1, driver)
+
+        assert "[b $primary]This directory" in str(
+            sheet.query_one("#tabs", Label).content
+        )
 
 
 #: A `claude` that stops to ask before it answers, as the real one does when it reaches for

--- a/tests/tui/test_config.py
+++ b/tests/tui/test_config.py
@@ -22,7 +22,7 @@ from hmz.tui.pick import Agent, Configures, Flows, setting
 from hmz.tui.selecting import Transcript
 from tests.stubs import written
 
-from .test_app import into_agent, keeps, onto
+from .test_app import into_agent, keeps, onto, rows
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -190,7 +190,7 @@ async def test_setting_up_comes_between_the_flow_and_its_agents(flows: Path) -> 
             await until(lambda: isinstance(app.screen, Flows), driver)
             sheet = app.screen
             assert isinstance(sheet, Flows)
-            await until(lambda: sheet._tab == 1, driver)
+            await until(lambda: sheet._inside, driver)
             await into_agent(app, driver)
             assert isinstance(app.screen, Agent)
 
@@ -207,7 +207,7 @@ async def test_a_flow_that_takes_no_setting_up_is_not_asked_about(flows: Path) -
             await _set_up(app, driver, "plain")
             sheet = app.screen
             assert isinstance(sheet, Flows)
-            await until(lambda: sheet._tab == 1, driver)
+            await until(lambda: sheet._inside, driver)
 
             assert isinstance(
                 app.screen, Flows
@@ -451,8 +451,13 @@ async def test_a_flow_that_groups_nothing_is_one_list(flows: Path) -> None:
 
 
 @pytest.mark.timeout(60)
-async def test_agents_does_not_ask_how_the_flow_is_set_up(flows: Path) -> None:
-    """The two are split: the flow's own settings are a key, its agents are a page."""
+async def test_the_agents_are_not_where_the_flow_itself_is_set_up(flows: Path) -> None:
+    """The two are split: what the flow takes is asked as it is opened, and only there.
+
+    Opening a flow is choosing it, so its own settings are what comes up on the way in -- and
+    what drives it, which is what is under them, says nothing about them. Two answers to one
+    question is one of them being wrong.
+    """
     app = Humanize()
     with unittest.mock.patch(
         "hmz.tui.app.installed",
@@ -470,13 +475,15 @@ async def test_agents_does_not_ask_how_the_flow_is_set_up(flows: Path) -> None:
             await driver.press("enter")
             await into_agent(app, driver)
 
-            # Straight to what the agent is, with nothing about the flow itself on the way.
+            # What the agent is, and not one row of what the flow itself takes.
             assert isinstance(app.screen, Agent)
+            assert "loud" not in rows(app)
+            assert "rounds" not in rows(app)
 
 
 @pytest.mark.timeout(60)
-async def test_agents_leaves_how_the_flow_is_set_up_alone(flows: Path) -> None:
-    """A question it did not ask is one it must not answer, either -- even by keeping it."""
+async def test_walking_past_how_the_flow_is_set_up_leaves_it_alone(flows: Path) -> None:
+    """Esc off the settings changes nothing: a walk to the agents is not an answer to them."""
     app = Humanize()
     with unittest.mock.patch(
         "hmz.tui.app.installed",

--- a/tests/tui/test_flowverses.py
+++ b/tests/tui/test_flowverses.py
@@ -281,9 +281,9 @@ async def test_the_flow_that_is_picked_is_the_one_that_was_chosen(theirs: Path) 
         await until(lambda: _rows(sheet) == ["theirs/loop"], driver)
 
         await driver.press("enter")
-        await until(lambda: sheet._tab == 1, driver)
+        await until(lambda: sheet._inside, driver)
 
-        # On to what it runs, which is the page beside it, holding that flow's own agents.
+        # And into what it runs, which is that flow's own agents.
         assert sheet._flow == "theirs/loop"
 
 
@@ -356,7 +356,7 @@ async def test_one_of_the_flows_a_file_holds_is_chosen_like_any_other(
         await driver.press("enter")
 
         # On to what that flow drives, rather than a refusal that the file has no `run`.
-        await until(lambda: sheet._tab == 1, driver)
+        await until(lambda: sheet._inside, driver)
         await into_agent(app, driver)
         assert isinstance(app.screen, Agent)
         assert "builder" in str(app.screen.query_one("#asked", Label).content)
@@ -390,12 +390,12 @@ async def test_each_of_them_is_set_up_with_its_own_settings(
 
         # And the one beside it takes nothing, so choosing it asks nothing.
         await driver.press("escape")
-        await until(lambda: sheet._tab == 1, driver)
-        await driver.press("shift+tab")
-        await until(lambda: sheet._tab == 0, driver)
+        await until(lambda: sheet._inside, driver)
+        await driver.press("escape")
+        await until(lambda: not sheet._inside, driver)
         await onto(app, driver, "local\x1flocal/three:rlcr")
         await driver.press("enter")
-        await until(lambda: sheet._tab == 1, driver)
+        await until(lambda: sheet._inside, driver)
 
         assert isinstance(app.screen, Flows)
 

--- a/tests/tui/test_flowverses_menu.py
+++ b/tests/tui/test_flowverses_menu.py
@@ -21,7 +21,7 @@ from textual.widgets import Label, OptionList
 from hmz.flows import LOCAL, OFFICIAL, USER, flowverses
 from hmz.flows import verses as store
 from hmz.tui import Humanize
-from hmz.tui.pick import Fetches, Flowverses, Holds
+from hmz.tui.pick import Fetches, Flows, Flowverses, Holds
 from tests.stubs import written
 
 from .test_app import onto, rows, until
@@ -320,3 +320,73 @@ async def test_what_happened_while_it_was_open_is_said_in_the_transcript(
         await until(lambda: not isinstance(app.screen, Flowverses), driver)
 
         assert "theirs is no longer here" in _transcript(app)
+
+
+@pytest.mark.timeout(60)
+async def test_the_places_are_walked_to_from_the_flows(theirs: Path) -> None:
+    """`v` on the flows opens them, and esc comes back to the list it was opened from.
+
+    Which is where somebody is when they want them: a flow that is not in the list is a place
+    that has not been added yet, and a menu reached only by a command they must already know
+    about is a menu they do not reach. What happened to the places is said under the flows,
+    since the flows are a different list afterwards.
+    """
+    store.add(str(theirs))
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/flow")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Flows), driver)
+        menu = app.screen
+        assert isinstance(menu, Flows)
+
+        await driver.press("v")
+        await until(lambda: isinstance(app.screen, Flowverses), driver)
+        assert rows(app) == ["builtin", OFFICIAL, "theirs", LOCAL, USER]
+
+        await onto(app, driver, "theirs")
+        await driver.press("d")
+        await driver.press("d")
+        await until(
+            lambda: (
+                "no longer here" in str(app.screen.query_one("#tuning", Label).content)
+            ),
+            driver,
+        )
+        await driver.press("escape")
+        await until(lambda: app.screen is menu, driver)
+
+        assert not menu._inside  # back on the flows, which is where `v` was pressed
+        assert "theirs is no longer here" in str(
+            menu.query_one("#tuning", Label).content
+        )
+        assert "theirs" not in str(menu.query_one("#tabs", Label).content)
+
+
+@pytest.mark.timeout(60)
+async def test_the_places_do_not_open_over_a_fetch_the_flows_started() -> None:
+    """Two clones of one flowverse land in one directory, and the loser takes the winner's.
+
+    The flows fetch whatever has never been fetched as they open, and the places fetch what
+    they are asked to. Both at once is git refusing the second for finding the path taken, and
+    tidying up after that failure takes the first one's work away with it.
+    """
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/flow")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Flows), driver)
+        menu = app.screen
+        assert isinstance(menu, Flows)
+        menu._fetching = OFFICIAL  # as catching up on fetches leaves it while it runs
+        menu._fill()
+
+        await driver.press("v")
+        await until(
+            lambda: (
+                "open once it is done" in str(menu.query_one("#tuning", Label).content)
+            ),
+            driver,
+        )
+
+        assert app.screen is menu  # and nothing opened over it

--- a/tests/tui/test_quick_flow.py
+++ b/tests/tui/test_quick_flow.py
@@ -124,15 +124,17 @@ async def sends(app: Humanize, driver: Pilot[None], line: str) -> None:
 
 
 async def saves(app: Humanize, driver: Pilot[None]) -> None:
-    """Saves the flow menu from the row that says so, which is on its agents page.
+    """Saves the flow menu from the row that says so, which is the last of its agents'.
+
+    A menu opened on a flow that was named opens inside it, there being nothing left to
+    choose, so the row is already there to walk to.
 
     Args:
       app: The interface.
       driver: What is pumping it.
     """
     sheet = cast("Flows", app.screen)
-    await driver.press("tab")
-    await until(lambda: sheet._tab == 1, driver)
+    await until(lambda: sheet._inside, driver)
     await opens(app, driver, "save")
     await until(lambda: not isinstance(app.screen, Flows), driver)
 


### PR DESCRIPTION
## What the user asked for

> *flow里面，flow和agents是深入关系而不是平行关系，不允许用tab来切换，进入深入一点的菜单想返回应该是esc，同时审计一下其它菜单是否类似问题都修复*
>
> */flowverses 菜单改为flows的子菜单*

## (a) The flow and its agents are a walk in, not two tabs

`/flow` was `TABS = ("Flow", "Agents")` with tab and shift+tab turning between them. Now:

- **enter** on a flow opens what drives it; **esc** comes back to the flows. Tab is not a key
  of that menu at all — pressing it does nothing, and the app's own tab (step between agent
  transcripts) is untouched, since it is already refused while a sheet is up.
- The sheet says where you are: the title is `Flow` on the list and the flow's own name inside
  it, and the keys row says `Esc back to the flows`.
- It is still **one menu**: walking in or out applies nothing, and the whole of it lands from
  the `save` row or from the save/discard box on the way out. That is why the agents are a view
  of the same sheet rather than a pushed screen — a child sheet would have had to either ask
  about saving twice or hold a draft it does not own.

**Esc leaves outright where there is nothing behind the agents to step back to**, which is two
cases, and telling them apart was the one real bug in the first cut of this branch:

- while a flow is running, choosing one is not offered at all (unchanged rule, new shape: the
  menu opens inside the agents rather than on a struck-through tab);
- a menu opened already naming a flow — `/flow <name>`, and `$flow ...` for a flow this
  workspace has never set up — was answered on the line that named it, and a flow named as a
  path is not in the list to be chosen from at all. Stepping "back" to a list nobody walked
  through would have swallowed the line typed to start something.

### The audit, as asked

| Menu | Verdict |
| --- | --- |
| `/settings` — `Everywhere` · `This directory` | **Parallel pages, tab is right, kept.** Two scopes of one question; either may be read first, and neither is reached by picking the other. |
| `/fallback` — `TABS = ("Fallback",)` | A strip of one title is a row offering nowhere to turn to. **Removed.** |
| `/providers` — `TABS = ("Providers",)` | Same, and it also bound tab/shift+tab to a page turn that could never fire. **Both removed.** |

## (b) Where flows come from is now a submenu of the flows

**v** on the flows opens it, and esc comes back. That is where somebody is when they want it: a
flow that is not in the list is a place that has not been added.

**It stays a sheet of its own rather than becoming a page of the flow menu, and `/flowverses`
stays a command.** That is the honest answer to the obstacle in the brief:

- The flow menu is a `Drafts`: it holds everything until it is saved. Adding a place, fetching
  one again and taking one away each run git the moment they are asked for. A page of that menu
  doing them would be one part of a sheet breaking the contract the whole sheet advertises. The
  rule the two now follow is statable: **what is held as a draft stays in one sheet; what acts
  as it is asked for is its own sheet.** Both read the same from the keyboard — enter in, esc
  back.
- **Should `/flowverses` the command be dropped?** (Unit 3's call.) My recommendation: **keep
  it.** The key belongs to the flows, and there are no flows while one is running — so the
  command is the only way in mid-run, and the spec is explicit that fetching a place then is
  allowed. Dropping it would make the menu unreachable for the length of a run.
- The duplicated `_fetches` coroutine is collapsed by deleting the flow menu's copy: the only
  fetch it still runs is the catch-up nobody asked for, now inlined into `_catches_up`, and
  everything a person asks of a flowverse happens in the menu `v` opens.

**One race the merge exposed:** `v` is refused while the flow menu's own catch-up fetch is
running, and says so under the list. Two clones of one place land in one directory, git refuses
the second for finding the path taken, and `verses.clone()` tidies up after that failure with
`shutil.rmtree` — taking the first one's work with it. (A cleaner fix lives in the flow layer:
clone into a temp directory and rename. That is unit 6's file, so this branch guards at the
menu.)

## Specs and docs

- `specs/tui.md` §The keys now distinguishes **parallel pages** (tab) from **what is reached by
  picking something** (enter in, esc back), and says why: a tab between two views of one
  question is orientation; a tab between a list and the thing picked out of it reads as a view
  that was there all along, so which thing was picked is a thing nobody can see they chose. It
  also says a menu of one page MUST NOT draw a strip.
- §Which flow, and what drives it, §What lands and when, §Where flows come from, and the `$`
  rules are rewritten to match.
- `docs/reference/tui.md`, `docs/weaver/flowverses.md`, `docs/weaver/loops.md`,
  `docs/weaver/flow-settings.md`, `docs/user/settings.md`, `docs/index.md` and every other page
  that said "the Agents page of `/flow`".
- `docs/tapes/flowverses.tape` still describes reality — `/flowverses` opens the same sheet —
  and is left recording the command rather than `v`, because opening the flows fetches whatever
  has never been fetched and the tape's container reaches no network. Said in its header.

## One consequence worth knowing about

With tab gone there is no longer a route to a flow's agents that skips the flow's own settings
sheet: opening a flow **is** choosing it, so a flow that takes settings puts them up on the way
in (esc leaves them exactly as they were). That keeps "choosing the flow again is how you answer
its settings again" true, which is what the docs promise. Two tests in `test_config.py` were
asserting the old tab route and now assert the walk.

## Verification

- `uv run pre-commit run --all-files` — ruff, ruff format, pyright strict: pass.
- `uv run pytest` — full suite.
- Headless pilot tests for each behaviour: entering a flow opens its agents, esc comes back, tab
  turns nothing, the agents are reachable and saveable while a flow runs, the places are walked
  to from the flows and report back under them, `v` is refused over a running fetch, and the
  single-page sheets draw no strip while `/settings` still turns on tab.
- **A real run**: `hmz` in a temp directory, walked `/flow` → a flow → an agent → back → `v` →
  what a place holds → back, four levels deep, confirming esc always steps exactly one and the
  save/discard box appears only on the way out of the menu. Also `/flow chat` (opens inside,
  esc leaves) and `s` + typing `v` (falls through to the search rather than opening the places).

## Noticed, not touched

- Dropping a flowverse while the flow menu holds a draft flow from that place leaves a draft
  naming a flow that no longer loads. The menu already says so where its agents would be, and
  this was already reachable through `/flowverses`; left alone.
- `Sheet.turnable()` and the struck-through title it draws now have no user in the tree —
  `/settings`' two pages are both always open. Kept: the spec still requires it of a page that
  may not be opened.
- `docs/weaver/loops.md` was quoting a refusal message `/flow` has not printed for a while
  (`no choosing a flow while a flow is running: ctrl+c twice stops it first`). Corrected here
  since the surrounding paragraph had to change anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
