### PR TITLE
refactor(tui)!: taking one away belongs where one is opened

### DIFF
--- a/docs/reference/flows.md
+++ b/docs/reference/flows.md
@@ -995,8 +995,8 @@ whatever you put there. They are listed as flowverses all the same, so that one 
 a flow is called and one list says where they are. `add`, `fetch` and `remove` all refuse them.
 
 In the [interface](/reference/tui), `/flowverses` is where they live: `a` adds one, `r` fetches
-the one under the cursor again, `d` twice takes an added one away, and enter says what one
-holds. Adding one takes a URL or an `owner/repo`, and a name to keep it under if the
+the one under the cursor again, and enter says what one holds — and, past the flows, takes the
+whole place away. Adding one takes a URL or an `owner/repo`, and a name to keep it under if the
 repository's own name is not the one you want. `/flow` keeps the two keys that are about flows
 rather than about places: left and right, which walk these same places because that is which
 list of flows is being read, and `f`, which copies the flow under the cursor into this project.

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -211,14 +211,15 @@ make, sign in or take away.
 
 `/providers` is where all of this happens. **a** makes one — which CLI, then how to sign in,
 then what that way asks, three questions rather than one form because each is only answerable
-once the one before it has been. **d** twice takes one away, credentials and all. **enter**
-opens what else can be done to the one under the cursor:
+once the one before it has been. **enter** opens what else can be done to the one under the
+cursor:
 
 | | |
 | --- | --- |
 | **correct what it holds** | The answers its way in was made with, asked again. What it holds is replaced rather than merged and the credentials a login left in its directory are left alone: a key corrected is not a reason to sign in again. |
 | **sign in again** | The backend's own way in, run again under this account's paths — for a way that has a command of its own. For one that is only answers, correcting it is what there is. |
 | **falls back to** | Which account of that CLI a turn carries on under when this one fails, or nothing at all for an account that is the end of the line. |
+| **take it away** | The account and its credentials, when the accounts menu is saved. One already marked to go says **keep it after all** instead: nothing has happened to it yet. |
 
 How many times over a failed turn is taken again is not among them: that is a thing about the
 place a turn runs at rather than about the credentials it runs with, and

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -152,7 +152,7 @@ list appears under the editor with a line about each.
 | `/flowverses` | | [Where flows come from](/weaver/flowverses): what places there are, what one of them holds, and one added, fetched again or taken away. Not which flow to run — that is `/flow`, where the arrows step between the same places. |
 | `/epics` | | The runs of this directory, newest first: what each was, how it went, and what there is to do with one — gather its [trace](/user/tracing), [export it](/user/export), say where it is written, and carry it on where its flow says it can be picked up. |
 | `/resume` | | Carries [the last run here](#carrying-the-last-one-on-outright) on: that run's own flow, on its own agents, with what it was asked to do, and on what it left behind. The same thing `/epics` offers of the run under its cursor, without the list — there is only ever one last run. Where there is nothing to carry on from it says which reason that is. |
-| `/providers` | | [The accounts](#the-accounts-themselves) an agent may be run as: what there is, and what can happen to one — made, taken away, and, on enter, corrected, signed in again, or pointed at what it falls back to. How often a failed turn is taken again is not here: that is said of a [place](#where-a-turn-goes-when-it-cannot-be-taken) rather than of an account. |
+| `/providers` | | [The accounts](#the-accounts-themselves) an agent may be run as: what there is, and what can happen to one — made, and, on enter, corrected, signed in again, pointed at what it falls back to, or taken away. How often a failed turn is taken again is not here: that is said of a [place](#where-a-turn-goes-when-it-cannot-be-taken) rather than of an account. |
 | `/settings` | | [What humanize remembers](#what-humanize-remembers): two pages, one for what is true of this machine and one for what is remembered about this directory. |
 | `/monitor` | | [The run, drawn](#watching-the-run): a box per agent that has worked, marked as it works and saying how long it has been at it, with the handovers between them as the arrows joining them, whatever each started of its own hanging under it, and [the board](/user/board) below. Enter reads an agent or changes a line. **esc** opens it. |
 | `/btw` | `<question>` | Asks a side question about the running flow from a read-only snapshot of its progress. It runs in a separate session and never steers the flow. |
@@ -380,8 +380,10 @@ fleet too long to draw is cut, with a line saying how many were left off.
 
 **The board is under the diagram**, for a flow that talks to you: the named lines you and the
 flow both write on, and neither waits at. `a` puts one up — a name, then what it says — enter
-changes the one under the cursor, and `d` twice takes it off. A line the flow keeps to itself
-says so instead of opening an editor. See [The mission board](/user/board).
+changes the one under the cursor, and `d` twice takes it off — the one taking-away still on a
+key, because enter on a line opens the words of that line rather than a menu with a row to
+spare, and it lands the moment it is pressed. A line the flow keeps to itself says so instead
+of opening an editor. See [The mission board](/user/board).
 
 **Enter or a click on a box reads that agent** — whether or not it is working. tab is held to
 the ones thinking, so this is the one place an agent that has stopped is reached. The box under
@@ -612,15 +614,20 @@ URL marked as not fetched yet](/demo/flowverses.png)
 
 | Key | |
 | --- | --- |
-| **enter** | What that flowverse holds: one row per flow, with the line it says about itself. Reading them means importing them, so it is asked of the one you opened rather than of all of them at once. |
+| **enter** | What that flowverse holds: one row per flow, with the line it says about itself, and past them the row that takes the flowverse away. Reading the flows means importing them, so it is asked of the one you opened rather than of all of them at once. |
 | **a** | Add one: a URL or an `owner/repo`, and a name to keep it under. |
 | **r** | Fetch the one under the cursor again, or for the first time. `builtin` came with humanize, and `local` and `user` are directories of your own: all three say there is nothing to fetch. |
-| **d** **d** | Take an added one away, flows and all. `builtin`, `official`, `local` and `user` are always here, and say so. |
 
-Its own menu rather than three more keys on `/flow`, because they are about something else:
-adding a repository, fetching one again and taking one away are done to the list of places,
-while the page they were on is asking which flow to run — and a sheet that asks one question
-with three keys about another is a sheet asking two.
+**Taking one away is inside what it holds**, rather than a key on the list. What a flowverse
+*is*, is what is in it, so the decision to be rid of one is made where that has just been read
+— and the row is past the end of the flows, out of their numbering, because it is about the
+place rather than about anything in it. `builtin`, `official`, `local` and `user` do not offer
+it at all, and the sheet says why where it would have been.
+
+Its own menu rather than more keys on `/flow`, because they are about something else: adding a
+repository and fetching one again are done to the list of places, while the page they were on
+is asking which flow to run — and a sheet that asks one question with keys about another is a
+sheet asking two.
 
 **What happens here happens as it is asked for** rather than when the menu is saved: each of
 these runs git, and something that has already been cloned is not a draft. A clone runs off
@@ -886,24 +893,27 @@ and a asking which backend a new one is for](/demo/accounts.gif)
 
 | Key | What it does |
 | --- | --- |
-| **enter** | Opens what there is to do with the one under the cursor: correct what it holds, sign it in again, say what it falls back to |
+| **enter** | Opens what there is to do with the one under the cursor: correct what it holds, sign it in again, say what it falls back to, take it away |
 | **a** | Makes one: which CLI, then how to sign in, then what that way asks. The list of CLIs is also where a CLI of your own that speaks ACP is written down |
-| **d** **d** | Takes it away, credentials and all |
 | **esc** | Closes the menu, asking about anything it is holding |
 
-![What enter opens on one account: correct what it holds, sign it in again, and what it
-falls back to](/demo/account-does.png)
+![What enter opens on one account: correct what it holds, sign it in again, what it falls back
+to, and take it away](/demo/account-does.png)
 
-Three questions about one account are a menu rather than three letters to read off the
+Four questions about one account are a menu rather than four letters to read off the
 bottom of the screen — while **enter**, which every list already means, was doing one of
 them.
 
+**Taking it away is the last of those rows**, read beside what the account is and what it
+holds, which is what you are deciding about. It is held until the menu is saved like the rest,
+so an account already marked to go offers *keep it after all* on that same row rather than the
+same offer twice.
+
 The last row under each CLI is the account this machine is already signed into — the CLI as
 you run it, which is what an agent nobody gave an account runs as, and where that agent's
-chain begins. Where it falls back to is the one of the three it takes; correcting it and
-signing it in are not offered at all, and the menu says why under the row that is left.
-**d** says the same thing: humanize did not make that account and keeps no credentials
-for it.
+chain begins. Where it falls back to is the one of the four it takes; correcting it, signing it
+in and taking it away are not offered at all, and the menu says why under the row that is left:
+humanize did not make that account and keeps no credentials for it.
 
 An account written down before retrying became a thing about a place still holds the tries
 somebody set on it, and this menu says under the list that they are no longer read: tries
@@ -939,9 +949,11 @@ may reach for are what that agent *is*, so they are not asked here and come acro
 unchanged.
 
 `a` chooses the place that cannot run and then the place that takes its turns, each as three
-questions: the CLI, one of its accounts, one of the models it says it runs. `d` twice takes a
-step away. Enter on a row asks the two things a step says — where its turns go, and how many
-times over a failed turn is taken again first.
+questions: the CLI, one of its accounts, one of the models it says it runs. Enter on a row asks
+the three things there are to say about a step — where its turns go, how many times over a
+failed turn is taken again first, and whether to be rid of it at all. Taking it away is the
+last of those rather than a key on the list: what the step says is what says whether it is
+wanted, so it is decided beside the two things it says.
 
 The retry sheet answers in rungs rather than in numbers: the tries step through 0, 1, 2, 3, 5,
 8, 13 and 21, and the time the retrying is given through *as long as it takes*, 30s, 1m, 5m,
@@ -963,7 +975,7 @@ Everything is held until the menu is saved on the way out, as everything on a me
   ❯ 1. claude@work/claude-opus-5   3 more tries, exponential · falls back to codex@key/gpt-5.6-sol
     2. codex@key/gpt-5.6-sol       falls back to dsh/deepseek-v4-flash
 
-  Enter for what happens · a adds one · d twice takes one away · Esc to close
+  Enter for what happens · a adds one · Esc to close
 ```
 
 A place cannot fall back to itself, and a chain that comes round on itself ends at the second

--- a/docs/tapes/accounts.tape
+++ b/docs/tapes/accounts.tape
@@ -27,8 +27,9 @@ Type "/providers" Enter
 Wait+Screen /Providers/
 Sleep 1400ms
 
-# Enter opens what there is to do with the one under the cursor -- three questions about one
-# account, rather than three letters to read off the bottom of the screen.
+# Enter opens what there is to do with the one under the cursor -- four questions about one
+# account, taking it away among them, rather than four letters to read off the bottom of the
+# screen.
 Enter
 Wait+Screen /What to do with this account/
 Sleep 1400ms

--- a/docs/tapes/flowverses.tape
+++ b/docs/tapes/flowverses.tape
@@ -30,7 +30,9 @@ Screenshot "/out/flowverses.png"
 Sleep 400ms
 
 # Enter says what one holds -- which means reading its flows, so it is asked of the one
-# that was opened rather than of all of them.
+# that was opened rather than of all of them. It is also where one is taken away, past the
+# flows: what a place is, is what is in it. Not on this one -- the cursor opens on `builtin`,
+# which is always here -- so the sheet says why there instead.
 Enter
 Wait+Screen /What this flowverse holds/
 Sleep 1400ms

--- a/docs/user/board.md
+++ b/docs/user/board.md
@@ -76,6 +76,12 @@ you have to go and open is a board nobody reads.
 | enter | change the line under the cursor |
 | `d` twice | take it off the board |
 
+The board is the one place taking something away is still a key pressed twice. Everywhere else
+in the interface a row opens onto a menu about itself, and being rid of it is a row in there;
+enter on a line of the board opens the words of that line, which has no room for one. And it
+lands the moment it is pressed — there is no menu to save and no walk out to change your mind on
+— so the first press says what the second will do, and moving the cursor puts it down again.
+
 ## Whose each line is
 
 A flow writing down how far through it is does not want that edited underneath it, and a list

--- a/docs/user/fallback.md
+++ b/docs/user/fallback.md
@@ -26,8 +26,10 @@ across the step unchanged. What failed was the place, so the place is what moves
 
 One page, one row per place. `a` chooses the place that cannot run — the CLI, then one of its
 accounts, then one of the models it says it runs — and then the place that takes its turns.
-Enter on a row asks the two things a step says: where its turns go, and how many times over a
-failed turn is taken again first. `d` twice takes a step away.
+Enter on a row asks the three things there are to say about a step: where its turns go, how many
+times over a failed turn is taken again first, and whether to be rid of it at all. Taking it
+away is the last row in there rather than a key on the list — what the step says is what says
+whether it is wanted.
 
 Nothing lands until the menu is saved on the way out, as on every menu.
 

--- a/docs/user/providers.md
+++ b/docs/user/providers.md
@@ -213,15 +213,20 @@ it sets:
 | --- | --- |
 | **enter** | What there is to do with the account under the cursor |
 | **a** | Make one: which CLI, then how to sign in, then what that way asks |
-| **d** **d** | Take it away, credentials and all |
 
-**enter** opens a menu of three rather than one letter apiece on the list:
+**enter** opens a menu of four rather than one letter apiece on the list:
 
 | | | |
 | --- | --- | --- |
 | **correct what it holds** | the answers its way in was made with, asked again | held until saved |
 | **sign in again** | its own way in, run again; it owns the terminal while it does | at once |
 | **falls back to** | which account a turn carries on under when this one fails | held until saved |
+| **take it away** | the account and its credentials | held until saved |
+
+Taking it away is in here rather than on a key of the list: it is read beside what the account
+is and what it holds, which is what you are deciding about. One already marked to go says **keep
+it after all** on that same row — nothing has happened to it yet, so what was said may be taken
+back before the menu is saved.
 
 How many times over a failed turn is taken again is not one of them: that is a thing about the
 place a turn runs at rather than about the credentials it runs with, and
@@ -237,7 +242,7 @@ other menu.
 The account this machine is already signed into is `as local`, last under each CLI, and the one
 thing it is offered is where it falls back to. The line under that says why rather than leaving
 rows that do nothing: humanize did not make that account and keeps no credentials for it, so
-there is nothing to correct and nothing to sign in.
+there is nothing to correct, nothing to sign in and nothing to take away.
 
 **a** asks which CLI first, because a backend's ways in are its own and the second question is
 only answerable once the first has been. The last row of that list is not a backend at all: [a

--- a/docs/weaver/flowverses.md
+++ b/docs/weaver/flowverses.md
@@ -136,13 +136,16 @@ See [SDK reference](/reference/sdk#flowverses).
 
 | Key | |
 | --- | --- |
-| **enter** | What that flowverse holds — which means importing its flows, so it is asked of the one you open rather than of the whole list |
+| **enter** | What that flowverse holds — which means importing its flows, so it is asked of the one you open rather than of the whole list. Past the flows, the row that takes the flowverse away |
 | **a** | Add one: a URL or an `owner/repo`, and a name to keep it under — blank for the repository's own |
 | **r** | Fetch the one under the cursor again, or for the first time |
-| **d** **d** | Take an added one away, flows and all |
 
-What a flowverse holds is something you read rather than choose from: each flow's name, and the
-line it says about itself.
+What a flowverse holds is mostly something you read rather than choose from: each flow's name,
+and the line it says about itself. The one row that is not a reading is the last, which takes
+the whole place away, flows and all. It is in here rather than on a key of the list because what
+a flowverse *is*, is what is in it — so being rid of one is decided where that has just been
+read. `builtin`, `official`, `local` and `user` do not offer it, and say why where it would
+have been.
 
 ![what builtin holds: chat, ralph_loop and stateful_ralph, each with the line its flow says
 about itself](/demo/flowverse-holds.png)

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -358,9 +358,17 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 - A page made of several lists MUST show what they are called, and the left and right arrows
   MUST step between them: the list itself is walked up and down, so across is what is left,
   and the titles are read the same way the pages' are.
-- Taking anything away MUST be asked for twice on the same key, the first press saying what
-  the second one does. Moving the cursor MUST put it down again, so that a stray press is
-  harmless.
+- Where a row opens onto what it is, taking it away MUST be a row of that menu rather than a
+  key of the list: what a thing is, is what is in it, and somebody deciding to be rid of one
+  has to have read the thing they are deciding about. It MUST be the last row, so that what it
+  is comes before what may happen to it, and a row that cannot be taken away MUST say why
+  where the row would have been rather than be silently absent.
+- Taking anything away on a key MUST be asked for twice on the same key, the first press
+  saying what the second one does, and moving the cursor MUST put it down again so that a
+  stray press is harmless. That is for a key that acts on the spot -- one press and the thing
+  is gone, with no menu walked into and no save to change one's mind before. A row that was
+  walked to and chosen has already been chosen once, so it MUST NOT be asked about twice as
+  well.
 - The keys MUST be inside the terminal, whatever the sheet is holding: the list is what MUST
   be shortened until they are, since everything else on a sheet is a line or two and the rows
   are what there are a hundred of. The keys are the last row, so they are what falls off the
@@ -500,7 +508,13 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   one place it is kept, whichever way somebody reached it.
 - Enter MUST say what one holds, which MUST be read only of the flowverse it was asked of: a
   flow is read by running it, so what a place holds is the one question about it with no cheap
-  answer. `a` MUST add one; `r` MUST fetch one again; `d` twice MUST take one away.
+  answer. `a` MUST add one and `r` MUST fetch one again.
+- Taking one away MUST be a row of what it holds rather than a key of the list: what a
+  flowverse is, is what is in it, so being rid of one is decided where that has just been
+  read. It MUST NOT be one of the flows -- it is about the place rather than about anything in
+  it, so it MUST be past the end of them, out of their numbering and out of whatever a search
+  narrowed them to. The four that are always here MUST NOT offer it, and MUST say so where it
+  would have been.
 - Nothing here MUST be held until the menu is saved: each of these runs git, and something
   that has already been cloned is not a draft. What became of one MUST be said under the list
   rather than raised at whoever opened it, and MUST NOT stop the interface redrawing while it
@@ -514,12 +528,16 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
 
 - The accounts menu MUST list every account there is under a heading per CLI, and MUST be read
   rather than chosen from: which account an agent runs as is asked where that agent is set up.
-  `a` MUST make one and `d` twice MUST take one away.
+  `a` MUST make one.
 - What else can be done to one account -- correcting what it holds, signing it in again,
-  saying which account it falls back to -- MUST be a menu opened with enter on the account it
-  is about, rather than a letter apiece on the list. Three questions about one row is a menu;
-  three letters that have to be read off the bottom of the screen are three keys nobody
-  presses, while enter -- which every list already means -- did one of them.
+  saying which account it falls back to, taking it away -- MUST be a menu opened with enter on
+  the account it is about, rather than a letter apiece on the list. Four questions about one
+  row is a menu; four letters that have to be read off the bottom of the screen are four keys
+  nobody presses, while enter -- which every list already means -- did one of them.
+- Taking it away MUST be the last of those rows, and MUST be held until the accounts menu is
+  saved like the rest of what is written down without running anything. An account already
+  held to go MUST be offered the way back on that same row rather than the same offer again:
+  nothing has happened to it yet, so what was said may be taken back.
 - How often a failed turn under it is taken again MUST NOT be among them: that is a thing about
   the place a turn runs at rather than about the credentials it runs with, and `/fallback` is
   the menu it is said on. An account still holding what was written down before it moved MUST
@@ -531,10 +549,10 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   want is not one humanize drives.
 - The account this machine is already signed into MUST be a row too, under each CLI that has
   an account of its own and after the ones somebody made: it is what an agent nobody gave an
-  account runs as, and where that agent's chain begins. Correcting it and signing it in MUST
-  NOT be offered for it, with the reason said where they would have been, and taking it away
-  MUST say why there is nothing to do rather than doing nothing: humanize did not make that
-  account and keeps no credentials for it.
+  account runs as, and where that agent's chain begins. Correcting it, signing it in and
+  taking it away MUST NOT be offered for it, with the reason said where they would have been:
+  humanize did not make that account and keeps no credentials for it. Saying why is what MUST
+  happen rather than three rows quietly not being there.
 - An account several backends could be run as MUST be asked, at the moment it is made and at
   the moment it is corrected, which of them to write it down for as well. It is one question
   about one account rather than a walk of its own, so it MUST be one sheet of switches, and
@@ -575,6 +593,9 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   numbers to type: a text box for an integer is a text box to validate. It MUST be said here
   rather than on an account, one row saying both what happens when a turn fails and how often
   it is taken again first, since both are answers to the one thing that happened.
+- Taking a step away MUST be the last row of what enter opens on it rather than a key of the
+  list: what the step says is what says whether it is wanted, so it is decided beside the two
+  things it says. It MUST be held until the menu is saved, as everything on this menu is.
 - The accounts page MUST be the same store `/providers` walks, and its keys MUST say so: an
   account is made and taken away there, and this page is where it is said what one falls back
   to. A key that did nothing MUST say why rather than do nothing.
@@ -700,9 +721,13 @@ answers to pick between, and a numbered diagram would offer a choice nobody is m
   say so and MUST NOT be opened for editing: a flow writing down how far through it is must not
   have that edited underneath it. Refusing MUST be said where the key was pressed rather than
   by doing nothing.
-- Putting a line up, changing one and taking one away MUST be the keys the rest of the
-  interface uses for those: a letter to add, enter to change what is under the cursor, and the
-  taking-away key pressed twice.
+- Putting a line up, changing one and taking one away MUST be a letter to add, enter to change
+  what is under the cursor, and the taking-away key pressed twice. This is the one place the
+  taking-away key is still pressed: enter on a line of the board opens what that line says,
+  which is words being typed rather than a menu with a row to spare, so there is nowhere to
+  walk to and the key acts where it is pressed. It lands at once, with no save to change one's
+  mind before and a flow that may read the board on its very next line, so it MUST be asked
+  for twice and MUST be put down again when the cursor moves.
 - Nothing here MUST be held until the sheet is left. This is not a menu: the flow may be
   reading the board on the next line it runs, and a line held back would be one the flow was
   never told about.

--- a/src/hmz/tui/pick.py
+++ b/src/hmz/tui/pick.py
@@ -764,10 +764,17 @@ class Sheet[T](ModalScreen[T | None]):
     def _armed(self, what: str) -> bool:
         """Whether a key that has to be pressed twice has been pressed once already.
 
-        Taking something away is the one thing on these sheets that cannot be undone, so it is
-        asked for twice: the first press arms the row under the cursor and says so, and the
-        second takes it away. Moving the cursor puts it down again -- see :meth:`_moved` --
-        which is what makes a stray keypress harmless.
+        For a key that acts where it is pressed: the first press arms the row under the
+        cursor and says what the second one does, and the second one does it. Moving the
+        cursor puts it down again -- see :meth:`_moved` -- which is what makes a stray
+        keypress harmless.
+
+        Where a row opens onto what it is, taking it away is a row of that sheet instead of a
+        key of this one, and nothing here is armed: a row somebody walked to and chose has
+        already been chosen once, and asking a second time about a walk is asking twice about
+        a thing nobody pressed by accident. What is left is the board on `/monitor`, whose
+        rows are lines of text rather than menus and whose taking-away is on the spot and read
+        by a flow that may be looking at the board on its next line.
 
         Args:
           what: The row, by its id.
@@ -1715,13 +1722,25 @@ def _came_from(one: Flowverse) -> str:
     return _hmz().verses.whence(one, "not a clone of anything")
 
 
-class Holds(Sheet[None]):
-    """What one flowverse holds, which is read rather than chosen from.
+#: What the row that takes a sheet's subject away answers with, on each of the submenus that
+#: has one. Where every row of a list opens onto what it is, taking one away belongs in there
+#: with everything else about it rather than on a key of the list -- so three sheets grew the
+#: same row, and one spelling is one thing for the sheet that opened them to read back.
+_TAKES_AWAY = "take-away"
 
-    A reading and not a menu: which flow to run is asked on `/flow`, where the flows of every
-    place are walked. This is the other question -- what is in this one -- and it is the one
+
+class Holds(Sheet[str]):
+    """What one flowverse holds, and the one thing there is to do to the flowverse itself.
+
+    Mostly a reading: which flow to run is asked on `/flow`, where the flows of every place
+    are walked. This is the other question -- what is in this one -- and it is the one
     question about a flowverse that costs something to answer, since what a file holds is not
     a fact its name carries: reading a flow means running it.
+
+    Taking the flowverse away is the last row, past the flows and out of their numbering. It
+    is here because this is where a flowverse is opened, and what one *is* is what it holds:
+    somebody deciding to be rid of one has just read the thing they are deciding about, which
+    a key on the list of names could not have shown them.
     """
 
     LETTERS: ClassVar = frozenset({"search"})
@@ -1746,7 +1765,8 @@ class Holds(Sheet[None]):
         self.query_one("#asked", Label).update(self._verse.name)
         self.query_one("#about", Label).update(
             f"What this flowverse holds, read from {escape(_came_from(self._verse))}. "
-            "Which of them to run is asked on /flow, where every place's flows are."
+            "Which of them to run is asked on /flow, where every place's flows are. The last "
+            "row takes the flowverse away, flows and all."
         )
         self._fill()
         self.query_one("#choices", OptionList).focus()
@@ -1760,13 +1780,24 @@ class Holds(Sheet[None]):
                 self._offers = []
         return self._offers
 
+    def _takes(self) -> bool:
+        """Whether this is one there is any taking away, which four of them are not."""
+        return not self._verse.fixed
+
     def _fill(self) -> None:
-        """Puts the flows up, each with the line it says about itself."""
+        """Puts the flows up, each with the line it says about itself, and the way to be rid.
+
+        The row that takes the flowverse away is past the end of the flows and out of both
+        the numbering and whatever a search narrowed them to: it is about the place rather
+        than about anything in it, and a search for a flow that found nothing must still be a
+        sheet somebody can be rid of the place from.
+        """
         listing = self.query_one("#choices", OptionList)
         shown = [one for one in self._flows() if self.fits(one.name, one.about)]
         self._counting = len(str(max(len(shown), 1)))
-        at = min(listing.highlighted or 0, max(len(shown) - 1, 0))
-        listing.set_options(
+        away = self._takes()
+        at = min(listing.highlighted or 0, max(len(shown) - 1 + (1 if away else 0), 0))
+        rows = [
             Option(
                 self._row(
                     seen,
@@ -1778,45 +1809,93 @@ class Holds(Sheet[None]):
                 id=f"={one.name}",
             )
             for seen, one in enumerate(shown)
-        )
-        listing.highlighted = at if shown else None
+        ]
+        if away:
+            # A row of air above it, carried in the row itself rather than as a row of its
+            # own: a blank row is somewhere the cursor can land, and this one is the last
+            # thing in the list, where the arrows walk straight on to it.
+            label = f"take {self._verse.name} away"
+            here = at == len(shown)
+            mark = f"{_INDENT}[$primary]{_HERE}[/] " if here else f"{_INDENT}  "
+            rows.append(
+                Option(
+                    f"\n{mark}{' ' * (self._counting + 2)}"
+                    f"[$primary]{escape(label)}[/]"
+                    f"{' ' * max(1, _LABEL - len(label))}"
+                    "[$text-muted]flows and all, as soon as this is chosen[/]",
+                    id=_TAKES_AWAY,
+                )
+            )
+        listing.set_options(rows)
+        listing.highlighted = at if rows else None
         self._drawn = listing.highlighted
-        said = "" if shown else self._nothing()
+        said = self._nothing(shown)
         self.query_one("#tuning", Label).update(
             f"[$text-muted]{said}[/]" if said else ""
         )
         self.query_one("#keys", Label).update(f"Esc to close{self.searching()}")
 
-    def _nothing(self) -> str:
-        """Why there is nothing in it, which is not always the same reason."""
-        if not self._verse.fetched:
-            return "not fetched yet; r fetches it"
-        if self._typed:
-            return "no flow of that name in it"
-        return "nothing in it: a flowverse keeps its flows in flows/"
+    def _nothing(self, shown: Sequence[Offer]) -> str:
+        """What to say under the list, which is why it is empty and why it is here for good.
+
+        Args:
+          shown: The flows on the sheet, which is what there is to say nothing about.
+
+        Returns:
+          Why there is nothing in it, where there is nothing in it, and why there is no
+          taking away the four that are always here -- a row somebody went looking for and
+          did not find is a sheet that has not said anything.
+        """
+        said: list[str] = []
+        if not shown:
+            if not self._verse.fetched:
+                said.append("not fetched yet; r on the list before this fetches it")
+            elif self._typed:
+                said.append("no flow of that name in it")
+            else:
+                said.append("nothing in it: a flowverse keeps its flows in flows/")
+        if not self._takes():
+            said.append(
+                f"{escape(self._verse.name)} is always here; it is not one to take away"
+            )
+        return "\n".join(said)
+
+    @on(OptionList.OptionSelected)
+    def _took(self, event: OptionList.OptionSelected) -> None:
+        """Answers with the flowverse going, for the one row here that is not a reading.
+
+        Args:
+          event: What was chosen.
+        """
+        if str(event.option.id or "") == _TAKES_AWAY:
+            # Answered rather than done here: what happens to the list of places is the list
+            # of places', which is also where what became of it is said.
+            self.dismiss(_TAKES_AWAY)
 
 
 class Flowverses(Sheet[list[str]]):
     """The places flows come from: what there is, what one holds, and what can happen to one.
 
-    Its own menu rather than keys on the one a flow is chosen at. Adding a repository,
-    fetching one again and taking one away are things done to the list of places rather than
-    to the flow under the cursor, and a sheet that asks `which flow` with three keys on it
-    about something else is a sheet asking two questions. `/flow` still steps between the
-    places with the arrows, that being about which list of flows is being read.
+    Its own menu rather than keys on the one a flow is chosen at. Adding a repository and
+    fetching one again are things done to the list of places rather than to the flow under
+    the cursor, and a sheet that asks `which flow` with keys on it about something else is a
+    sheet asking two questions. `/flow` still steps between the places with the arrows, that
+    being about which list of flows is being read.
+
+    Taking one away is not a key here either: enter opens what a flowverse holds, and being
+    rid of one is said in there, among everything else about it.
 
     What happens here happens as it is asked for rather than being held until the menu is
     saved: each of these runs git, and something that has already been cloned is not a draft.
     """
 
-    LETTERS: ClassVar = frozenset({"search", "adding", "refresh", "drop"})
+    LETTERS: ClassVar = frozenset({"search", "adding", "refresh"})
 
     BINDINGS: ClassVar = [
         ("escape", "back", "back"),
         Binding("s", "search", "search", priority=True),
         Binding("a", "adding", "add one", priority=True),
         Binding("r", "refresh", "fetch it again", priority=True),
-        Binding("d", "drop", "take it away", priority=True),
     ]
 
     def __init__(self) -> None:
@@ -1839,7 +1918,8 @@ class Flowverses(Sheet[list[str]]):
         self.query_one("#about", Label).update(
             "Where flows come from: a git repository with a flows/ directory apiece, cloned "
             "under humanize's home, and the flows of your own read where they lie. Each is "
-            "offered under its name here. Enter says what one holds."
+            "offered under its name here. Enter says what one holds, and is where one is "
+            "taken away."
         )
         self._read()
         self._fill()
@@ -1889,7 +1969,7 @@ class Flowverses(Sheet[list[str]]):
         )
         self.query_one("#keys", Label).update(
             "Enter says what one holds · a adds one · r fetches one again · "
-            f"d twice takes one away · Esc to close{self.searching()}"
+            f"Esc to close{self.searching()}"
         )
 
     def _follows(self, listing: OptionList) -> None:
@@ -1923,7 +2003,9 @@ class Flowverses(Sheet[list[str]]):
             "App[None]",
             self.app,  # pyright: ignore[reportUnknownMemberType]
         )
-        await showing.push_screen_wait(Holds(one))
+        said = await showing.push_screen_wait(Holds(one))
+        if said == _TAKES_AWAY:
+            self._removes(one)
         self._fill()
 
     @work
@@ -1964,26 +2046,27 @@ class Flowverses(Sheet[list[str]]):
 
         await self._fetches(name, fetching)
 
-    def action_drop(self) -> None:
-        """Takes the flowverse under the cursor away, flows and all, once d is twice."""
-        one = self._under()
-        if one is None:
-            return
-        if not self._armed(one.name):
-            self._said = f"press d again to take {escape(one.name)} away, flows and all"
-            self._fill()
-            return
+    def _removes(self, one: Flowverse) -> None:
+        """Takes a flowverse away, flows and all, as what it holds was just asked for.
+
+        Nothing is asked again here: the row that answers with this said what it was going to
+        do, and it was chosen on the sheet that had just shown what is about to go. What
+        became of it is said under the list rather than raised at whoever opened the menu --
+        the question this page is asking still stands -- and the cursor is let go of, since a
+        marker left against a name nothing answers to is a list pointing at nothing.
+
+        Args:
+          one: The flowverse.
+        """
         try:
             _hmz().verses.remove(one.name)
         except (OSError, ValueError) as why:
             self._said = escape(str(why))
-            self._fill()
             return
         self._said = f"{escape(one.name)} is no longer here"
         self._told.append(f"[dim]{escape(one.name)} is no longer here[/dim]")
         self._was = ""
         self._read()
-        self._fill()
 
     async def _fetches(self, named: str, doing: Callable[[], str]) -> None:
         """Runs one git fetch off the event loop, and shows the list it left behind.
@@ -4889,11 +4972,12 @@ _GOES, _TAKEN_AGAIN = "goes", "tried"
 
 
 class Failing(Picks):
-    """What to say about one place: where its turns go, and how often they are taken again.
+    """What to say about one place: where its turns go, how often, and whether to say it.
 
-    Its own menu rather than a letter apiece on the list of steps. They are two questions
+    Its own menu rather than a letter apiece on the list of steps. They are three questions
     about the place under the cursor, and enter -- which every list already means -- is what
-    opens them.
+    opens them. Being rid of the step is one of them because it is the last thing to decide
+    once the other two have been read: what the step says is what says whether it is wanted.
     """
 
     def __init__(self, place: str, step: Step) -> None:
@@ -4909,11 +4993,12 @@ class Failing(Picks):
         self.about = (
             "What happens when a turn at this place cannot be taken. It is taken again as "
             "many times as this says, and then at whatever it falls back to -- in a session "
-            "of its own, no backend taking another backend's session id."
+            "of its own, no backend taking another backend's session id. The last row is "
+            "how to have nothing written down about it at all."
         )
 
     def rows(self) -> list[tuple[str, str, str]]:
-        """The two, each saying what it is now."""
+        """The three, each saying what it is now."""
         tries = (
             f"{self._step.tries} more tries, {self._step.policy}"
             if self._step.tries
@@ -4926,6 +5011,11 @@ class Failing(Picks):
                 self._step.to or "nowhere: a failed turn is a failed turn",
             ),
             (_TAKEN_AGAIN, "taken again", tries),
+            (
+                _TAKES_AWAY,
+                "take it away",
+                "this place says nothing, once the menu behind this is saved",
+            ),
         ]
 
 
@@ -4948,13 +5038,12 @@ class Fallbacks(Drafts[list[str]]):
     """
 
     TABS: ClassVar = ("Fallback",)
-    LETTERS: ClassVar = frozenset({"search", "adding", "drop"})
+    LETTERS: ClassVar = frozenset({"search", "adding"})
 
     BINDINGS: ClassVar = [
         ("escape", "back", "back"),
         Binding("s", "search", "search", priority=True),
         Binding("a", "adding", "add one", priority=True),
-        Binding("d", "drop", "take one away", priority=True),
     ]
 
     def __init__(self, agents: dict[str, tuple[Model, ...]]) -> None:
@@ -5014,8 +5103,7 @@ class Fallbacks(Drafts[list[str]]):
             f"[$text-muted]{self._said or self._nothing(rows)}[/]"
         )
         self.query_one("#keys", Label).update(
-            "Enter for what happens · a adds one · d twice takes one away · "
-            f"Esc to close{self.searching()}"
+            f"Enter for what happens · a adds one · Esc to close{self.searching()}"
         )
 
     @staticmethod
@@ -5039,17 +5127,18 @@ class Fallbacks(Drafts[list[str]]):
         """Says that one more place falls back to another, which is two places to choose."""
         self._adds()
 
-    def action_drop(self) -> None:
-        """Takes the step under the cursor away, once d has been pressed twice."""
-        named = self.under()
-        if not named:
-            return
-        if not self._armed(named):
-            self._said = f"press d again to take {escape(named)} away"
-            self._fill()
-            return
-        self._steps = [one for one in self._steps if one.spec != named]
-        self._said = f"{escape(named)} falls back nowhere when this menu is saved"
+    def _drops(self, said: str) -> None:
+        """Holds one place having nothing written about it, until the menu is saved.
+
+        Held rather than done, as everything on this menu is: the row goes from the list at
+        once so that what is read is what is held, and the cursor lands on the first of what
+        is left rather than on a place that is no longer one of the rows.
+
+        Args:
+          said: The place, as it is written down.
+        """
+        self._steps = [one for one in self._steps if one.spec != said]
+        self._said = f"{escape(said)} falls back nowhere when this menu is saved"
         self.changed()
         self._fill()
 
@@ -5090,6 +5179,9 @@ class Fallbacks(Drafts[list[str]]):
         chosen = await showing.push_screen_wait(Failing(said, step))
         if chosen is None:
             return  # walked out, which changes nothing
+        if chosen == _TAKES_AWAY:
+            self._drops(said)
+            return
         if chosen == _GOES:
             at = await self._chosen(f"What takes {said}'s turns")
             if at:
@@ -5222,7 +5314,8 @@ def _falling(step: Step) -> str:
 
 #: What can be done to one account, which is what enter opens rather than what a row of
 #: letter keys does. Each of these is a question about the account under the cursor, and a
-#: menu of four is a menu; four keys nobody can see are four keys nobody presses.
+#: menu of four is a menu; four keys nobody can see are four keys nobody presses. Being rid
+#: of one is the fourth and is spelled with the rest of them -- see :data:`_TAKES_AWAY`.
 _CORRECTS, _SIGNS_IN, _FALLS_BACK = "corrects", "signs-in", "falls"
 
 #: What one account is written down in, spelled here because what is read below is the key the
@@ -5270,39 +5363,49 @@ def _tries_moved(cli: str, name: str) -> str:
 
 
 class Account(Picks):
-    """What to do with one account: correct it, sign it in again, say where it falls back to.
+    """What to do with one account: correct it, sign it in, point it somewhere, be rid of it.
 
-    Its own menu rather than a letter apiece on the list of accounts. They are three questions
+    Its own menu rather than a letter apiece on the list of accounts. They are four questions
     about the account under the cursor, and a sheet whose keys are `l` and `f` is a sheet
     whose keys have to be learned from a line at the bottom of it -- while enter, which every
-    list already means, was doing one of the three.
+    list already means, was doing one of the four.
+
+    Taking it away is the last of them rather than a key on the list before this: the row
+    that does it is read beside what the account is and what it is holding, which is what
+    somebody deciding to be rid of it is deciding about.
 
     How many times over a failed turn is tried again is not among them. That is a thing about
     the place a turn runs at rather than about the credentials it runs with, and `/fallback`
     is the menu it is said on.
     """
 
-    def __init__(self, cli: str, name: str) -> None:
+    def __init__(self, cli: str, name: str, *, gone: bool = False) -> None:
         """Asks about one account.
 
         Args:
           cli: The backend it belongs to.
           name: What it is called, or "" for the account this machine is already signed into.
+          gone: Whether the menu behind this is already holding it to be taken away, which is
+            what makes the last row say the opposite. What is held may be taken back before
+            it is saved, and a row that offered again to take away what is already going
+            would be a row somebody pressed and got nothing from.
         """
         super().__init__()
         self._cli = cli
         self._name = name
+        self._gone = gone
         #: What this account still says about tries, read once here: the line under the list
         #: is drawn again on every keystroke, and the file cannot change while this is up.
         self._stale_tries = _tries_moved(cli, name)
         self.asked = f"{cli}/{name}" if name else f"{cli}, as this machine is signed in"
         self.about = (
-            "What to do with this account. Correcting it and saying where it falls back to "
-            "land when the accounts menu is saved; signing in happens as it is asked for."
+            "What to do with this account. Correcting it, saying where it falls back to and "
+            "taking it away land when the accounts menu is saved; signing in happens as it "
+            "is asked for."
         )
 
     def rows(self) -> list[tuple[str, str, str]]:
-        """The three, less the two there is nothing to do for this machine's own account."""
+        """The four, less the three there is nothing to do for this machine's own account."""
         held = [
             (
                 _FALLS_BACK,
@@ -5324,21 +5427,30 @@ class Account(Picks):
                 "run its own way in again; it owns the terminal while it does",
             ),
             *held,
+            (
+                _TAKES_AWAY,
+                "keep it after all" if self._gone else "take it away",
+                "it is held to go when the accounts menu is saved"
+                if self._gone
+                else "the account and its credentials, when that menu is saved",
+            ),
         ]
 
     def nothing(self) -> str:
-        """Why two of them are not here, and what this account holds that nothing reads.
+        """Why three of them are not here, and what this account holds that nothing reads.
 
         Returns:
           One line apiece, or "" for the account with neither to say -- which is any account
-          humanize made and nobody ever wrote tries on.
+          humanize made and nobody ever wrote tries on. Why three of the four rows are not
+          here is said rather than left to be noticed: a row somebody went looking for and
+          did not find is a menu that has not answered them.
         """
         said: list[str] = []
         if not self._name:
             said.append(
                 f"this is {escape(self._cli)} as this machine is already signed in: "
-                "humanize keeps no credentials for it, so there is nothing to correct or "
-                "sign in"
+                "humanize keeps no credentials for it, so there is nothing to correct, "
+                "sign in or take away"
             )
         if self._stale_tries:
             said.append(self._stale_tries)
@@ -5351,7 +5463,7 @@ class Providers(Drafts[list[str]]):
     Read rather than chosen from: which account an agent runs as is asked where that agent is
     set up, so nothing here is being picked for anything. What it is for is what can happen to
     one -- made, set up again, signed in again, marked as where a turn goes when another
-    account fails, taken away -- and all but the first two of those are one menu, opened with
+    account fails, taken away -- and all but the first of those are one menu, opened with
     enter on the account they are about. A row of letter keys was a row of keys somebody had
     to read off the bottom of the screen while enter, which every list already means, did one
     of the four.
@@ -5366,7 +5478,7 @@ class Providers(Drafts[list[str]]):
     """
 
     TABS: ClassVar = ("Providers",)
-    LETTERS: ClassVar = frozenset({"search", "adding", "drop"})
+    LETTERS: ClassVar = frozenset({"search", "adding"})
 
     BINDINGS: ClassVar = [
         ("escape", "back", "back"),
@@ -5374,7 +5486,6 @@ class Providers(Drafts[list[str]]):
         Binding("shift+tab", "prev_tab", "previous page", priority=True),
         Binding("s", "search", "search", priority=True),
         Binding("a", "adding", "make one", priority=True),
-        Binding("d", "drop", "take one away", priority=True),
     ]
 
     def __init__(self) -> None:
@@ -5515,8 +5626,7 @@ class Providers(Drafts[list[str]]):
             f"[$text-muted]{said}[/]" if said else ""
         )
         self.query_one("#keys", Label).update(
-            "Enter for what to do with one · a makes one · d twice takes one away · "
-            f"Esc to close{self.searching()}"
+            f"Enter for what to do with one · a makes one · Esc to close{self.searching()}"
         )
 
     def _follows(self, listing: OptionList) -> None:
@@ -5585,30 +5695,30 @@ class Providers(Drafts[list[str]]):
         self.changed()
         self._fill()
 
-    def action_drop(self) -> None:
-        """Marks the account under the cursor to be taken away, once d is pressed twice."""
-        one = self._under()
-        if one is None:
-            return
-        if not one.name:
-            self._said = self._machines(one.cli, "take away")
-            self._fill()
-            return
+    def _drops(self, one: Provider) -> None:
+        """Holds one account to be taken away when this menu is saved, or takes that back.
+
+        Held rather than done, as the rest of what this menu writes down is: credentials go
+        with it, and a menu that deleted as it was read would be one where walking out had
+        changed something nobody confirmed. The row stays where it is, saying what is going
+        to happen to it, so the cursor is left on the thing it was on.
+
+        Nothing is refused here. The account this machine is already signed into is not
+        offered the row that answers with this -- humanize did not make it and keeps no
+        credentials for it -- and :meth:`Account.nothing` is where that is said, which is
+        where somebody looking for the row would have been looking.
+
+        Args:
+          one: The account.
+        """
         named = self._named(one)
         if named in self._gone:
-            self._gone.discard(named)  # said twice is said and taken back
+            # Said and taken back, which is the other half of what that row offers.
+            self._gone.discard(named)
             self._said = f"{escape(named)} stays"
-            self.changed()
-            self._fill()
-            return
-        if not self._armed(named):
-            self._said = (
-                f"press d again to take {escape(named)} away, credentials and all"
-            )
-            self._fill()
-            return
-        self._gone.add(named)
-        self._said = f"{escape(named)} goes when this menu is saved"
+        else:
+            self._gone.add(named)
+            self._said = f"{escape(named)} goes when this menu is saved"
         self.changed()
         self._fill()
 
@@ -5635,7 +5745,9 @@ class Providers(Drafts[list[str]]):
             "App[None]",
             self.app,  # pyright: ignore[reportUnknownMemberType]
         )
-        said = await showing.push_screen_wait(Account(one.cli, one.name))
+        said = await showing.push_screen_wait(
+            Account(one.cli, one.name, gone=self._named(one) in self._gone)
+        )
         if said is None:
             return  # walked out of it, which does nothing to the account
         if said == _CORRECTS:
@@ -5644,6 +5756,8 @@ class Providers(Drafts[list[str]]):
             self.action_again(one)
         elif said == _FALLS_BACK:
             self.action_fallback(one)
+        elif said == _TAKES_AWAY:
+            self._drops(one)
 
     @work
     async def _corrects(self, one: Provider) -> None:
@@ -7204,7 +7318,15 @@ class Monitoring(Sheet[str]):
         self._writes("")
 
     def action_drop(self) -> None:
-        """Takes the line under the cursor off the board, once d has been pressed twice."""
+        """Takes the line under the cursor off the board, once d has been pressed twice.
+
+        The one taking-away still asked for on a key, because it is the one that is not a
+        walk into what the thing is: enter on a line of the board opens what that line says,
+        which is words being typed rather than a menu with room for a row about the line. So
+        the press stays, and it stays asked for twice -- it lands the moment it is pressed,
+        with no save to change one's mind before and a flow that may read the board on its
+        very next line.
+        """
         named = self.under()
         board = self._boarding()
         if board is None or not named.startswith(_ON_BOARD):

--- a/tests/tui/test_fallback.py
+++ b/tests/tui/test_fallback.py
@@ -18,9 +18,17 @@ from textual.widgets import Label, OptionList
 from hmz.coganchor import fallbacks
 from hmz.coganchor.backends import Model
 from hmz.tui import Humanize
-from hmz.tui.pick import Accounts, Catalogue, Clis, Failing, Fallbacks, Retries
+from hmz.tui.pick import (
+    _TAKES_AWAY,
+    Accounts,
+    Catalogue,
+    Clis,
+    Failing,
+    Fallbacks,
+    Retries,
+)
 
-from .test_app import keeps, onto, rows, until
+from .test_app import drops, keeps, onto, rows, until
 
 if TYPE_CHECKING:
     from textual.pilot import Pilot
@@ -144,8 +152,69 @@ async def test_a_place_cannot_fall_back_to_itself() -> None:
 
 
 @pytest.mark.timeout(60)
-async def test_a_step_is_taken_away_on_the_key_everything_is_taken_away_on() -> None:
-    """D twice, which is what a day's work behind a key that is also pressed by mistake is."""
+async def test_a_step_is_taken_away_from_inside_what_it_says() -> None:
+    """Enter opens what a step is, and being rid of it is the last row of that.
+
+    Held until the menu is saved, like everything else the sheet is holding: what the row
+    says is what lands, and nothing has landed while the menu is still up.
+    """
+    fallbacks.points("claude/claude-opus-5", "codex/gpt-5.6-sol")
+    app = Humanize()
+    async with app.run_test() as driver:
+        await _opens(app, driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Failing), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await onto(app, driver, _TAKES_AWAY)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Fallbacks), driver)
+
+        # Gone from the list, and nothing on disk until the menu is saved.
+        assert rows(app) == []
+        assert "falls back nowhere when this menu is saved" in _under(app)
+        assert fallbacks.falls()
+
+        await keeps(app, driver)
+        await until(lambda: not isinstance(app.screen, Fallbacks), driver)
+
+    assert fallbacks.falls() == []
+
+
+@pytest.mark.timeout(60)
+async def test_walking_out_of_a_step_taken_away_lands_nothing() -> None:
+    """It is a draft until the menu is saved, and a draft thrown away is a step left alone."""
+    fallbacks.points("claude/claude-opus-5", "codex/gpt-5.6-sol")
+    app = Humanize()
+    async with app.run_test() as driver:
+        await _opens(app, driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Failing), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await onto(app, driver, _TAKES_AWAY)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Fallbacks), driver)
+
+        await drops(app, driver)
+        await until(lambda: not isinstance(app.screen, Fallbacks), driver)
+
+    assert fallbacks.falls() == [
+        fallbacks.Falls("claude/claude-opus-5", "codex/gpt-5.6-sol")
+    ]
+
+
+@pytest.mark.timeout(60)
+async def test_the_key_that_used_to_take_a_step_away_takes_nothing_away() -> None:
+    """Asking twice was for a key that acted on the spot, and there is no such key here now."""
     fallbacks.points("claude/claude-opus-5", "codex/gpt-5.6-sol")
     app = Humanize()
     async with app.run_test() as driver:
@@ -154,19 +223,11 @@ async def test_a_step_is_taken_away_on_the_key_everything_is_taken_away_on() -> 
             lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
         )
         await driver.press("d")
-        await driver.pause()
-
-        assert "press d again" in _under(app)
-        assert fallbacks.falls()  # still there: one press says what the next one does
-
         await driver.press("d")
         await driver.pause()
 
-        assert rows(app) == []
-        await keeps(app, driver)
-        await until(lambda: not isinstance(app.screen, Fallbacks), driver)
-
-    assert fallbacks.falls() == []
+        assert "press d again" not in _under(app)
+        assert rows(app) == ["claude/claude-opus-5"]
 
 
 @pytest.mark.timeout(90)
@@ -183,7 +244,11 @@ async def test_how_often_a_failed_turn_is_taken_again_is_on_the_same_step() -> N
         await until(lambda: isinstance(app.screen, Failing), driver)
         listing = app.screen.query_one("#choices", OptionList)
         await until(lambda: bool(listing.options), driver)
-        assert [str(one.id) for one in listing.options] == ["=goes", "=tried"]
+        assert [str(one.id) for one in listing.options] == [
+            "=goes",
+            "=tried",
+            f"={_TAKES_AWAY}",
+        ]
 
         await driver.press("down", "enter")
         await until(lambda: isinstance(app.screen, Retries), driver)

--- a/tests/tui/test_flowverses_menu.py
+++ b/tests/tui/test_flowverses_menu.py
@@ -1,10 +1,12 @@
 """`/flowverses` -- the places flows come from, and the four things to do with one.
 
-Its own menu rather than three keys on the sheet a flow is chosen at. Adding a repository,
-fetching one again and taking one away are things done to the list of places rather than to
-the flow under the cursor, and a sheet that asks `which flow` with keys on it about something
-else is a sheet asking two questions. What one holds is the fourth: it is the one question
-about a flowverse that costs something to answer, since reading a flow means running it.
+Its own menu rather than two keys on the sheet a flow is chosen at. Adding a repository and
+fetching one again are things done to the list of places rather than to the flow under the
+cursor, and a sheet that asks `which flow` with keys on it about something else is a sheet
+asking two questions. What one holds is the third: it is the one question about a flowverse
+that costs something to answer, since reading a flow means running it. And taking one away is
+the fourth, which is a row of what it holds rather than a key here: what a flowverse is, is
+what is in it, so being rid of one is decided where that has just been read.
 
 Driven headlessly, as every test of the interface is, so what is checked is where a keystroke
 lands rather than how it is drawn.
@@ -21,7 +23,7 @@ from textual.widgets import Label, OptionList
 from hmz.flows import LOCAL, OFFICIAL, USER, flowverses
 from hmz.flows import verses as store
 from hmz.tui import Humanize
-from hmz.tui.pick import Fetches, Flowverses, Holds
+from hmz.tui.pick import _TAKES_AWAY, Fetches, Flowverses, Holds
 from tests.stubs import written
 
 from .test_app import onto, rows, until
@@ -130,7 +132,8 @@ async def test_what_one_holds_is_read_when_it_is_asked_for(theirs: Path) -> None
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Holds), driver)
 
-        assert rows(app) == ["theirs/loop"]
+        # The flows, and past them the one row that is not a reading.
+        assert rows(app) == ["theirs/loop", _TAKES_AWAY]
         assert "Somebody else's loop" in str(
             app.screen.query_one("#choices", OptionList).get_option_at_index(0).prompt
         )
@@ -261,16 +264,18 @@ async def test_a_name_that_is_not_one_is_refused_before_anything_is_cloned() -> 
 
 
 @pytest.mark.timeout(60)
-async def test_one_that_was_added_may_be_taken_away_from_here(theirs: Path) -> None:
-    """Twice on the same key, since it cannot be undone: flows and all."""
+async def test_one_that_was_added_is_taken_away_from_inside_what_it_holds(
+    theirs: Path,
+) -> None:
+    """Where a row opens onto what it is, being rid of it is a row in there: flows and all."""
     store.add(str(theirs))
     app = Humanize()
     async with app.run_test() as driver:
         sheet = await _open(app, driver)
         await onto(app, driver, "theirs")
-
-        await driver.press("d")
-        await until(lambda: "press d again" in _under(sheet), driver)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Holds), driver)
+        await onto(app, driver, _TAKES_AWAY)
         assert [one.name for one in flowverses()] == [
             "builtin",
             OFFICIAL,
@@ -279,26 +284,62 @@ async def test_one_that_was_added_may_be_taken_away_from_here(theirs: Path) -> N
             USER,
         ]
 
-        await driver.press("d")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Flowverses), driver)
         await until(lambda: "no longer here" in _under(sheet), driver)
 
         assert [one.name for one in flowverses()] == ["builtin", OFFICIAL, LOCAL, USER]
         assert rows(app) == ["builtin", OFFICIAL, LOCAL, USER]
+        # And the marker is on a row that is still there, rather than on the hole one left.
+        listing = sheet.query_one("#choices", OptionList)
+        assert listing.highlighted == 0
+
+
+@pytest.mark.timeout(60)
+async def test_the_key_that_used_to_take_one_away_takes_nothing_away(
+    theirs: Path,
+) -> None:
+    """Asking twice was for a key that acted on the spot, and there is no such key here now."""
+    store.add(str(theirs))
+    app = Humanize()
+    async with app.run_test() as driver:
+        sheet = await _open(app, driver)
+        await onto(app, driver, "theirs")
+
+        await driver.press("d")
+        await driver.press("d")
+        await driver.pause()
+
+        assert "press d again" not in _under(sheet)
+        assert [one.name for one in flowverses()] == [
+            "builtin",
+            OFFICIAL,
+            "theirs",
+            LOCAL,
+            USER,
+        ]
 
 
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize("named", ["builtin", LOCAL])
-async def test_none_of_the_ones_always_here_may_be_taken_away(named: str) -> None:
-    """The package, where the rest come from, and the two your own flows live in."""
+async def test_none_of_the_ones_always_here_offer_to_be_taken_away(named: str) -> None:
+    """The package, where the rest come from, and the two your own flows live in.
+
+    The row is not there at all, and the sheet says why: a row somebody went looking for and
+    did not find is a menu that has not answered them.
+    """
     app = Humanize()
     async with app.run_test() as driver:
-        sheet = await _open(app, driver)
+        await _open(app, driver)
         await onto(app, driver, named)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Holds), driver)
 
-        await driver.press("d")
-        await driver.press("d")
-        await until(lambda: "always here" in _under(sheet), driver)
+        assert _TAKES_AWAY not in rows(app)
+        assert "always here" in _under(app.screen)  # pyright: ignore[reportArgumentType]
 
+        await driver.press("escape")
+        await until(lambda: isinstance(app.screen, Flowverses), driver)
         assert rows(app) == ["builtin", OFFICIAL, LOCAL, USER]
 
 
@@ -314,8 +355,11 @@ async def test_what_happened_while_it_was_open_is_said_in_the_transcript(
     async with app.run_test() as driver:
         await _open(app, driver)
         await onto(app, driver, "theirs")
-        await driver.press("d")
-        await driver.press("d")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Holds), driver)
+        await onto(app, driver, _TAKES_AWAY)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Flowverses), driver)
         await driver.press("escape")
         await until(lambda: not isinstance(app.screen, Flowverses), driver)
 

--- a/tests/tui/test_providers.py
+++ b/tests/tui/test_providers.py
@@ -22,6 +22,7 @@ from hmz.runtime.kept import Runs
 from hmz.runtime.settings import Settings
 from hmz.tui import Humanize
 from hmz.tui.pick import (
+    _TAKES_AWAY,
     Account,
     Accounts,
     Agent,
@@ -34,6 +35,7 @@ from hmz.tui.pick import (
 
 from .test_app import (
     _transcript,
+    drops,
     into_agent,
     into_flows,
     keeps,
@@ -57,6 +59,13 @@ def _under(app: Humanize) -> str:
     return str(app.screen.query_one("#tuning", Label).content)
 
 
+def _drawn(app: Humanize) -> str:
+    """Every row the sheet on top has put up, as one block to read."""
+    return "\n".join(
+        str(one.prompt) for one in app.screen.query_one("#choices", OptionList).options
+    )
+
+
 async def _no_copies(app: Humanize, driver: Pilot[None]) -> None:
     """Walks past the question of which other backends to write the new account down for.
 
@@ -78,9 +87,9 @@ async def _no_copies(app: Humanize, driver: Pilot[None]) -> None:
 async def _doing(app: Humanize, driver: Pilot[None], held: str) -> None:
     """Opens what there is to do with the account under the cursor, and picks one of them.
 
-    Which is what enter on an account is now: three questions about it -- correct it, sign it
-    in again, where it falls back to -- rather than three letter keys on the list of
-    accounts.
+    Which is what enter on an account is now: four questions about it -- correct it, sign it
+    in again, where it falls back to, be rid of it -- rather than four letter keys on the
+    list of accounts.
 
     Args:
       app: The interface.
@@ -772,9 +781,9 @@ async def test_a_chain_pointed_at_an_account_the_same_save_takes_away_goes_nowhe
             "=codex/work",
         ]
 
-        await driver.press(
-            "d", "d"
-        )  # `spare`, marked to be taken away when this is saved
+        # `spare`, held to be taken away when this menu is saved.
+        await _doing(app, driver, _TAKES_AWAY)
+        await until(lambda: isinstance(app.screen, Providers), driver)
         await driver.press("down")  # onto `work`
         await _doing(app, driver, "falls")
         await until(lambda: isinstance(app.screen, Falls), driver)
@@ -806,16 +815,8 @@ async def test_taking_an_account_away_says_what_went_with_it() -> None:
             lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
         )
 
-        # Twice, because it cannot be undone -- and held until the menu is saved.
-        await driver.press("d")
-        await until(
-            lambda: (
-                "press d again" in str(app.screen.query_one("#tuning", Label).content)
-            ),
-            driver,
-        )
-        assert providers.find("claude", "deepseek") is not None
-        await driver.press("d")
+        # From inside what there is to do with it, and held until the menu is saved.
+        await _doing(app, driver, _TAKES_AWAY)
         await until(
             lambda: (
                 "when this menu is saved"
@@ -831,6 +832,88 @@ async def test_taking_an_account_away_says_what_went_with_it() -> None:
 
     assert "claude/deepseek is gone, credentials and all" in said
     assert providers.find("claude", "deepseek") is None
+
+
+@pytest.mark.timeout(60)
+async def test_an_account_held_to_go_is_offered_the_way_back() -> None:
+    """Nothing has happened yet, so the row that marked it is the row that unmarks it."""
+    _account()
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/providers")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Providers), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await _doing(app, driver, _TAKES_AWAY)
+        await until(lambda: isinstance(app.screen, Providers), driver)
+        assert "to be taken away" in _drawn(app)
+
+        # Open again and the row says the opposite, rather than offering the same thing.
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Account), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        assert "keep it after all" in str(
+            app.screen.query_one("#choices", OptionList).options[-1].prompt
+        )
+        await onto(app, driver, _TAKES_AWAY)
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Providers), driver)
+        await until(lambda: "deepseek stays" in _under(app), driver)
+
+        await keeps(app, driver)
+        await until(lambda: not isinstance(app.screen, Providers), driver)
+
+    assert providers.find("claude", "deepseek") is not None
+
+
+@pytest.mark.timeout(60)
+async def test_an_account_held_to_go_stays_where_the_menu_is_not_saved() -> None:
+    """It is a draft until the menu is saved, and credentials are not thrown away on a walk."""
+    _account()
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/providers")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Providers), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+        await _doing(app, driver, _TAKES_AWAY)
+        await until(lambda: isinstance(app.screen, Providers), driver)
+
+        await drops(app, driver)
+        await until(lambda: not isinstance(app.screen, Providers), driver)
+
+    assert providers.find("claude", "deepseek") is not None
+
+
+@pytest.mark.timeout(60)
+async def test_the_key_that_used_to_take_an_account_away_takes_nothing_away() -> None:
+    """Asking twice was for a key that acted on the spot, and there is no such key here now."""
+    _account()
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press(*"/providers")
+        await driver.press("enter")
+        await until(lambda: isinstance(app.screen, Providers), driver)
+        await until(
+            lambda: bool(app.screen.query_one("#choices", OptionList).options), driver
+        )
+
+        await driver.press("d")
+        await driver.press("d")
+        await driver.pause()
+
+        assert "press d again" not in _under(app)
+        assert "to be taken away" not in _drawn(app)
+        await keeps(app, driver)
+        await until(lambda: not isinstance(app.screen, Providers), driver)
+
+    assert providers.find("claude", "deepseek") is not None
 
 
 def test_an_agent_is_made_as_the_account_it_was_given() -> None:
@@ -919,14 +1002,10 @@ async def test_the_account_this_machine_is_signed_into_is_a_row_of_its_own() -> 
 
         await driver.press("down")  # onto it
         await driver.pause()
-        # There is nothing to take away about it, and pressing d says so.
-        await driver.press("d")
-        await driver.pause()
-        assert "there is nothing to" in _under(app)
-        assert isinstance(app.screen, Providers)
 
-        # Correcting it and signing it in are not offered at all, with the reason said where
-        # they would have been: humanize did not make that account and keeps nothing for it.
+        # Correcting it, signing it in and taking it away are not offered at all, with the
+        # reason said where they would have been: humanize did not make that account and
+        # keeps nothing for it.
         await driver.press("enter")
         await until(lambda: isinstance(app.screen, Account), driver)
         await until(
@@ -937,6 +1016,7 @@ async def test_the_account_this_machine_is_signed_into_is_a_row_of_its_own() -> 
             for one in app.screen.query_one("#choices", OptionList).options
         ] == ["falls"]
         assert "keeps no credentials for it" in _under(app)
+        assert "take away" in _under(app)
         await driver.press("escape")
         await until(lambda: isinstance(app.screen, Providers), driver)
 


### PR DESCRIPTION
Where every row of a list already opens onto what it is, the `d`-twice key that took one away was a second way of saying the same thing. Being rid of a thing is now the last row of the menu about that thing.

## What moved

| sheet | was | now |
| --- | --- | --- |
| `/flowverses` | `d` twice on the list | last row of **what it holds** — past the flows, out of their numbering and out of whatever a search narrowed them to |
| `/providers` | `d` twice on the list | last row of **what to do with this account** — `take it away`, held until the menu is saved |
| `/fallback` | `d` twice on the list | last row of **what happens** — `take it away`, held until the menu is saved |
| `/monitor` board | `d` twice | **unchanged** — see below |

Each keeps its own landing semantics: `/flowverses` still runs `git rm` as it is asked for, and the two `Drafts` sheets still only mark, with the deletion landing on save. `Providers`' three-state toggle survives as a row that says the opposite once the account is held to go — `keep it after all`, so what was said may be taken back. Both refusals survive and are now *visible* rather than silent: `builtin`/`official`/`local`/`user` do not get a take-away row and `Holds` says why, and the machine-local account does not get one and `Account`'s line under the list says why.

## Why the board keeps `d` twice

Its premise does not hold there. Enter on a line of the board opens what that line *says* — words being typed, not a menu with a row to spare — so there is nowhere to walk to and the key acts where it is pressed. And it lands the moment it is pressed: no save to change one's mind before it, and a flow that may read the board on its very next line. Growing `Entry` into a menu would have made writing a line a two-step walk to solve a problem the board does not have. So the arming stays exactly where a key still acts on the spot, which is what the rewritten spec rule and `Sheet._armed`'s docstring now say. `_moved`'s disarm-on-cursor-move is untouched.

## Spec and docs

`specs/tui.md` §"The keys" is rewritten into two rules — a row for a thing that opens, a key asked twice for a thing that acts on the spot — and the `/flowverses`, accounts, `/fallback` and board sections follow. `docs/reference/tui.md`, `docs/reference/providers.md`, `docs/reference/flows.md`, `docs/user/{providers,fallback,board}.md`, `docs/weaver/flowverses.md` and the two demo tapes are updated with them.

## Verification

- `uv run pytest` — 2868 passed, 72 skipped.
- `uv run pre-commit run --all-files` — ruff, ruff format and pyright strict all pass.
- New headless pilot tests per sheet: the retired `d` takes nothing away, the submenu's row is there and works, a `Drafts` sheet only lands on save (and lands nothing when the save is dropped), a protected row still refuses, and the parent list is left on a row that exists.
- A real interactive run against a temporary `HUMANIZE_HOME`, walking each menu and deleting something: `claude/spare` gone from disk after the save, `fallbacks.json` back to `[]` after the save, the `theirs` flowverse gone from disk with the parent list left on `builtin` and `theirs is no longer here` under it, `builtin` refusing with its reason shown inside what it holds, and `/monitor` drawing as before.

## Noticed, not touched

`Reports` (the first-start question) raised `ScreenStackError: Can't pop screen` from `Picks._took` when enter landed on it twice in quick succession in a real terminal. Pre-existing and outside this unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
