### PR TITLE
fix(agents): a tool call is said as the agent reaches for it

### DIFF
--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -77,6 +77,12 @@ CLI on its own command line, or through a settings file this run alone is pointe
 length of the run — your own hooks stay yours, and a flow that ends leaves the machine as it
 found it.
 
+The table is there only while a hook is. It is a program the CLI starts and waits for before
+every tool it runs, so an agent with nothing hung on `PreToolUse` is given none at all rather
+than paying for one per file read. Hanging or unhanging one between two turns starts the next
+turn in a CLI told the new answer; hanging one while a turn is already running has it read off
+that turn's own stream until the turn after, which watches the tool rather than stopping it.
+
 On a backend with no such seam, and on a turn whose work lands on [another
 machine](/features/anchor) — where the relay is not — the moment is still told to every hook
 hung on it, and a refusal there is a flow watching a tool rather than stopping one.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -683,6 +683,7 @@ mapping of model to tokens spent.
 | `text` | The agent talking. |
 | `reasoning` | The agent thinking aloud. |
 | `tool` | The agent using one. |
+| `notice` | **humanize** rather than the agent: a rate limit being waited out, another account being carried on as, a turn being cut off, a wedged backend being taken away. |
 | `result` | The answer the turn ends on. **Exactly one closes a turn**, and it is what calling the session returns. |
 | `failed` | The turn closed the other way, carrying what went wrong in place of an answer. |
 | `took` | A word [put into the running turn](#talking-to-a-turn-already-running) is now in front of the model, and is what the event carries. |
@@ -693,6 +694,18 @@ over the utterance they came to — as the agent reaches for a tool, since what 
 reaching is what says why it reached, and again as the message ends. So a paragraph is one
 event, and a turn of ten tool calls is ten or so events rather than several thousand. If you
 want the tokens as they land, read them from the backend yourself; a flow reads what was said.
+
+A `tool` event is the other way round: it lands as the agent **reaches**, not once it has
+finished reaching. The arguments of a call stream in like anything else, and for a write they
+are the whole file — so a row that waited for them would be a row that appeared minutes after
+the agent started writing, with nothing said in between. Where a backend streams them the row
+goes out at the first fragment that says what the call is about, which is the path or the
+command, and the file follows behind it.
+
+A `notice` is the one kind that is not the agent at all. It is what humanize is doing about the
+turn, and it exists because a turn told to wait half a minute and a turn that has hung look
+identical from outside. The interface draws it whichever way [`/details`](/user/details) is
+set.
 
 A watcher sees three more that a stream does not: `begins` and `ends`, which bracket the turn,
 and `asks`, which is the agent stopping to ask its user something.
@@ -711,7 +724,9 @@ have nowhere to say the next thing back to. It is `None` only for something the 
 rather than one of them: a question put by a server that serves every session of it at once.
 
 A watcher that raises is the watcher's own problem: a flow must not fail because something
-looking at it did.
+looking at it did. It is reported as a snag rather than swallowed in silence — one draw that
+failed is one thing the agent said that nobody will ever see, and a run whose rows all went
+that way reads as a turn sitting there doing nothing.
 
 This is the only place a run is visible. A flow drives the sessions and answers to nobody, so
 the turns going past are all there is — which is what the interface's status column is built
@@ -886,9 +901,15 @@ with agent.hooks.on(Moment.PRE_TOOL_USE, no_shell):
 The seam is the CLI's own and is scoped to the run: `--settings` carries the whole of a
 settings file as a literal on Claude Code's command line, and Qwen Code is pointed at a
 settings file of ours through the variable it already reads its effort from. Nothing of the
-person's own configuration is read, written or replaced, and the table is installed whether or
-not anything is hung on the moment — a hook goes up and comes down while the agent runs, so
-what is hung is asked when the moment fires rather than when the CLI started.
+person's own configuration is read, written or replaced.
+
+The table is installed only while something is hung on the moment. It is a program the CLI
+starts and waits for before every tool it runs, one call after another, so a table written for
+hooks that are not there costs every file read its own delay for nobody. Hanging a hook or
+taking one down between two turns starts the next turn in a CLI told the new answer, exactly as
+moving the effort does; one hung while a turn is already running is read off that turn's own
+stream instead, which watches the tool rather than gating it. What is hung is still asked when
+the moment fires rather than when the CLI started.
 
 `PRE_TOOL_USE` and `PERMISSION_REQUEST` are two moments and both fire. The table gets the first
 word, a CLI running its hooks before it decides whether a tool is permitted, so a refusal at

--- a/docs/user/details.md
+++ b/docs/user/details.md
@@ -35,6 +35,22 @@ Both settings draw from the same [events](/reference/agents#watching-a-turn-as-i
 discarded. Turning it back on does not recover what scrolled past, but the
 [trace](/user/tracing) has all of it either way, always.
 
+## What it never hides
+
+A `notice` is humanize saying what it is doing about the turn — waiting out a rate limit,
+carrying on as another account, cutting the turn off, taking it away from a backend that had
+stopped saying anything. That is not the working, and it is drawn whichever way the switch is
+set:
+
+```
+● waiting 30s for a rate limit; carrying on as work
+```
+
+A turn told to wait half a minute and a turn that has hung look the same from the outside, and
+that line is the only thing that tells them apart. It used to be drawn as a tool call, which
+meant that asking not to see every file read was also asking not to be told why the run had
+gone quiet.
+
 ## It is a screen setting, not an agent setting
 
 `/details` changes nothing about the run. The agent is not told about the setting, and it does

--- a/docs/user/fallback.md
+++ b/docs/user/fallback.md
@@ -146,9 +146,11 @@ answers it); trying again in 30s (1 of 1)
 claude is rate-limited (…); carrying on as work
 ```
 
-Whatever is watching the agent sees those as `tool` events; where nothing is watching, they go
-on stderr beside the progress the backend itself puts there. A turn told to wait half a minute
-is exactly the turn you would otherwise watch do nothing at all.
+Whatever is watching the agent sees those as `notice` events; where nothing is watching, they
+go on stderr beside the progress the backend itself puts there. A turn told to wait half a
+minute is exactly the turn you would otherwise watch do nothing at all — which is why they are
+their own kind rather than tool calls, and why [`/details`](/user/details) does not hide them
+with the working.
 
 A backend that already knows which kind it was says so itself and is believed. Nothing guesses
 at a message when the CLI has named the failure.

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -124,6 +124,23 @@ class Saying:
   tool call. A backend that says only one of the two halves would be one whose subagents never
   finish, so it MUST say both or neither.
 
+- A tool call MUST be said as the agent reaches for it rather than once it has finished
+  reaching. The arguments of a call are what it was called with, and for a write they are the
+  file: a driver that waits for the whole of them says nothing at all for as long as the model
+  takes to write it, which on a slow model is minutes of a turn that reads as hung -- and the
+  silence lands exactly where the work is largest. Where a backend streams those arguments a
+  driver MUST say the call at the first fragment there is anything to say it about, MUST ask
+  its CLI for the fragments where that is a flag, and MUST say it exactly once however many
+  ways the backend then repeats the same call. A call whose arguments never read as words MUST
+  still be said, by name, when they stop arriving: a reach is a reach.
+
+- `notice` MUST be humanize rather than the agent: a turn waiting out a rate limit, carried to
+  another account, cut off, or taken away from a backend that had stopped saying anything.
+  These were said as tool calls, which made them the working -- and an interface that hides the
+  working hid the one line that tells a stall from a hang from the person sitting in front of
+  the silence. What the agent did MUST NOT be said as one, and what humanize did MUST NOT be
+  said as anything else.
+
 - These MUST NOT name the base classes. Every backend needs them and none of them needs the
   base classes to say one, so a reader of somebody else's stream format imports this alone.
 
@@ -353,10 +370,18 @@ stops and waits to be told, and `Gate` is what stands in that place.
   flow that ends MUST leave that machine as it found it. A switch of the CLI's own that would
   turn the whole table off MAY be said off at that same layer, since a gate that quietly does
   nothing is worse than one that was never installed.
-- The table MUST be installed whether or not anything is hung on the moment. A hook goes up and
-  comes down while the agent runs, so a table that depended on what was hung when the CLI
-  started would be one that had to restart the CLI; what is hung MUST be asked at the moment it
-  fires, which is the only moment the answer is true.
+- The table MUST be installed only where something is hung on the moment. A table is a program
+  the CLI starts and waits for before every tool it runs, one call after another, so a table
+  written for hooks that are not there is a relay spawned per file read and its own delay added
+  to each of them for nobody. A hook hung or taken down between two turns MUST be answered the
+  way a moved effort is -- the next turn starting a CLI told the new answer -- and one hung
+  while a turn is running MUST be read off that turn's own stream instead, watching the tool
+  rather than gating it. What is hung MUST still be asked at the moment it fires, which is the
+  only moment the answer is true.
+- `Hooks.gated` MUST answer False for a moment nothing is hung on, whatever gate an earlier
+  hook left serving. It is what a session reads to decide whether to say the moment off its
+  own stream, and a gate outliving the hook that asked for it would otherwise be a moment that
+  fires in neither place.
 - The relay MUST be `hmz hook`, and the callback MUST run in the process the flow is in, for
   the reason `hmz tools` exists: a hook that ran anywhere else would be a subprocess and not a
   callable of the flow's. The socket MUST be in a directory this user alone may enter.
@@ -625,6 +650,13 @@ class AgentBase(ABC):
   be told None only for something the agent said rather than one of them -- a question put by a
   server that serves every session of it at once. An agent may be holding ten conversations, and
   a watcher that cannot tell them apart is one reading ten interleaved with nowhere to answer.
+- A watcher that raises MUST NOT take the turn down with it, and MUST NOT be swallowed in
+  silence either. One draw that failed is one thing the agent said that nobody will ever see,
+  and an interface whose rows all went that way reads as a turn sitting there doing nothing --
+  a hang to whoever is watching and no trace at all to whoever is asked about it afterwards. It
+  MUST be reported as a snag, once per kind per agent, since a watcher that fails on one event
+  fails on every one of them. The report MUST say which kind was lost and MUST NOT say what was
+  said: the failure is ours to hear about and the turn's words are not.
 - `opened` MUST report the backend's id for every session this agent has opened, oldest first,
   including the sessions nobody holds any more. It is what a flow hands a trace to say which
   trajectories were this agent's.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -214,6 +214,13 @@ line, with what the flow is doing beside the transcript.
   a flow is watched to see where it has got to: what the agents said is that, and a tool row
   per file read is a screen nobody is reading with the answer somewhere in it. On, all of it
   MUST be shown rather than a sample of it.
+- What humanize is doing about a turn MUST be shown either way. A rate limit being waited out,
+  another account being carried on as, a turn being cut off, a backend that stopped saying
+  anything being taken away: none of that is the working, and a turn told to wait half a minute
+  and a turn that has hung look identical from here. Hidden with the tool rows, the one line
+  that tells them apart is hidden from exactly the person sitting in front of the silence -- so
+  a `notice` MUST be drawn whatever `/details` says, and MUST read as its own thing rather than
+  as another tool row.
 - An agent that stops to ask MUST be able to reach whoever is at the prompt: the question and
   what it offers MUST be shown, and the next line typed MUST be the answer rather than a word
   put into the turn. It MUST be shown against whichever of that agent's sessions is working,

--- a/src/hmz/cli/output.py
+++ b/src/hmz/cli/output.py
@@ -456,6 +456,11 @@ class Shown:
         elif event.kind == "tool":
             named, _, about = event.text.partition(" ")
             self._out.line((f"{_SAID} ", "green"), (named, ""), (f"({about})", "dim"))
+        elif event.kind == "notice":
+            # humanize saying what it is doing about the turn rather than the agent working:
+            # a rate limit being waited out, another account being carried on as, a turn being
+            # cut off. Said in its own colour so it does not read as a tool call.
+            self._out.line((f"{_SAID} ", "yellow"), (event.text, "dim"))
         elif event.kind in ("subagent", "subagent-ends"):
             named, _, about = event.text.partition(" ")
             done = "started" if event.kind == "subagent" else "done"

--- a/src/hmz/coganchor/agents/base.py
+++ b/src/hmz/coganchor/agents/base.py
@@ -844,7 +844,7 @@ class SessionBase(ABC):
             # is prevented by stopping the agent, which is a different thing.
             return
         self._cut = why or "interrupted"
-        self._heard(Event(kind="tool", text=f"cutting the turn off: {self._cut}"))
+        self._heard(Event(kind="notice", text=f"cutting the turn off: {self._cut}"))
         self._cuts()
         if self._moved_to is not None:
             # And the conversation this one moved to, since the turn being cut off may be
@@ -976,7 +976,7 @@ class SessionBase(ABC):
             same budget again: a loop that took the turn over on a schedule would be cut off
             at the same word every round and never get anywhere.
         """
-        self._heard(Event(kind="tool", text=f"turn cut off: {why}"))
+        self._heard(Event(kind="notice", text=f"turn cut off: {why}"))
         budget = self._capped
         if self._over and budget is not None and budget.then == "fail":
             raise Unrecoverable(1, [self._agent.backend], said, f"turn cut off: {why}")
@@ -1271,7 +1271,7 @@ class SessionBase(ABC):
                             # gating. Where a gate is up the CLI asks first and waits, so the
                             # moment fires from there instead -- and firing it here as well
                             # would be one tool call putting the same hook twice.
-                            if not self._agent.hooks.gated(Moment.PRE_TOOL_USE):
+                            if not self._asking(Moment.PRE_TOOL_USE):
                                 named, _, about = event.text.partition(" ")
                                 self._fire(Moment.PRE_TOOL_USE, tool=named, about=about)
                         elif event.kind in ("subagent", "subagent-ends"):
@@ -1527,10 +1527,15 @@ class SessionBase(ABC):
         minute for a rate limit is exactly the turn somebody would otherwise watch do
         nothing at all.
 
+        Said as a `notice` rather than as a tool call, which is what it was until an
+        interface that hides the working hid this with it: what a turn is waiting for is not
+        how the turn is getting its work done, and somebody who asked not to see every file
+        read did not ask to be left watching a rate limit in silence.
+
         Args:
           text: The line, as :meth:`_recovering` and its like build one.
         """
-        self._heard(Event(kind="tool", text=text))
+        self._heard(Event(kind="notice", text=text))
         if not self._agent._watchers:
             say(text, sys.stderr)
 
@@ -1782,6 +1787,30 @@ class SessionBase(ABC):
         """
         self._agent._heard(event, self)
         return event
+
+    def _asking(self, moment: Moment) -> bool:
+        """Whether the CLI now running this conversation asks about a moment and waits.
+
+        Of the process rather than of the agent, which is the difference that matters: a table
+        is written when a CLI starts, a gate outlives the hook that first asked for one, and a
+        session whose CLI was started without a table would otherwise stop saying the moment
+        off its own stream while the CLI never asked about it either -- a hook that fires in
+        neither place. Sibling sessions of one agent are the same story: one of them holding a
+        table says nothing about the process the other is running.
+
+        The gate's own answer here, for the backends whose turns are read off a stream and
+        whose CLIs take no table at all -- which is every backend but two, and for those two
+        it is the floor rather than the answer: a driver that writes a table says on top of
+        this whether the process now up was given one.
+
+        Args:
+          moment: The moment.
+
+        Returns:
+          True where the moment is fired from the CLI's own table instead, which is what tells
+          this turn not to say it a second time off the stream it is reading.
+        """
+        return self._agent.hooks.gated(moment)
 
     def _fire(
         self,
@@ -3084,6 +3113,10 @@ class AgentBase(ABC):
         self._watchers: list[
             Callable[[AgentBase, SessionBase | None, Event], None]
         ] = []
+        #: The kinds of event a watcher has already failed on, so that one broken listener is
+        #: one report rather than one per thing the agent says. A watcher that raises on a
+        #: tool row raises on every tool row.
+        self._deafened: set[str] = set()
         #: What is hung on this agent's moments, which a flow adds to and takes from while
         #: the agent is running: the hooks are the flow's own callables rather than a table
         #: the backend read out of a settings file before anything started.
@@ -3994,6 +4027,15 @@ class AgentBase(ABC):
         since a turn saying something is a turn on some other thread than the one hanging a
         watcher on the agent.
 
+        Swallowed and reported, not swallowed alone. One draw that raised is one thing the
+        agent said that nobody will ever see, and an interface whose tool rows all went that
+        way reads as a turn sitting there doing nothing -- which is a hang to whoever is
+        watching it and leaves no trace at all to whoever is asked about it afterwards. Once
+        per kind per agent, since a watcher that fails on one event fails on every one of
+        them and a report per event would be the same fault a thousand times. What is said is
+        which kind was lost and what failed, never what was said: the failure is ours to hear
+        about and the turn's words are not.
+
         Args:
           event: What was said.
           session: Which conversation said it, or None for something the agent said rather
@@ -4004,8 +4046,25 @@ class AgentBase(ABC):
         with self._holding:
             watching = tuple(self._watchers)
         for listener in watching:
-            with contextlib.suppress(Exception):
+            try:
                 listener(self, session, event)
+            except Exception as why:  # noqa: BLE001 -- a watcher fails on its own account
+                with self._holding:
+                    if event.kind in self._deafened:
+                        continue
+                    self._deafened.add(event.kind)
+                # And the report is not a second thing that may take the turn down: this
+                # whole branch exists so that something looking at a flow cannot fail it, and
+                # a reporter that raised here would be the very failure it was reporting.
+                with contextlib.suppress(Exception):
+                    from hmz.runtime import telemetry
+
+                    telemetry.snag(
+                        "watcher-raised",
+                        backend=self.backend,
+                        kind=event.kind,
+                        why=type(why).__name__,
+                    )
 
     def asked(self, question: Question) -> str | None:
         """Puts something a turn stopped to ask to whoever is driving this agent.

--- a/src/hmz/coganchor/agents/claude.py
+++ b/src/hmz/coganchor/agents/claude.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from .base import AgentBase, StreamSessionBase
 from .config import AgentConfig
 from .event import Event, Question, Usage
-from .hooks import EVERYWHERE, SUBAGENTS, WAITING, Moment, about
+from .hooks import EVERYWHERE, SUBAGENTS, WAITING, Moment, about, arriving
 
 if TYPE_CHECKING:
     import os
@@ -94,6 +94,24 @@ _AS_IT_GOES = {
     "cache_read": "cache_read_input_tokens",
     "cache_write": "cache_creation_input_tokens",
 }
+
+
+@dataclass(slots=True)
+class _Reaching:
+    """A tool call the model is still writing the arguments of.
+
+    Attributes:
+      marked: Claude's own id for the call, which is what pairs an agent this one started
+        with the result that ends it.
+      named: What the tool is called, which Claude says in the first fragment of all.
+      arriving: What of its arguments has come in.
+      said: Whether the row has gone out, so that the fragments after it do not send it again.
+    """
+
+    marked: str
+    named: str
+    arriving: str = ""
+    said: bool = False
 
 
 def _result_failure(said: dict[str, Any]) -> str | None:
@@ -205,6 +223,19 @@ class ClaudeCodeSession(StreamSessionBase):
         #: a sibling session between the two reads would be written down as a name the process
         #: was told about when the process was told nothing at all, and never asked again.
         self._telling: tuple[str, ...] = ()
+        #: Whether the process now up was given a hook table of its own, and whether the
+        #: command line just built gave one -- the same pair, for the same reason: a hook hung
+        #: or taken down between two turns is a process started under the wrong answer.
+        self._gated: bool | None = None
+        self._gating = False
+        #: The tool calls whose arguments are still arriving, by the block of the message each
+        #: is being written into. The index is Claude's own numbering of the blocks of one
+        #: message, under the call the message belongs to: an agent this one started writes
+        #: its messages on this same stream and numbers its own blocks from zero.
+        self._reaching: dict[tuple[str, int], _Reaching] = {}
+        #: The calls this turn has already said, by Claude's own id for each, so that the
+        #: whole of one arriving a moment later as part of a message is not a second row.
+        self._announced: set[str] = set()
 
     @property
     def named(self) -> str | None:
@@ -247,6 +278,14 @@ class ClaudeCodeSession(StreamSessionBase):
             "--output-format",
             "stream-json",
             "--verbose",
+            # A message arrives whole when the block it is a part of has finished, and a tool
+            # call's block is not finished until the whole of what it was called with has
+            # been written -- which for a `Write` is the file. Without this the turn says
+            # nothing from the moment the model reaches for something to the moment it has
+            # finished saying what it reached with, which is a minute of silence on a large
+            # edit and reads as a turn that has hung. With it the reach is announced as it
+            # happens, and :meth:`_streaming` is what reads it.
+            "--include-partial-messages",
             *self._holding(),
             "--permission-mode",
             _PERMITTED[self._agent.config.permission],
@@ -319,10 +358,14 @@ class ClaudeCodeSession(StreamSessionBase):
         waits to be told, so that is where humanize puts the moment -- pointed at
         `hmz hook --at <socket>`, which carries it back to the hooks hung on this agent.
 
-        Said whether or not anything is hung on that moment, and not made conditional on it:
-        a hook goes up and comes down while the agent runs, and a table that depended on what
-        was hung when the process started would be a table that had to restart the process --
-        so the socket is always there, and what is hung is asked at the moment it fires.
+        Said only where something is actually hung on that moment. A table is a program Claude
+        starts and then waits for before every tool it runs, one call after another -- so a
+        table written for hooks that are not there is a relay spawned per file read and a
+        quarter of a second added to each, for nothing. A hook hung or taken down between two
+        turns is answered the way a moved effort is, by ending this process and resuming the
+        conversation in one started under the new answer; one hung while a turn is running is
+        read off that turn's own stream instead, watching the tool rather than gating it,
+        which is what `Hooks.gated` says and what every backend without a table does anyway.
 
         Not for an anchored turn, whose Claude runs on another machine: the relay is a program
         on this one talking to a socket on this one, and a table naming it over there would be
@@ -336,15 +379,45 @@ class ClaudeCodeSession(StreamSessionBase):
         settings: dict[str, Any] = {
             "fastMode": self._agent.config.service_tier == "fast"
         }
-        # Seconds, which is the unit Claude Code reads this number in. Nothing at all for an
-        # anchored turn, and nothing for a gate that could not be served: either is a turn
-        # whose `PreToolUse` is read off the stream again rather than one pointed at a socket
-        # nothing is listening on.
-        if self._agent.anchor is None and (
-            table := self._agent.hooks.gate().table(WAITING)
-        ):
+        # Read once and kept, so that what the process is recorded as having been told is what
+        # this line actually tells it: a hook hung by a sibling session between two reads
+        # would otherwise be written down as a table the process never got.
+        self._gating = self._hooking()
+        # Seconds, which is the unit Claude Code reads this number in. Nothing at all for a
+        # gate that could not be served, which is a turn whose `PreToolUse` is read off the
+        # stream again rather than one pointed at a socket nothing is listening on.
+        if self._gating and (table := self._agent.hooks.gate().table(WAITING)):
             settings["hooks"] = table
         return settings
+
+    def _asking(self, moment: Moment) -> bool:
+        """Whether the Claude now running this conversation was given a table of its own.
+
+        What the process was told rather than what is hung now: `--settings` is read when
+        Claude starts, so a hook hung after that is one this process will never stop to ask
+        about, and the moment has to go on being read off this turn's own stream until the
+        turn after has started a Claude that was told.
+
+        Args:
+          moment: The moment.
+
+        Returns:
+          True where this process asks about it and waits to be told.
+        """
+        return bool(self._gated) and super()._asking(moment)
+
+    def _hooking(self) -> bool:
+        """Whether a Claude started now would be given a hook table of its own.
+
+        Returns:
+          True where this machine runs the turn and something is hung on the one moment a
+          table is for. Asked as a question of its own because two places need the same
+          answer: the line that builds the settings, and the one that says whether the
+          process now up was built under a different one.
+        """
+        return self._agent.anchor is None and self._agent.hooks.hooked(
+            Moment.PRE_TOOL_USE
+        )
 
     def _write(self, text: str, ticket: str = "") -> str:
         """Renders one thing to say as the user message Claude reads it as.
@@ -378,8 +451,10 @@ class ClaudeCodeSession(StreamSessionBase):
         self._counted, self._fed, self._seen = {}, Counter(), {}
         # And whatever was under the turn the last process was taking: it went with it.
         self._fleet = {}
+        self._reaching, self._announced = {}, set()
         self._at = self.effort
         self._offering = self._telling
+        self._gated = self._gating
 
     def _offered(self) -> tuple[str, ...]:
         """What a Claude started now would be told the flow's own callbacks are.
@@ -405,8 +480,15 @@ class ClaudeCodeSession(StreamSessionBase):
         same way. What is compared is the list the process was actually told, not whether it
         was told anything: a tool swapped for another is one the model has never heard of and
         one it can still reach for and be told is not there.
+
+        And so is the hook table: `--settings` is read when Claude starts, so a hook hung
+        after it started is one the CLI would never stop to ask about, and one taken down is a
+        relay still being spawned before every tool for nobody. The first turn after either
+        runs in a process told which it is.
         """
         if self._at is not None and self._at != self.effort:
+            return True
+        if self._gated is not None and self._gated != self._hooking():
             return True
         return self._offering is not None and self._offering != self._offered()
 
@@ -510,19 +592,29 @@ class ClaudeCodeSession(StreamSessionBase):
 
         A message carries a list of parts, and thinking, speaking and reaching for a tool can
         all be in the same one -- so every part is read, not the first that says anything.
+        What was thought and what was said are read there, whole: Claude closes each part with
+        a message of its own, so the utterance is already the utterance rather than fragments
+        of one. Only the reach for a tool is read out of the fragments, by `_streaming`, and
+        only because the fragments of that one are the whole of what is being waited for.
 
         Args:
           line: The line, as written.
 
         Yields:
-          What it said, which is nothing for a line saying nothing worth showing: a partial
-          chunk, a tool's result coming back, or something a later Claude has added.
+          What it said, which is nothing for a line saying nothing worth showing: a tool's
+          result coming back, a fragment of words still being written, or something a later
+          Claude has added.
         """
         try:
             said: dict[str, Any] = json.loads(line)
         except json.JSONDecodeError:
             return  # not ours: Claude prints the odd plain line among the JSON
-        if said.get("type") == "control_request":
+        if said.get("type") == "stream_event":
+            yield from self._streaming(
+                cast("dict[str, Any]", said.get("event") or {}),
+                str(said.get("parent_tool_use_id") or ""),
+            )
+        elif said.get("type") == "control_request":
             # Claude waits on the answer, so one left unanswered is a turn that never ends.
             self._answer(said)
         elif said.get("type") == "command_lifecycle":
@@ -556,6 +648,9 @@ class ClaudeCodeSession(StreamSessionBase):
                 self._adopt(self._named)  # a turn has landed, so the session is open
             tokens, risen = self._spent(said)
             self._settle(risen)
+            # The turn is over, so what it reached for is nothing the next one has to know
+            # about: a session takes thousands of turns, and these would grow with all of them.
+            self._reaching, self._announced = {}, set()
             yield Event(
                 kind="result",
                 text=str(said.get("result") or ""),
@@ -572,17 +667,16 @@ class ClaudeCodeSession(StreamSessionBase):
                 ):
                     yield Event(kind="reasoning", text=part["thinking"])
                 elif part.get("type") == "tool_use":
-                    # The name and what it was called on, which is what a tool call reads
-                    # as: `Read src/x.py`, `Bash git status`. Only what will fit on a row.
-                    called: dict[str, Any] = part.get("input") or {}
-                    named = str(part.get("name") or "tool")
-                    said_as = f"{named} {about(called)}".strip()[:120]
-                    if named in _FLEET:
-                        marked = str(part.get("id") or "")
-                        self._fleet[marked] = said_as
-                        yield Event(kind="subagent", text=said_as, whose=marked)
+                    marked = str(part.get("id") or "")
+                    if marked and marked in self._announced:
+                        # Said as the model reached for it, rather than here where the whole
+                        # of what it reached with has finally arrived. Saying it again would
+                        # be two rows for one call.
                         continue
-                    yield Event(kind="tool", text=said_as)
+                    called: dict[str, Any] = part.get("input") or {}
+                    yield from self._called(
+                        marked, str(part.get("name") or "tool"), about(called)
+                    )
         elif said.get("type") == "user":
             # A tool answering, which is the only thing said back to Claude on this stream
             # that is worth reading: one of them is an agent of its own having finished.
@@ -592,6 +686,102 @@ class ClaudeCodeSession(StreamSessionBase):
                 marked = str(part.get("tool_use_id") or "")
                 if was := self._fleet.pop(marked, ""):
                     yield Event(kind="subagent-ends", text=was, whose=marked)
+
+    def _streaming(self, event: dict[str, Any], under: str) -> Iterator[Event]:
+        """Reads one piece of a message Claude is still writing.
+
+        `--include-partial-messages` is on for one thing, and this is it. A tool call is
+        announced here the moment the model reaches for it; in the message that carries the
+        call it is announced only once the arguments have all arrived, and for a `Write` those
+        arguments are the file. Between the two the turn says nothing whatever, which is a
+        minute of silence on a large edit and reads from outside as an agent that has hung.
+
+        Nothing else is read from here. What was thought and what was said arrive whole on the
+        message Claude closes each part with, and that is the utterance rather than the
+        fragments of one -- a row per fragment is a paragraph broken into fifty answers.
+
+        Args:
+          event: What the line carried, which is Anthropic's own streaming event.
+          under: The tool call this message is being written under -- "" for the agent's own
+            and the id of the call for an agent it started. Both are written on this one
+            stream, and each numbers the blocks of its own messages from zero.
+
+        Yields:
+          The call, as soon as there is enough of its arguments to say what it is about.
+        """
+        at = (under, int(cast("int", event.get("index") or 0)))
+        match event.get("type"):
+            case "content_block_start":
+                block = cast("dict[str, Any]", event.get("content_block") or {})
+                if block.get("type") == "tool_use":
+                    self._reaching[at] = _Reaching(
+                        marked=str(block.get("id") or ""),
+                        named=str(block.get("name") or "tool"),
+                    )
+            case "content_block_delta":
+                delta = cast("dict[str, Any]", event.get("delta") or {})
+                reaching = self._reaching.get(at)
+                if (
+                    reaching is None
+                    or reaching.said
+                    or delta.get("type") != "input_json_delta"
+                ):
+                    return
+                reaching.arriving += str(delta.get("partial_json") or "")
+                if words := arriving(reaching.arriving):
+                    reaching.said = True
+                    yield from self._called(reaching.marked, reaching.named, words)
+            case "content_block_stop":
+                reaching = self._reaching.pop(at, None)
+                if (
+                    reaching is None
+                    or reaching.said
+                    or reaching.marked in self._announced
+                ):
+                    # Said as the model reached for it, or said by the message that carries
+                    # the call whole -- which lands a moment before this on a Claude that is
+                    # keeping up. Either way this is the second time round.
+                    return
+                # Nothing among the arguments said anything early enough to say it with, and
+                # no message has carried the call. They have all arrived now, so they are read
+                # the way that message would have read them: one call reads as one row
+                # whichever of the two got there first.
+                reaching.said = True
+                try:
+                    whole = json.loads(reaching.arriving or "{}")
+                except json.JSONDecodeError:
+                    whole = {}
+                yield from self._called(
+                    reaching.marked,
+                    reaching.named,
+                    about(cast("dict[str, Any]", whole))
+                    if isinstance(whole, dict)
+                    else "",
+                )
+            case _:  # a message starting or ending, and the fragments of words
+                pass
+
+    def _called(self, marked: str, named: str, about_it: str) -> Iterator[Event]:
+        """One tool call, as the row a transcript has room for.
+
+        Args:
+          marked: Claude's own id for the call, which is what pairs an agent this one started
+            with the result that ends it.
+          named: What the tool is called.
+          about_it: What it was called on, as far as anybody knows it yet.
+
+        Yields:
+          The call: `Read src/x.py`, `Bash git status`. As a `subagent` where what it starts
+          is an agent of its own, since a fleet under a turn is agents rather than tool calls.
+        """
+        if marked:
+            self._announced.add(marked)
+        said_as = f"{named} {about_it}".strip()[:120]
+        if named in _FLEET:
+            self._fleet[marked] = said_as
+            yield Event(kind="subagent", text=said_as, whose=marked)
+            return
+        yield Event(kind="tool", text=said_as)
 
     def _answer(self, said: dict[str, Any]) -> None:
         """Answers something Claude asked of us over the same stream the turn is read from.

--- a/src/hmz/coganchor/agents/event.py
+++ b/src/hmz/coganchor/agents/event.py
@@ -275,11 +275,16 @@ class Event:
       kind: What was said. `text` is the agent talking, `reasoning` is it thinking aloud,
         `tool` is it using one, and `result` is the answer the turn ends on -- exactly one
         of which closes a turn. `failed` closes it the other way, carrying what went wrong
-        in place of an answer. A watcher sees five more: `begins` and `ends`, which bracket
+        in place of an answer. A watcher sees six more: `begins` and `ends`, which bracket
         the turn itself, `asks`, which is the agent stopping to ask its user something,
         `took`, which is the agent saying that a word put into the turn is now in front of
-        it -- carrying that word, so that whoever said it knows which one landed -- and
-        `subagent` and `subagent-ends`, which bracket an agent this one started of its own.
+        it -- carrying that word, so that whoever said it knows which one landed --
+        `subagent` and `subagent-ends`, which bracket an agent this one started of its own,
+        and `notice`, which is humanize rather than the agent: a turn waiting out a rate
+        limit, carried to another account, cut off, or taken away from a backend that had
+        stopped saying anything. A `notice` is not the working, and must not be hidden with
+        it -- a turn told to wait half a minute and a turn that has hung look identical from
+        outside, and the one thing that tells them apart is the line saying which it is.
       text: The words themselves, ready to be shown. For a `subagent` it is what the agent
         under this one is called and what it was asked to do.
       whose: Which of a turn's several things this is about, where a turn has several going

--- a/src/hmz/coganchor/agents/hooks.py
+++ b/src/hmz/coganchor/agents/hooks.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 import threading
 import weakref
 from dataclasses import dataclass, field
@@ -52,6 +53,7 @@ __all__ = [
     "Verdict",
     "about",
     "answers",
+    "arriving",
 ]
 
 
@@ -382,17 +384,21 @@ class Hooks:
           moment: The moment.
 
         Returns:
-          True where a gate is serving it, which is what tells a session not to say the moment
-          a second time off the stream it is reading: the CLI has already asked, and a turn
-          that fired the moment twice would be one whose hooks ran twice for one tool. False
-          for a gate that could not be served at all, whose turns go on reading the moment off
-          the stream rather than reading it nowhere.
+          True where a gate is serving it and something is hung on it, which is what tells a
+          session not to say the moment a second time off the stream it is reading: the CLI
+          has already asked, and a turn that fired the moment twice would be one whose hooks
+          ran twice for one tool. False for a gate that could not be served at all, whose
+          turns go on reading the moment off the stream rather than reading it nowhere -- and
+          false with nothing hung, because a CLI is only given a table for a moment something
+          is waiting on, so a gate that was up for an earlier hook is not a gate this turn's
+          process was told about.
         """
         with self._lock:
             return (
                 self._gate is not None
                 and moment in self._gate.moments
                 and self._gate.serving
+                and bool(self._hung.get(moment))
             )
 
 
@@ -431,6 +437,72 @@ def about(called: Mapping[str, Any]) -> str:
         ),
         "",
     )
+
+
+#: One thing at a time out of half-written JSON: a string that has been *closed*, or one of
+#: the characters that says where in the object the next thing is. A string still arriving
+#: matches nothing, which is the whole point -- half a value is half a path, and a row saying
+#: `write /tmp/se` would be worse than no row.
+_TOKENS = re.compile(r'"(?:[^"\\]|\\.)*"|[][{}:,]')
+
+#: How far into the arguments this looks before it gives up and waits for the end. A row has
+#: room for a line, and a value that has not finished in four thousand characters is the file
+#: being written rather than the path it is being written to -- so reading further is reading
+#: the whole of a growing buffer again on every fragment of it, for something not worth
+#: showing.
+_ROOM = 4096
+
+
+def arriving(partial: str) -> str:
+    """The same, read off arguments that have not all arrived yet.
+
+    A CLI streams what a tool was called with, and the message that carries the call whole
+    lands only once the last fragment has -- which for a `write` is the entire file, and so is
+    minutes on a slow model in which the agent has reached for something and the turn has said
+    nothing at all. The path and the command are in the first fragments, so this is what a row
+    can say as soon as there is anything to say.
+
+    The same answer :func:`about` gives, said earlier: the first value of the object itself
+    that is words, which means the same string in the same place whether a row was drawn from
+    the fragments or from the whole. Nothing nested is reached into, because `about` reaches
+    into nothing, and a hook told two different things about one tool call depending on how
+    its CLI happened to send it would be worse than one told nothing.
+
+    Args:
+      partial: The call's input as JSON, which is as much of it as has come in.
+
+    Returns:
+      The first thing in it that is words -- the path, the command, the query -- and "" while
+      nothing in it has finished arriving, which is a row that waits for the next fragment
+      rather than one that says half a path.
+    """
+    depth = 0
+    # Whether what comes next is a value of the object itself, rather than its key or
+    # something inside one of its values.
+    valued = False
+    for found in _TOKENS.finditer(partial[:_ROOM]):
+        said = found.group()
+        if said in ("[", "{"):
+            depth += 1
+        elif said in ("]", "}"):
+            depth -= 1
+        elif said == ":":
+            valued = depth == 1
+        elif said == ",":
+            valued = False
+        elif valued and depth == 1:
+            valued = False
+            # Through the reader rather than as it stands: what arrives is JSON, so a newline
+            # in a command is two characters and a quote in it is escaped. An escape JSON does
+            # not have is not a value this can name, and is the end of the reading: whatever
+            # wrote it is not writing what this is here to read.
+            try:
+                words = str(json.loads(said))
+            except json.JSONDecodeError:
+                return ""
+            if words.strip():
+                return words
+    return ""
 
 
 def answers(line: str, hooks: Hooks) -> str:
@@ -583,11 +655,15 @@ class Gate:
     nothing of the user's own settings is read, written or replaced, so a person's own hooks go
     on being theirs and a flow that ends leaves nothing behind.
 
-    Started once and held for as long as the agent is, rather than per turn and rather than
-    only while something is hung: a hook is hung on a live agent and taken down again while it
-    runs, so a table installed only for the hooks that happened to be up when the CLI started
-    would be a flow whose later hooks quietly did nothing. What is hung is asked at the moment
-    it fires, which is the only moment the answer is true.
+    Started when a turn is first run under a hook, and then held for as long as the agent is
+    rather than made again per turn: a CLI restarted mid-session reaches the same socket it
+    always did. Asked for only where something is actually hung on the moment, because a table
+    is a program the CLI starts and waits for before every tool it runs -- a relay per file
+    read, one after another, for hooks that are not there. A hook hung or taken down between
+    two turns is answered the way a changed effort is, by starting the next turn in a process
+    told the new answer; one hung while a turn is running is read off that turn's own stream
+    instead, watching the tool rather than gating it. What is hung is still asked at the moment
+    it fires, which is the only moment that answer is true.
     """
 
     #: The moments a CLI's own table is pointed here for. One, because one is what this is

--- a/src/hmz/coganchor/agents/pi.py
+++ b/src/hmz/coganchor/agents/pi.py
@@ -20,15 +20,25 @@ from hmz import home
 from .base import AgentBase, StreamSessionBase
 from .config import AgentConfig
 from .event import Event, Question, Usage
+from .hooks import arriving
 from .preload import preloaded
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
 
 #: What each kind of thing pi says a turn did reads as. A message is a list of parts and pi
-#: says each of them twice -- once as it starts and once with the whole of it -- so only the
-#: ends are read: they are the only ones that carry any words.
+#: says each of them three times -- as it starts, once per fragment, and once with the whole
+#: of it -- and for words the end is the only one worth reading: a row per fragment is one
+#: paragraph broken into fifty answers of a word each.
 _PARTS = {"text_end": "text", "thinking_end": "reasoning", "toolcall_end": "tool"}
+
+#: The three pi says a tool call under, and all three are read. A call's end is the moment its
+#: arguments have all arrived, and its arguments are what it was called with -- so for a
+#: `write` that end is the whole of the file, and a row held for it is a minute in which the
+#: agent has reached for something and the turn has said nothing at all. pi hands over the
+#: fragments as they came, so the row goes out at the first one there is anything to say it
+#: about.
+_REACHING = ("toolcall_start", "toolcall_delta", "toolcall_end")
 
 #: The ways an extension may stop a turn to ask the person at the prompt something. The rest
 #: of what one may put on the screen -- a notice, a status, a widget -- is told rather than
@@ -134,6 +144,10 @@ class PiSession(StreamSessionBase):
         #: What the process now up was last told to think at, so that a flow moving the
         #: effort mid-session is told to pi rather than left on the flag it was started with.
         self._at: str | None = None
+        #: The calls this turn has already said, by pi's own id for each, so that the row goes
+        #: out at the first fragment of the arguments that says anything and not again at
+        #: every fragment after it.
+        self._reaching: set[str] = set()
 
     @property
     def named(self) -> str | None:
@@ -250,6 +264,7 @@ class PiSession(StreamSessionBase):
     def _restarted(self) -> None:
         """Forgets the turn the last process was in the middle of, which this one is not."""
         self._said, self._failed, self._spent, self._costing = "", None, 0, Usage()
+        self._reaching = set()
         self._at = self.effort
 
     def _read(self, line: str) -> Iterator[Event]:
@@ -309,31 +324,79 @@ class PiSession(StreamSessionBase):
                 pass
 
     def _part(self, event: dict[str, Any]) -> Iterator[Event]:
-        """Reads one part of a message pi has finished writing.
+        """Reads one part of a message pi is writing.
 
         Args:
           event: The `assistantMessageEvent`, as read.
 
         Yields:
-          What the agent said or reached for, and nothing for a part still being written.
+          What the agent said, once its part is written, and what it reached for, as soon as
+          there is enough of the call to say what it is about.
         """
-        kind = _PARTS.get(str(event.get("type") or ""))
-        if kind is None:
+        named = str(event.get("type") or "")
+        if named in _REACHING:
+            yield from self._reaches(event)
             return
-        if kind == "tool":
-            called: dict[str, Any] = event.get("toolCall") or {}
-            arguments: dict[str, Any] = called.get("arguments") or {}
-            # The name and what it was called on, which is what a tool call reads as:
-            # `bash echo hi`, `read src/x.py`. Only what will fit on a row.
-            yield Event(
-                kind="tool",
-                text=f"{called.get('name') or 'tool'} {_about(arguments)}".strip()[
-                    :120
-                ],
-            )
+        kind = _PARTS.get(named)
+        if kind is None:
             return
         if (words := str(event.get("content") or "")).strip():
             yield Event(kind=kind, text=words)
+
+    def _reaches(self, event: dict[str, Any]) -> Iterator[Event]:
+        """Says that the agent has reached for something, once, as early as it can be said.
+
+        pi carries the call itself on the event that ends it and the message so far on all
+        three, so the block this event is about says what the call is called before it says
+        what it was called on. The row goes out at the first fragment that finishes a value in
+        the arguments rather than at the end, because the end is where the arguments stop
+        arriving and the arguments are the file.
+
+        Read off `partialJson`, which is those fragments as they came, rather than off the
+        `arguments` pi parses them into: that parse repairs what is half-written, so a value
+        still arriving reads as a whole one and the row would say `write /tmp/se`.
+
+        Args:
+          event: The `assistantMessageEvent`, which is a `toolcall_start`, a `toolcall_delta`
+            or a `toolcall_end`.
+
+        Yields:
+          The call: `bash echo hi`, `write src/x.py`. Only what will fit on a row, and nothing
+          at all for a call already said or one whose arguments have said nothing yet.
+        """
+        ending = str(event.get("type")) == "toolcall_end"
+        called: dict[str, Any] = event.get("toolCall") or {}
+        if not called:
+            # Not the end, so the block being written is where the call is: pi numbers the
+            # parts of the message it hands over on every one of these.
+            message: dict[str, Any] = event.get("partial") or {}
+            parts = cast("list[Any]", message.get("content") or [])
+            at = int(cast("int", event.get("contentIndex") or 0))
+            if not 0 <= at < len(parts):
+                return
+            called = cast("dict[str, Any]", parts[at])
+        # A call pi gave no id is said where it always was, at the end: there is nothing to
+        # tell it from the next one, and folding every unnamed call onto one blank id would
+        # say the first and silently drop every call after it.
+        marked = str(called.get("id") or "")
+        if not marked:
+            if not ending:
+                return
+        elif marked in self._reaching:
+            return  # said already, as the model reached for it
+        words = (
+            _about(cast("dict[str, Any]", called.get("arguments") or {}))
+            if ending
+            else arriving(str(called.get("partialJson") or ""))
+        )
+        if not words and not ending:
+            return  # nothing among the arguments has finished arriving to say it about
+        if marked:
+            self._reaching.add(marked)
+        yield Event(
+            kind="tool",
+            text=f"{called.get('name') or 'tool'} {words}".strip()[:120],
+        )
 
     def _message(self, message: dict[str, Any]) -> None:
         """Takes what one request to the model came to, as it comes back.
@@ -384,6 +447,9 @@ class PiSession(StreamSessionBase):
         """
         said, failed, spent, turn = self._said, self._failed, self._spent, self._costing
         self._said, self._failed, self._spent, self._costing = "", None, 0, Usage()
+        # The turn is over, so what it reached for is nothing the next one has to know about:
+        # a session takes thousands of turns, and this would grow with all of them.
+        self._reaching = set()
         tokens = {self._agent.config.model: spent} if spent > 0 else {}
         if failed is not None and not said:
             return Event(kind="failed", text=failed, tokens=tokens, spent=turn)

--- a/src/hmz/coganchor/agents/qwen.py
+++ b/src/hmz/coganchor/agents/qwen.py
@@ -35,7 +35,7 @@ from ._inputs import snapshot
 from .base import AgentBase, CommandSessionBase, SessionBase, StreamSessionBase
 from .config import AgentConfig
 from .event import Event, Failed, Usage
-from .hooks import WAITING, Gate
+from .hooks import WAITING, Gate, Moment
 from .preload import preloaded
 
 if TYPE_CHECKING:
@@ -260,6 +260,12 @@ class QwenCodeSession(StreamSessionBase):
         self._announced: str | None = None
         self._launched: tuple[object, ...] | None = None
         self._requested: tuple[object, ...] = ()
+        #: Whether the settings file this turn is run against holds a hook table. Written
+        #: where that file is built and read where a moment is about to be said off the
+        #: stream: a gate outlives the hook that asked for it, so a turn that was not given a
+        #: table has to go on saying the moment itself rather than leaving it to a CLI that
+        #: was never told to ask.
+        self._tabled = False
 
     def _stream(
         self, prompt: str, *, schema: type[BaseModel] | None = None
@@ -374,6 +380,22 @@ class QwenCodeSession(StreamSessionBase):
                     )
         return snapshot(paths)
 
+    def _asking(self, moment: Moment) -> bool:
+        """Whether the Qwen Code running this conversation was pointed at a table of its own.
+
+        What the file the process was started against holds rather than what is hung now: a
+        hook hung after it started is one this process will never stop to ask about, and the
+        moment has to go on being read off this turn's own stream until the turn after has
+        started one that was told.
+
+        Args:
+          moment: The moment.
+
+        Returns:
+          True where this process asks about it and waits to be told.
+        """
+        return self._tabled and super()._asking(moment)
+
     def _stale(self) -> bool:
         """Restarts before settings or mounted flow resources change."""
         return self._launched is not None and self._launched != self._requested
@@ -474,7 +496,11 @@ class QwenCodeSession(StreamSessionBase):
         `PreToolUse` read off the stream this session reads arrives after Qwen Code has
         announced the tool and is about to run it, and Qwen Code's own table is the one place
         it stops and waits to be told. Not for an anchored turn, whose `qwen` runs on another
-        machine and could not reach the socket the relay carries the moment to.
+        machine and could not reach the socket the relay carries the moment to -- and not for
+        an agent with nothing hung on that moment: a table is a program the CLI starts and
+        waits for before every tool it runs, so writing one for hooks that are not there is a
+        relay spawned per file read, one after another, for nobody. Hanging one or taking it
+        down moves the file, and a moved settings file is a process started again under it.
 
         And where the CLI's compiled bundle is kept between processes, unless whoever started
         the flow has said where themselves: a session a turn is a Node process a turn, and
@@ -484,7 +510,13 @@ class QwenCodeSession(StreamSessionBase):
         what a turn of it actually runs, reads, writes and opens can be read from inside the process
         it runs in. :mod:`hmz.coganchor.agents.preload` is what decides whether one is wanted.
         """
-        gate = self._agent.hooks.gate() if self._agent.anchor is None else None
+        gate = (
+            self._agent.hooks.gate()
+            if self._agent.anchor is None
+            and self._agent.hooks.hooked(Moment.PRE_TOOL_USE)
+            else None
+        )
+        self._tabled = gate is not None and gate.serving
         held = {
             **super()._environment(),
             _SETTINGS: str(_thinking(self.effort, gate)),

--- a/src/hmz/coganchor/agents/watchdog.py
+++ b/src/hmz/coganchor/agents/watchdog.py
@@ -659,11 +659,13 @@ class Watchdog:
 
         As the retries and the fallbacks say themselves, and for the same reason: what a flow
         can see is what it can act on, and an agent quietly restarted under a watcher is a
-        watcher reading a lie.
+        watcher reading a lie. A `notice` for that reason too -- this is the line that says a
+        silence was noticed, so an interface that hid it with the working would hide it from
+        exactly the person sitting in front of the silence.
 
         Args:
           what: The step, said of the backend.
         """
         self._session._heard(
-            Event(kind="tool", text=f"{self._session._agent.backend} {what}")
+            Event(kind="notice", text=f"{self._session._agent.backend} {what}")
         )

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -3255,6 +3255,7 @@ class Humanize(App[None]):
             "ends",
             "failed",
             "asks",
+            "notice",
             "tool",
             "text",
             "result",
@@ -3368,6 +3369,18 @@ class Humanize(App[None]):
                     f"{'started' if event.kind == 'subagent' else 'done'}[/]",
                     packs=True,
                 )
+        elif event.kind == "notice":
+            # Not the working, so `/details` does not hide it: this is humanize saying what it
+            # is doing about a turn -- waiting out a rate limit, carrying on as another
+            # account, cutting the turn off, taking it away from a backend that had stopped
+            # saying anything. Hidden with the tool rows it reads as a hang, which is the one
+            # thing the line exists to tell apart from a hang.
+            self._on_screen(
+                self._part,
+                whose,
+                f"[yellow]{_SAID}[/] [dim]{escape(event.text)}[/]",
+                packs=False,
+            )
         elif event.kind == "tool" and self._details:
             # The tool on the bullet, what it came back with under it -- Claude Code's shape.
             named, _, about = escape(event.text).partition(" ")

--- a/tests/agents/test_agent_fallback.py
+++ b/tests/agents/test_agent_fallback.py
@@ -290,7 +290,7 @@ def test_a_model_that_is_gone_walks_no_account_before_it_takes_the_step(
     said: list[str] = []
     agent.watch(
         lambda _agent, _session, event: (
-            said.append(event.text) if event.kind == "tool" else None
+            said.append(event.text) if event.kind == "notice" else None
         )
     )
 
@@ -318,7 +318,7 @@ def test_a_turn_that_failed_for_nothing_anybody_named_steps_as_it_always_did(
     said: list[str] = []
     agent.watch(
         lambda _agent, _session, event: (
-            said.append(event.text) if event.kind == "tool" else None
+            said.append(event.text) if event.kind == "notice" else None
         )
     )
 

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -27,6 +27,7 @@ from hmz.coganchor.agents import (
     ClaudeCodeAgent,
     ClaudeCodeAgentConfig,
     CommandSessionBase,
+    Event,
     Question,
     Stopped,
 )
@@ -772,6 +773,60 @@ def test_an_agent_takes_the_name_a_flow_calls_it_unless_it_has_one() -> None:
 
     assert named.id == "actor"  # a name given where the agent was made is the name
     assert unnamed.id == "reviewer"
+
+
+def test_a_watcher_that_raises_is_reported_rather_than_only_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A draw that failed is a thing the agent said that nobody will ever see.
+
+    Swallowed in silence, a run whose rows all went that way reads as a turn sitting there
+    doing nothing -- a hang to whoever is watching it and no trace at all afterwards. Once
+    per kind, since a watcher that fails on one event fails on every one of them.
+    """
+    from hmz.runtime import telemetry
+
+    agent = ClaudeCodeAgent(CONFIG)
+    heard: list[str] = []
+    reported: list[tuple[str, object]] = []
+
+    def noted(name: str, **said: object) -> None:
+        reported.append((name, said.get("kind")))
+
+    monkeypatch.setattr(telemetry, "snag", noted)
+
+    def broken(_agent: object, _session: object, event: Event) -> None:
+        raise RuntimeError(event.kind)
+
+    agent.watch(broken)
+    agent.watch(lambda _agent, _session, event: heard.append(event.kind))
+
+    for _ in range(3):
+        agent._heard(Event(kind="tool", text="Read x.py"))
+    agent._heard(Event(kind="text", text="hello"))
+
+    # The turn is untouched, and so is every other watcher.
+    assert heard == ["tool", "tool", "tool", "text"]
+    assert reported == [("watcher-raised", "tool"), ("watcher-raised", "text")]
+
+
+def test_a_report_that_will_not_be_made_is_not_a_turn_that_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The branch exists so a watcher cannot fail a flow; the reporting must not either."""
+    from hmz.runtime import telemetry
+
+    def unreportable(name: str, **said: object) -> None:
+        del name, said
+        raise OSError("no reporting from here")
+
+    monkeypatch.setattr(telemetry, "snag", unreportable)
+    agent = ClaudeCodeAgent(CONFIG)
+    agent.watch(lambda _agent, _session, _event: (_ for _ in ()).throw(RuntimeError()))
+
+    agent._heard(
+        Event(kind="tool", text="Read x.py")
+    )  # says nothing, and raises nothing
 
 
 def test_a_question_reaches_whoever_is_driving_the_agent_and_nobody_otherwise() -> None:

--- a/tests/agents/test_hooks_gate.py
+++ b/tests/agents/test_hooks_gate.py
@@ -299,6 +299,7 @@ def test_claude_is_told_where_this_agent_s_moments_are_on_its_own_command_line()
 ):
     """`--settings` is the whole of a settings file for one run: no file of anybody's."""
     agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high"))
+    agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
     session = agent.new()
 
     argv = session._command()
@@ -316,6 +317,7 @@ def test_claude_is_told_where_this_agent_s_moments_are_on_its_own_command_line()
 def test_qwen_is_told_through_the_settings_file_it_is_already_pointed_at() -> None:
     """One file for one run, at the layer that outranks what a person has configured."""
     agent = QwenCodeAgent(AgentConfig(model="m", effort="high"))
+    agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
     session = agent.new()
 
     where = session._environment()[_SETTINGS]
@@ -335,6 +337,8 @@ def test_two_agents_are_two_gates_and_two_settings_files() -> None:
     """A file keyed by effort alone would point one agent's turns at another's socket."""
     one = QwenCodeAgent(AgentConfig(model="m", effort="high"))
     two = QwenCodeAgent(AgentConfig(model="m", effort="high"))
+    for agent in (one, two):
+        agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
 
     theirs = [agent.new()._environment()[_SETTINGS] for agent in (one, two)]
 
@@ -349,6 +353,7 @@ def test_a_moment_the_backend_itself_asks_about_is_not_said_twice() -> None:
     assert not hooks.gated(Moment.PRE_TOOL_USE)
     assert hooks.gated(Moment.STOP) is False
 
+    hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
     gate = hooks.gate()
     try:
         assert hooks.gated(Moment.PRE_TOOL_USE)
@@ -357,6 +362,119 @@ def test_a_moment_the_backend_itself_asks_about_is_not_said_twice() -> None:
         assert not hooks.gated(Moment.USER_PROMPT_SUBMIT)
     finally:
         gate.close()
+
+
+def test_a_moment_nothing_is_hung_on_is_not_gated_by_a_gate_from_an_earlier_hook() -> (
+    None
+):
+    """A CLI is only given a table for a moment something waits on, so nor is this one.
+
+    A gate outlives the hook that first asked for it, and a session reading `gated` to decide
+    whether to say the moment off its own stream would otherwise stop saying it for good --
+    the CLI having no table any more and this saying it had one.
+    """
+    hooks = _hooks()
+    hung = hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
+    gate = hooks.gate()
+    try:
+        assert hooks.gated(Moment.PRE_TOOL_USE)
+
+        hung.off()
+
+        assert not hooks.gated(Moment.PRE_TOOL_USE)
+    finally:
+        gate.close()
+
+
+def test_a_claude_with_nothing_hung_on_the_moment_is_given_no_table_at_all() -> None:
+    """A table is a program started and waited for before every tool the turn runs.
+
+    Written for hooks that are not there it is a relay spawned per file read, one after
+    another, adding its own quarter-second to each for nobody.
+    """
+    agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high"))
+    session = agent.new()
+
+    argv = session._command()
+    settings = json.loads(argv[argv.index("--settings") + 1])
+
+    assert "hooks" not in settings
+    # So the moment is read off the stream instead, which is what every backend does.
+    assert not agent.hooks.gated(Moment.PRE_TOOL_USE)
+    # And nothing was ever bound: a socket per agent that never had a hook is a socket, a
+    # thread and a directory for each of them.
+    assert agent.hooks._gate is None
+
+
+def test_a_hook_hung_between_two_turns_restarts_the_claude_that_was_not_told() -> None:
+    """`--settings` is read when the process starts, so a later hook is one it never hears.
+
+    The same answer a moved effort gets: this turn ends the process and resumes the
+    conversation in one started under what is true now.
+    """
+    agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high"))
+    session = agent.new()
+    session._command()
+    session._restarted()
+
+    assert not session._stale()
+
+    hung = agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
+
+    assert session._stale()
+
+    # And back again: a hook taken down leaves a process spawning a relay for nobody.
+    session._command()
+    session._restarted()
+    assert not session._stale()
+    hung.off()
+    assert session._stale()
+
+
+def test_a_turn_whose_cli_was_told_nothing_goes_on_saying_the_moment_itself() -> None:
+    """A gate outlives the hook that asked for it; a process is told once, when it starts.
+
+    So a hook hung while a turn is already running must be read off that turn's own stream --
+    watching the tool rather than gating it -- rather than left to a CLI that was never told
+    to ask. Read off the process and not off the agent, or the moment fires in neither place.
+    """
+    agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high"))
+    hung = agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
+    told = agent.new()
+    told._command()
+    told._restarted()
+
+    assert told._asking(Moment.PRE_TOOL_USE)
+
+    # The hook comes down, and the next turn starts a Claude with no table in it.
+    hung.off()
+    untold = agent.new()
+    untold._command()
+    untold._restarted()
+
+    assert not untold._asking(Moment.PRE_TOOL_USE)
+
+    # And now one goes up again, mid-turn, on the agent whose gate is still serving.
+    agent.hooks.on(Moment.PRE_TOOL_USE, lambda _one: None)
+
+    assert not untold._asking(Moment.PRE_TOOL_USE)
+    # The one whose process was told still leaves it to the CLI, which is still asking.
+    assert told._asking(Moment.PRE_TOOL_USE)
+
+
+def test_a_qwen_with_nothing_hung_on_the_moment_is_given_no_table_at_all() -> None:
+    """The same, through the file Qwen Code is pointed at rather than through a flag."""
+    agent = QwenCodeAgent(AgentConfig(model="m", effort="high"))
+    session = agent.new()
+
+    where = session._environment()[_SETTINGS]
+    settings = json.loads(open(where, encoding="utf-8").read())  # noqa: SIM115, PTH123
+
+    assert "hooks" not in settings
+    assert "disableAllHooks" not in settings
+    # And what the file was already for is still in it.
+    assert settings["model"]["reasoningEffort"] == "high"
+    assert agent.hooks._gate is None
 
 
 def test_a_backend_with_no_table_of_its_own_goes_on_watching_its_stream() -> None:

--- a/tests/agents/test_reaching.py
+++ b/tests/agents/test_reaching.py
@@ -1,0 +1,415 @@
+"""When a turn says the agent has reached for something, which is not when it has finished.
+
+A tool call's arguments are what it was called with, and for a `Write` they are the file: a
+driver that waits for the whole of them before saying anything says nothing for as long as the
+model takes to write the file, which on a slow one is minutes of a turn that looks hung. What
+is checked here is that the row goes out at the first fragment there is anything to say it
+about, and exactly once however many ways the backend then repeats the call.
+
+Against the protocol rather than against live CLIs, for the reason `tests/agents/test_hooks_gate.py`
+is written that way: what is owed to the two ends is exact, and reading it off a real turn
+would be reading it off whatever that model happened to do.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from hmz.coganchor.agents import (
+    AgentConfig,
+    ClaudeCodeAgent,
+    ClaudeCodeAgentConfig,
+    PiAgent,
+)
+from hmz.coganchor.agents.hooks import _ROOM, about, arriving
+
+if TYPE_CHECKING:
+    from hmz.coganchor.agents.event import Event
+
+
+def _claude() -> Any:
+    """A Claude conversation with no process behind it: `_read` is a reader and nothing more."""
+    return ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high")).new()
+
+
+def _pi() -> Any:
+    """The same for pi, whose events are read the same way."""
+    return PiAgent(AgentConfig(model="m", effort="high")).new()
+
+
+def _said(session: Any, *lines: dict[str, Any]) -> list[Event]:
+    """Everything a session says while it reads those lines, in the order it said it."""
+    return [event for line in lines for event in session._read(json.dumps(line) + "\n")]
+
+
+def _streamed(**event: Any) -> dict[str, Any]:
+    """One `stream_event` of Claude's, as `--include-partial-messages` writes it."""
+    return {"type": "stream_event", "event": event, "parent_tool_use_id": None}
+
+
+def test_claude_says_a_write_as_it_starts_rather_than_once_the_file_has_arrived() -> (
+    None
+):
+    """The path is in the first fragments and the file is in the rest of them."""
+    session = _claude()
+
+    opening = _said(
+        session,
+        _streamed(
+            type="content_block_start",
+            index=0,
+            content_block={"type": "tool_use", "id": "toolu_1", "name": "Write"},
+        ),
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={"type": "input_json_delta", "partial_json": '{"file_pat'},
+        ),
+    )
+
+    assert opening == []  # half a path is not a row
+
+    said = _said(
+        session,
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={"type": "input_json_delta", "partial_json": 'h": "hello.py", "cont'},
+        ),
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "Write hello.py")]
+
+    # And then the file itself, which is what the row would otherwise have waited for -- and
+    # the message that finally carries the whole call, which is the same call and not a
+    # second row.
+    rest = _said(
+        session,
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={"type": "input_json_delta", "partial_json": 'ent": "a\\nb\\nc"}'},
+        ),
+        _streamed(type="content_block_stop", index=0),
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Write",
+                        "input": {"file_path": "hello.py", "content": "a\nb\nc"},
+                    }
+                ],
+            },
+        },
+    )
+
+    assert rest == []
+
+
+def test_claude_says_a_call_whose_arguments_never_read_as_words_at_its_end() -> None:
+    """A tool that takes none, or takes numbers: the name alone is still a reach."""
+    session = _claude()
+
+    said = _said(
+        session,
+        _streamed(
+            type="content_block_start",
+            index=1,
+            content_block={"type": "tool_use", "id": "toolu_2", "name": "TodoWrite"},
+        ),
+        _streamed(
+            type="content_block_delta",
+            index=1,
+            delta={"type": "input_json_delta", "partial_json": '{"count": 3}'},
+        ),
+        _streamed(type="content_block_stop", index=1),
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "TodoWrite")]
+
+
+def test_claude_says_a_call_the_message_got_to_first_only_the_once() -> None:
+    """The message carrying the whole call lands a moment before the block it was in closes.
+
+    So a call whose arguments never read as words is said there, and the closing block must
+    not say it a second time: one tool call is one row.
+    """
+    session = _claude()
+
+    said = _said(
+        session,
+        _streamed(
+            type="content_block_start",
+            index=0,
+            content_block={"type": "tool_use", "id": "toolu_7", "name": "TodoWrite"},
+        ),
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={
+                "type": "input_json_delta",
+                "partial_json": '{"todos": [{"content": "fix it"}]}',
+            },
+        ),
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_7",
+                        "name": "TodoWrite",
+                        "input": {"todos": [{"content": "fix it"}]},
+                    }
+                ],
+            },
+        },
+        _streamed(type="content_block_stop", index=0),
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "TodoWrite")]
+
+
+def test_claude_still_says_a_call_that_arrived_in_no_fragments_at_all() -> None:
+    """An anchored turn, or a CLI that was never asked for the pieces, reads as it always did."""
+    session = _claude()
+
+    said = _said(
+        session,
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_3",
+                        "name": "Bash",
+                        "input": {"command": "ls -la"},
+                    }
+                ],
+            },
+        },
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "Bash ls -la")]
+
+
+def test_claude_says_an_agent_it_started_as_early_as_it_says_a_tool() -> None:
+    """A fleet under a turn is agents, and the id is what ends the one that started."""
+    session = _claude()
+
+    said = _said(
+        session,
+        _streamed(
+            type="content_block_start",
+            index=0,
+            content_block={"type": "tool_use", "id": "toolu_4", "name": "Task"},
+        ),
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={
+                "type": "input_json_delta",
+                "partial_json": '{"description": "read the notes",',
+            },
+        ),
+    )
+
+    assert [(one.kind, one.text, one.whose) for one in said] == [
+        ("subagent", "Task read the notes", "toolu_4")
+    ]
+
+    ended = _said(
+        session,
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "toolu_4"}],
+            },
+        },
+    )
+
+    assert [(one.kind, one.whose) for one in ended] == [("subagent-ends", "toolu_4")]
+
+
+def test_an_agent_under_a_turn_numbers_its_own_blocks_from_zero() -> None:
+    """Its messages are written on this same stream, so the index alone names two calls."""
+    session = _claude()
+
+    said = _said(
+        session,
+        _streamed(
+            type="content_block_start",
+            index=0,
+            content_block={"type": "tool_use", "id": "toolu_5", "name": "Read"},
+        ),
+        {
+            "type": "stream_event",
+            "parent_tool_use_id": "toolu_4",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_6", "name": "Grep"},
+            },
+        },
+        {
+            "type": "stream_event",
+            "parent_tool_use_id": "toolu_4",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"q": "hello"}'},
+            },
+        },
+        _streamed(
+            type="content_block_delta",
+            index=0,
+            delta={"type": "input_json_delta", "partial_json": '{"file_path": "x.py"}'},
+        ),
+    )
+
+    assert [(one.kind, one.text) for one in said] == [
+        ("tool", "Grep hello"),
+        ("tool", "Read x.py"),
+    ]
+
+
+def _pi_part(**event: Any) -> dict[str, Any]:
+    """One `assistantMessageEvent` of pi's, as it writes one on stdout."""
+    return {"type": "message_update", "assistantMessageEvent": event}
+
+
+def _pi_writing(arrived: str) -> dict[str, Any]:
+    """The block pi is writing a `write` call into, with that much of its input in it.
+
+    pi hands over the message so far on every fragment, with the fragments themselves under
+    `partialJson` and its own repaired reading of them under `arguments` -- so the two say
+    different things about a value that is still arriving, which is the point.
+    """
+    return {
+        "content": [
+            {
+                "type": "toolCall",
+                "id": "call_1|1",
+                "name": "write",
+                "arguments": {"path": arrived.split('"')[3]}
+                if '": "' in arrived
+                else {},
+                "partialJson": arrived,
+            }
+        ]
+    }
+
+
+def test_pi_says_a_write_while_the_file_is_still_arriving() -> None:
+    """The fragments say it as soon as one of them closes a value, and not before."""
+    session = _pi()
+
+    opening = _said(
+        session,
+        _pi_part(type="toolcall_start", contentIndex=0, partial=_pi_writing("")),
+        _pi_part(
+            type="toolcall_delta",
+            contentIndex=0,
+            delta='{"path": "hel',
+            partial=_pi_writing('{"path": "hel'),
+        ),
+    )
+
+    # Half a path, which pi's own reading of the fragments would have said whole: a row
+    # saying `write hel` would be worse than no row at all.
+    assert opening == []
+
+    said = _said(
+        session,
+        _pi_part(
+            type="toolcall_delta",
+            contentIndex=0,
+            delta='lo.py", "content": "a',
+            partial=_pi_writing('{"path": "hello.py", "content": "a'),
+        ),
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "write hello.py")]
+
+    # And the end of the call, which is where the row used to go out and where it must not
+    # go out twice.
+    ended = _said(
+        session,
+        _pi_part(
+            type="toolcall_end",
+            contentIndex=0,
+            toolCall={
+                "type": "toolCall",
+                "id": "call_1|1",
+                "name": "write",
+                "arguments": {"path": "hello.py", "content": "a\nb\nc"},
+            },
+        ),
+    )
+
+    assert ended == []
+
+
+def test_pi_says_a_call_whose_arguments_said_nothing_at_its_end() -> None:
+    """The end says it whatever the arguments came to: a reach is a reach."""
+    session = _pi()
+
+    said = _said(
+        session,
+        {
+            "type": "message_update",
+            "assistantMessageEvent": {
+                "type": "toolcall_end",
+                "contentIndex": 0,
+                "toolCall": {"id": "call_2|2", "name": "list_todos", "arguments": {}},
+            },
+        },
+    )
+
+    assert [(one.kind, one.text) for one in said] == [("tool", "list_todos")]
+
+
+def test_a_row_says_what_the_whole_of_the_call_would_have_said() -> None:
+    """One call reads as one row, whichever of the two ways of reading it got there first.
+
+    A hook is told what the agent reached for off that row, so a reader that dug into a
+    nested argument the whole-message one never looks at would be telling a flow two
+    different things about one tool call depending on how its CLI happened to send it.
+    """
+    for called in (
+        {"file_path": "hello.py", "content": "a\nb\nc"},
+        {"count": 3, "path": "x.py"},
+        {"path": "   ", "command": "ls -la"},
+        {"todos": [{"content": "fix the bug"}]},
+        {"edits": [{"old": "a"}], "note": "second pass"},
+        {"command": 'echo "a": "b"', "path": "x"},
+        {"command": "grep -r {a} ."},
+        {"nested": {"key": "value"}, "path": "/x"},
+        {},
+    ):
+        assert arriving(json.dumps(called)) == about(called), called
+
+
+def test_half_an_argument_is_not_a_row() -> None:
+    """A row saying `Write /tmp/se` would be worse than the row that has not come yet."""
+    assert arriving('{"file_path": "/tmp/se') == ""
+    assert arriving('{"file_path": ') == ""
+    assert arriving("") == ""
+    assert arriving('{"file_path": "/tmp/sea.py"') == "/tmp/sea.py"
+    # And an escape JSON does not have is not a value this can name: whatever wrote that is
+    # not writing what this is here to read.
+    assert arriving(r'{"file_path": "\q"}') == ""
+
+
+def test_a_payload_that_never_ends_is_not_read_again_for_every_fragment_of_it() -> None:
+    """The file being written is not the path it is being written to, however long it gets."""
+    assert arriving('{"content": "' + "x" * (_ROOM * 4)) == ""

--- a/tests/agents/test_recovery.py
+++ b/tests/agents/test_recovery.py
@@ -83,7 +83,7 @@ def _watched(agent: AgentBase) -> list[str]:
     agent.watch(
         lambda _agent, _session, event: (
             narrated.append(event.text)
-            if event.kind == "tool" and event.text.startswith(f"{agent.backend} ")
+            if event.kind == "notice" and event.text.startswith(f"{agent.backend} ")
             else None
         )
     )

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -162,6 +162,9 @@ def test_a_run_nobody_is_watching_is_written_without_an_escape_in_it(
         shown.heard(agent, None, Event(kind="begins", text=""))
         shown.heard(agent, None, Event(kind="text", text="fixing the checker"))
         shown.heard(agent, None, Event(kind="tool", text="Bash ls -la"))
+        shown.heard(
+            agent, None, Event(kind="notice", text="waiting 30s for a rate limit")
+        )
         shown.heard(agent, None, Event(kind="ends", text=""))
     said = capsys.readouterr()
 
@@ -169,6 +172,9 @@ def test_a_run_nobody_is_watching_is_written_without_an_escape_in_it(
     assert "builder is working" in said.err
     assert "fixing the checker" in said.err
     assert "Bash(ls -la)" in said.err
+    # What humanize is doing about the turn, which is not the agent working and is shown as
+    # its own thing: a recovery nobody can see is indistinguishable from a hang.
+    assert "waiting 30s for a rate limit" in said.err
     assert "Worked for" in said.err
 
 

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -1290,6 +1290,44 @@ async def test_what_a_turn_did_on_the_way_is_shown_only_where_it_is_asked_for() 
         assert "thinking aloud" in shown
 
 
+@pytest.mark.timeout(60)
+async def test_what_humanize_is_doing_about_a_turn_is_not_hidden_with_the_working() -> (
+    None
+):
+    """A turn told to wait half a minute and a turn that has hung look the same from here.
+
+    The line saying which it is was said as a tool call, so asking not to see every file read
+    was asking not to be told a rate limit was being waited out either.
+    """
+    from hmz.coganchor.agents import Event
+    from hmz.coganchor.agents.claude import ClaudeCodeAgent, ClaudeCodeAgentConfig
+
+    app = Humanize()
+    async with app.run_test() as driver:
+        agent = ClaudeCodeAgent(ClaudeCodeAgentConfig(model="m", effort="high"))
+        app._agents = [agent]
+        session = agent.new()
+
+        def turn() -> None:
+            app._heard(agent, session, Event(kind="begins", text=""))
+            app._heard(agent, session, Event(kind="tool", text="Read pyproject.toml"))
+            app._heard(
+                agent,
+                session,
+                Event(kind="notice", text="waiting 30s for a rate limit"),
+            )
+            app._heard(agent, session, Event(kind="ends", text=""))
+
+        assert not app._details
+        await asyncio.to_thread(turn)
+        await until(lambda: "Worked for" in _transcript(app), driver)
+
+        shown = _transcript(app)
+        assert "waiting 30s for a rate limit" in shown
+        # And still none of the working, which is the other half of the same switch.
+        assert "pyproject.toml" not in shown
+
+
 def test_a_backend_offers_what_it_last_said_it_runs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## The report

> 之前似乎在用chat flow下，claude输出一条消息后继续执行很久都没新的消息，而details on了也没见到出现那些更细节的东西

Reproduced, and it is real. A tool call's arguments are what it was called with,
and for a `Write` they are the file. Claude Code announces the call on the
message that carries it whole — which lands only once the last fragment of those
arguments has arrived. Between the model reaching for the tool and the file
finishing, the driver emitted **nothing at all**.

Measured on `claude-haiku-4-5` writing a sixty-line poem:

```
  +0.00 assistant [thinking]
  +6.43 assistant [tool_use Write]     <- 6.4s of a blank screen
```

On a slow model writing five hundred lines that is minutes, and it lands exactly
where the work is largest. Nothing distinguishes it from a hang.

## The fix

Claude is asked for the fragments — `--include-partial-messages`, which the CLI
has taken for a year and which appeared nowhere in this repo — and says the
reach at the first fragment that finishes a value in the arguments, which is the
path or the command. The same call arriving a moment later as part of a message
is not a second row.

The same live task, in the interface, after:

```
   4.60  tool        'Write /tmp/tui4/sea.py'
  14.36  reasoning   'Good, I've created the script...'
```

The row is on screen for the 9.8 seconds the file takes to stream, instead of
appearing at the end of them.

pi had the same shape and was already being sent the fragments — its driver
threw them away with a comment saying so. It reads them now. Both read them
through one `hooks.arriving`, which answers exactly what `about` answers off the
whole input, so a hook is told one thing about one call however its CLI happened
to send it.

## Three more silences

- **A hook table was written whether or not a hook existed.** It is a program the
  CLI starts and waits for before every tool it runs. Claude and Qwen Code got
  one unconditionally — a relay spawned per file read, one after another, for
  nobody. Written only where something is hung now; hanging or unhanging one
  between two turns starts the next turn in a CLI told the new answer, as a moved
  effort does. `gated` answers of the *process* rather than of the agent, so a
  gate that outlived the hook that made it cannot leave the moment firing in
  neither place.
- **A retry, a fallback, a cut-off turn and a wedged backend were said as tool
  calls**, so `/details off` hid them — and a turn told to wait half a minute for
  a rate limit then looked exactly like a turn that had hung. They are a `notice`
  now, drawn either way. It also stops them firing `PreToolUse` with `claude` as
  the tool the agent had reached for.
- **A watcher that raised lost its event in silence**, which is how an interface
  comes to draw nothing and leave no trace of why. It still cannot fail a turn,
  and is reported as a snag — once per kind, saying which kind was lost and
  nothing of what was said.

## The audit

| already early | fixed here | not fixed |
| --- | --- | --- |
| codex, cursor, opencode, mimo, grok, agy, acp, kimi | **claude**, **pi**, **qwen** (table only) | zcode, dsh |

`zcode` and `dsh` have the same late row and each has the earlier message sitting
on its stream (`zcode.py` discards it at the `case _:` for "the pieces of a
tool's arguments"; `dsh.py` drops unmapped `assistant/chunk` types). Neither can
be driven through the gateway on this machine, so their field names could not be
checked against a live turn and are left alone rather than guessed at from a
bundle nobody can run. Noted separately: `cursor` emits no `reasoning` at all.

## Verification

- `uv run pytest` — 2881 passed, 72 skipped
- `uv run pre-commit run --all-files` — clean
- Live headless `hmz exec -f chat` through the real `claude` CLI
- Live interface turn, `/details` on and off, through the real `claude` CLI
- Live `pi` turn through the gateway — one row per call, full paths, no duplicates

Specs and docs updated: `specs/agents.md`, `specs/tui.md`,
`docs/reference/agents.md`, `docs/user/details.md`, `docs/user/fallback.md`,
`docs/features/hooks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
