### PR TITLE
feat(tui): a flow is stopped by a line typed once as well as by a key pressed twice

### DIFF
--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -106,6 +106,12 @@ for the flow to unwind — every conversation still open is closed under its tur
 backend's process going, and what the flow reads as a turn that failed. With nothing running,
 two presses leave; `/exit` is the other way out.
 
+**`/stop` is the same stop, typed, and asks once.** The key asks twice because a finger lands
+on it by mistake; typing a command out and sending it is that deliberation already made. It
+leaves no half-made gesture behind it either — a press before it and a press after it are not
+two presses of one — so the press after a `/stop` is the one that does not wait for the flow to
+unwind, exactly as it is after the second press, and a first press again once the flow is gone.
+
 **esc does not stop anything.** It is pressed to dismiss whatever is on the screen everywhere
 else in this interface, so it is not the key that ends a day's work: it opens
 [`/monitor`](#watching-the-run) instead, which is where the run is watched and where the
@@ -171,6 +177,7 @@ list appears under the editor with a line about each.
 | `/afk` | `[on\|off]` | Whether an agent may stop and ask you something. See [below](#questions-and-being-away). |
 | `/fallback` | | Where a turn goes when what was taking it cannot: an agent that has nowhere left to run, and an account that has gone down. See [below](#where-a-turn-goes-when-it-cannot-be-taken). |
 | `/clear` | | Clears the screen, and nothing else: the transcript being read, not the others, and nothing that is running. |
+| `/stop` | | Stops the flow — the whole flow, not just the turn — which is what **ctrl+c** twice does. It is not asked twice: the key asks because a finger lands on it by mistake, and nothing is typed by mistake, so writing it out and sending it is the deliberation the second press stands in for. With nothing running it says so, which the key never does; a flow already told to stop and not yet gone is said to be stopping rather than told again, and the [third press](/user/stopping) is what is left for that one. |
 | `/exit` | | Leaves; a flow that is running can be left running. With one going it asks first what is to become of it: stop it and leave, or [let go of this terminal](/reference/daemon) and leave it running — the run carries on where nothing is reading it, and `hmz` in this directory opens it again from the top. That second answer is offered only where something outside this terminal is holding the run; where nothing is, closing the terminal is what closes the run, so the answer offered instead is staying here. With nothing running it is a window being closed, and asks nothing. |
 
 `/details` and `/afk` flip when given nothing, and take `on` or `off` when you want to say
@@ -942,7 +949,7 @@ on — one question has one answer, whichever way you came to it:
 | `<run> cannot be read back` | Its record is not one — a run that died mid-line left a line rather than an epic. |
 | `<flow> does not say it can be picked up` | Asked of the flow as it is today, not of what the run recorded — and a flow that will not load at all reads as one that says no. |
 | `<run> left nothing behind` | Its flow says it can be picked up, and that run either stopped before it wrote down where it had got to or [emptied what it wrote](/user/resuming#when-it-is-saved) — which is a flow saying the next run here starts clean. Starting from the top under a line saying which run it came from would be a record of something that did not happen, so it says what the next move is: say what to do, and the flow starts. |
-| `no picking a run up while a flow is running` | A run picked up is a flow started, and there is one going. [ctrl+c twice](/user/stopping) stops it first. |
+| `no picking a run up while a flow is running` | A run picked up is a flow started, and there is one going. [ctrl+c twice or `/stop`](/user/stopping) stops it first. |
 | `no picking a run up while the flow is still stopping` | ctrl+c twice has been pressed and the flow has not gone yet. It unwinds in its own time and writes down where it got to as it goes, so a run picked up from a state still moving under it is a round done twice. A flow that will not unwind at all is what the [third press](/user/stopping) is for. |
 
 `/resume` takes nothing after it. A line that names a run is said back rather than dropped —

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -285,8 +285,9 @@ agent, opposite behaviour. The flow decides, not the agent.
 
 **Turn failing vs. agent stopping — what a loop should do.** A turn that failed is ordinary;
 `suppress=True` turns it into an empty answer and the loop goes round again. An agent that has
-been *told to stop* (ctrl+c twice in the interface, or `agent.stop()`) raises `Stopped`, which
-`suppress` deliberately does not catch, because a loop that carried on past it would never end.
+been *told to stop* (ctrl+c twice or `/stop` in the interface, or `agent.stop()`) raises
+`Stopped`, which `suppress` deliberately does not catch, because a loop that carried on past it
+would never end.
 It does not catch an `Unrecoverable` either, and for the same reason: a turn that failed for a
 reason no other try could come out differently on is one the next round would meet again.
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -41,7 +41,7 @@ whole piece of work start to finish; everything under them is for looking up.
 | [History](/user/history) | Everything typed here before, on ↑ and ↓ |
 | [Exporting a run](/user/export) | **export it**, on a run of `/epics`: the whole run as one archive to send |
 | [What a project remembers](/user/settings) | Reopening finds it set up the way you left it |
-| [Stopping](/user/stopping) | **ctrl+c** twice ends the flow; what that does to a turn |
+| [Stopping](/user/stopping) | **ctrl+c** twice or **`/stop`** ends the flow; what that does to a turn |
 
 ## Setting an agent up
 

--- a/docs/user/resuming.md
+++ b/docs/user/resuming.md
@@ -115,7 +115,7 @@ in silence.
 | `<run> cannot be read back` | Its record is not one: a run that died mid-line left a line rather than an epic. |
 | `<flow> does not say it can be picked up` | Asked of the flow as it stands today, not of what the run recorded. |
 | `<run> left nothing behind` | It stopped before it wrote down where it had got to, or it emptied what it wrote — which is the flow saying the next run starts clean. Say what to do and it starts from the top. |
-| `no picking a run up while a flow is running` | A run picked up is a flow started, and one is going. [ctrl+c twice](/user/stopping) stops it first. |
+| `no picking a run up while a flow is running` | A run picked up is a flow started, and one is going. [ctrl+c twice or `/stop`](/user/stopping) stops it first. |
 | `no picking a run up while the flow is still stopping` | ctrl+c twice was pressed and the flow has not gone yet — it is closing out the turn it was in, and still writing down where it got to. |
 
 `/resume` takes nothing after it: a line that names a run is said back rather than dropped.

--- a/docs/user/stopping.md
+++ b/docs/user/stopping.md
@@ -10,13 +10,26 @@ Press **ctrl+c** twice in the interface while a flow is running. Twice, because 
 behind a key that is also pressed by mistake: the first press says `press ctrl+c again to stop
 the flow`, and the second one does it.
 
-## The three ways to stop
+Or type **`/stop`** and send it, which is the same stop asked once.
+
+## The four ways to stop
 
 | | |
 | --- | --- |
 | **ctrl+c** twice, in the interface | Stops the flow — the whole flow, not just the turn. Clears what is half-typed first, if anything is. |
+| **`/stop`**, at the prompt | The same, asked once. |
 | **ctrl+c**, on a `hmz exec` command line | The same. |
 | **`agent.stop()`**, from anywhere | The same, for that agent. |
+
+**`/stop` is not asked twice.** The key is, because a finger lands on it by mistake; nothing is
+typed by mistake, so writing the command out and sending it is the deliberation the second
+press stands in for. It says so where there is nothing to stop, which the key never does —
+with nothing running the key is the one that leaves, and what it says is about leaving.
+
+It also leaves no half-made gesture behind it. A ctrl+c pressed before a `/stop` and one
+pressed after it are not two presses of one gesture: the command came between them, so the
+press after it starts again from the beginning — the third press below while the flow is still
+unwinding, and otherwise the first of a fresh one.
 
 **A third press does not wait for it.** A flow told to stop unwinds in its own time — a loop
 sleeps off its round, a server is given its seconds — and the press after the one that stopped
@@ -59,6 +72,8 @@ got to as it goes, so `/resume` in that window is refused with `no picking a run
 flow is still stopping` — picked up from a state still moving under it, the next run would do a
 round the stopped one had already recorded. A flow that will not unwind at all is what the third
 press is for: it leaves nothing reading as a run in progress, and `/resume` is answerable again.
+A second `/stop` in that window is no help either — it says the flow is already stopping rather
+than telling it again, since the agents it is holding are what that press reaches.
 
 ## What stopping is not
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -219,7 +219,7 @@ command -v claude codex kimi pi opencode mimo zcode
 
 Or `no switching flow while a flow is running`. Choosing a flow means running it, which means
 stopping whatever was running — and humanize says so rather than doing it behind your back.
-Press ctrl+c twice first.
+Press ctrl+c twice first, or type [`/stop`](/user/stopping), which is the same stop asked once.
 
 ### `a flow is already running`
 

--- a/docs/user/unattended.md
+++ b/docs/user/unattended.md
@@ -215,8 +215,8 @@ process takes it too. The turn under way dies with it, what it was doing is left
 to, and the command exits `130`.
 
 The [epic](/user/tracing#what-a-run-writes-down) records that run as **`failed`**. `stopped`
-is for an agent [told to stop by hand](/user/stopping), with ctrl+c twice in the interface or
-`agent.stop()` from inside the flow. Nothing on a command line tells the two apart.
+is for an agent [told to stop by hand](/user/stopping), with ctrl+c twice or `/stop` in the
+interface, or `agent.stop()` from inside the flow. Nothing on a command line tells the two apart.
 
 Either way, a flow that says it [can be picked up](/user/resuming) carries on from what that
 run left behind: run the same line again, or type `/resume` in the interface, which takes the

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -271,6 +271,19 @@ line, with what the flow is doing beside the transcript.
 - With nothing running, two presses MUST leave. Twice for the reason stopping is asked twice,
   and never on one press: it is pressed while work is going on, and leaving is not what was
   meant by it. A press long enough after the last MUST be the first of its own gesture.
+- `/stop` MUST stop the flow the way the second press does, and MUST NOT ask twice. The key
+  is asked twice because a finger lands on it by mistake; a command is written out and sent,
+  and that typing is the deliberation the second press stands in for -- asking again for
+  something somebody spelled out is a question with one answer.
+- It MUST NOT count as a press, and MUST leave no half-made gesture behind it either: a press
+  made before it and a press made after it MUST NOT be two presses of one gesture. They are a
+  gesture a command interrupted, and counted as one they are the interface closing on the one
+  key after a line that said there was nothing to stop.
+- `/stop` MUST say so where there is nothing to stop, which the key never says: with nothing
+  running the key is the one that leaves, and what it says is about leaving. `/stop` has the
+  one thing to mean, and a command typed on purpose that answers with nothing reads as a
+  command that did not work. A flow already told to stop MUST be said to be stopping rather
+  than told again, the agents it is holding being what the third press reaches.
 - `esc` MUST NOT stop a flow. It is pressed to dismiss whatever is on the screen everywhere
   else in this interface, and a key pressed to dismiss things MUST NOT be the key that ends a
   day's work. It MUST be `/monitor` instead, which is where the run is watched and where the

--- a/src/hmz/tui/app.py
+++ b/src/hmz/tui/app.py
@@ -139,6 +139,12 @@ _LINES = 2000
 #: a press minutes later is a first press rather than half of one nobody remembers making.
 _AGAIN = 3.0
 
+#: What a flow told to stop and not yet gone is doing, said wherever that state is the answer
+#: -- to `/stop`, and to everything `_mid_run` turns down. One state reads as one state only
+#: while it is said in one wording: two sentences for it are two states to whoever is at the
+#: prompt, and each of them one somebody has to work out for themselves.
+_UNWINDING = "it is closing out the turn it was in"
+
 #: The three steps one agent of a flow is configured in, in the order they are asked: which
 #: coding agent takes its turns and as whom, which model it runs and at what effort, and --
 #: only for a place the flow said may be pointed anywhere -- which machine its work lands on.
@@ -1900,9 +1906,7 @@ class Humanize(App[None]):
         # `ctrl+c twice` is not the answer here: it has already been pressed.
         if self._stopping:
             self.show(
-                f"hmz: {what} while the flow is still stopping: it is closing out the "
-                "turn it was in",
-                "red",
+                f"hmz: {what} while the flow is still stopping: {_UNWINDING}", "red"
             )
             return True
         return False
@@ -2356,15 +2360,54 @@ class Humanize(App[None]):
         self._welcome()  # a cleared screen is a screen just opened, and one opens with this
         self._draw()
 
+    def action_stop(self) -> None:
+        """Stops the flow on a line typed rather than a key pressed, and asks once for it.
+
+        The key asks twice because a day's work is behind a key that a finger also lands on
+        by mistake. Nothing is typed by mistake: writing `/stop` out and sending it is the
+        deliberation the second press stands in for, so asking again would be a question with
+        one answer.
+
+        A flow already told to stop is said to be stopping rather than told again: stopping
+        hands the agents it is holding on to the ones on their way out, and running it over an
+        empty list would hand nothing on and drop the ones already there -- which is the third
+        press losing its only way to the conversations still open under their turns.
+
+        Nothing running at all is said as well. The key never says that, because with nothing
+        running it is the key that leaves and what it says is about leaving; `/stop` has only
+        the one thing to mean, and a command typed on purpose that answers with nothing reads
+        as a command that did not work.
+
+        Whatever it found, the count of presses goes back to nothing, which is what the second
+        press does after it stops a flow. A `/stop` is not a press and must not be counted as
+        one -- but neither may it leave a press made before it standing, or the press made
+        after it would be the second of a gesture the command interrupted: with the flow by
+        then unwound, that is the interface closing on one key after a line that said there
+        was nothing to stop.
+        """
+        if self._agents:
+            self.action_stop_flow()
+        elif self._stopping:
+            self.show(f"hmz: the flow is already stopping: {_UNWINDING}", "red")
+        else:
+            self.show("hmz: no flow is running, so there is nothing to stop", "red")
+        self._presses = 0
+        self._draw()  # rather than at the next tick: it was just typed
+
     def action_stop_flow(self) -> None:
-        """Stops the whole flow, not just the turn -- which is the second ctrl+c.
+        """Stops the whole flow, not just the turn -- which is the second ctrl+c or `/stop`.
 
         Every agent is told to take no further turn, so the one running now is closed out and
         the loop driving it ends rather than handing on to the next agent. The agents are let
         go of here rather than when the flow's own thread notices, so that the next thing
         said starts something instead of being put to a flow that is on its way out -- and
         kept as the ones stopping, since a flow unwinds in its own time and the press after
-        this one is the one that does not wait for it. Silent when nothing is running.
+        this one is the one that does not wait for it.
+
+        Silent when nothing is running, every caller having its own answer for that: the key
+        is mid-gesture and the press after it says what it does, a flow chosen while none runs
+        has nothing to say about the one that was not there, and `/stop` looks before it calls
+        this and says for itself that there was nothing to stop.
         """
         for agent in self._agents:
             agent.stop()
@@ -3934,6 +3977,11 @@ _COMMANDS: tuple[Command, ...] = (
         "Toggle whether an agent may ask you",
         lambda app, argv: app.action_afk(argv),
         takes="[on|off]",
+    ),
+    Command(
+        "stop",
+        "Stop the flow; typed out, so not asked twice",
+        lambda app, _: app.action_stop(),
     ),
     Command(
         "exit",

--- a/tests/tui/test_keys.py
+++ b/tests/tui/test_keys.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from textual.screen import Screen
 from textual.widgets import Label, OptionList
 
 import hmz.tui.pick
@@ -54,6 +53,8 @@ from .test_app import into_agent, into_flows, onto, rows, until
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from textual.screen import Screen
 
 #: One installed CLI at two efforts, so that the sheets an agent is set up on have both a
 #: list to pick from and a rung to step along.
@@ -322,7 +323,7 @@ async def test_the_question_about_what_a_menu_holds_is_five_words() -> None:
         )
         # Every word in the box, keys and all, less the dot that separates two keys.
         words = said.replace("·", " ").split()
-        assert len(words) <= 5, words  # noqa: PLR2004 -- what `under five words` comes to
+        assert len(words) <= 5, words
 
 
 @pytest.mark.timeout(60)

--- a/tests/tui/test_stopping.py
+++ b/tests/tui/test_stopping.py
@@ -1,0 +1,261 @@
+"""`/stop` -- the stop that is typed rather than pressed, and so is asked once.
+
+The key is asked twice because a day's work is behind a key that a finger also lands on by
+mistake. A command is written out and sent, and that typing is the deliberation the second
+press stands in for -- so what is checked here is that one line does what two presses do,
+that it says so where the key is silent, and that it leaves the key's own gesture exactly
+where it stands.
+
+Driven headlessly, as every test of the interface is, so what is checked is what a typed line
+did rather than how it was drawn.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest.mock
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hmz.runtime.epic import epics
+from hmz.runtime.kept import Runs
+from hmz.tui import Humanize
+from tests.stubs import events as recorded
+from tests.stubs import written
+from tests.tui.conftest import transcript, until
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from textual.pilot import Pilot
+
+#: A flow that drives one agent for one turn, which is enough to have something to stop.
+FLOW = """
+from pathlib import Path
+
+from hmz.coganchor.agents import AgentBase
+from hmz.flows import flow
+
+
+@flow
+def run(agents: tuple[AgentBase], task: str) -> None:
+    session = agents[0].new()
+    Path("said.txt").write_text(session(task) + "\\n")
+"""
+
+#: A `claude` that never answers, so that the turn is still open when the line is typed.
+PATIENT = """
+import json, sys
+
+flags = dict(zip(sys.argv, sys.argv[1:]))
+print(json.dumps({"type": "system", "session_id": flags["--session-id"]}), flush=True)
+for line in sys.stdin:
+    print(json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "text", "text": "working"}]}}), flush=True)
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A directory of our own, with a coding agent that keeps its turn open on PATH."""
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    fake = binaries / "claude"
+    fake.write_text(f"#!{sys.executable}\n{PATIENT}")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{binaries}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+async def _typed(driver: Pilot[None], line: str) -> None:
+    """Types one line a character at a time and sends it, as somebody at the prompt does.
+
+    Character by character rather than assigned, so that the offers the line opens on its way
+    are open exactly as they would be -- enter over an open list takes what is under the
+    cursor rather than sending, and a line typed in one go would never find that out.
+
+    Args:
+      driver: What is pumping the interface.
+      line: What to type.
+    """
+    await driver.press(*line)
+    await driver.pause()
+    await driver.press("enter")
+    await driver.pause()
+
+
+@pytest.mark.timeout(90)
+async def test_a_typed_stop_stops_the_flow_as_the_second_press_does(
+    workspace: Path,
+) -> None:
+    """One line does what two presses do: the loop ends rather than handing on.
+
+    And the run ends with it -- an epic is one run of one flow, and a run stopped by hand is
+    written down as stopped rather than as one that finished.
+    """
+    written(workspace, "flow", FLOW)
+    app = Humanize()
+    async with app.run_test() as driver:
+        app._flow_named, app._models = "flow", [Runs("claude/m:high")]
+        await _typed(driver, "start")
+        await until(
+            lambda: bool(app._agents and any(agent.sessions for agent in app._agents)),
+            driver,
+        )
+
+        await _typed(driver, "/stop")
+        await until(lambda: not app._agents, driver)
+
+        assert "stopping the flow" in transcript(app)
+        (epic,) = epics(workspace)
+        assert recorded(epic)[-1] == {
+            "event": "ended",
+            "at": unittest.mock.ANY,
+            "how": "stopped",
+        }
+
+
+@pytest.mark.timeout(60)
+async def test_a_typed_stop_says_so_where_there_is_nothing_to_stop() -> None:
+    """The key is silent here; a command typed on purpose must not be.
+
+    Silence is right for a press in the middle of a gesture, since the press after it has an
+    answer of its own. A line somebody spelled out and sent that answered with nothing reads
+    as a line that did not work.
+    """
+    app = Humanize()
+    async with app.run_test() as driver:
+        await _typed(driver, "/stop")
+        await until(lambda: "nothing to stop" in transcript(app), driver)
+
+        assert app.is_running
+
+
+@pytest.mark.timeout(60)
+async def test_a_flow_already_stopping_is_said_to_be_rather_than_told_again() -> None:
+    """Telling it again would drop the agents the third press has to reach.
+
+    Stopping hands the agents it holds on to the ones on their way out. Run over an empty
+    list it would hand nothing on and let go of the ones already there, so the press that
+    does not wait for the flow would find no conversation left to close.
+    """
+    from hmz.coganchor.agents import ClaudeCodeAgent, ClaudeCodeAgentConfig
+
+    app = Humanize()
+    async with app.run_test() as driver:
+        app._stopping = [
+            ClaudeCodeAgent(ClaudeCodeAgentConfig(model="claude-opus-5", effort="high"))
+        ]
+        held = app._stopping
+
+        await _typed(driver, "/stop")
+        await until(lambda: "already stopping" in transcript(app), driver)
+
+        assert app._stopping is held
+
+
+def test_stop_is_offered_among_the_commands_and_says_it_is_asked_once() -> None:
+    """The list is where somebody reads what a command does before they type it.
+
+    That it is not asked twice is the one thing about this command that the key it stands in
+    for does differently, so the line beside it is where that is said.
+    """
+    from hmz.tui.app import _BY_NAME, _COMMANDS
+    from hmz.tui.complete import offered
+
+    assert "/stop" in offered("/", _COMMANDS)
+    assert _BY_NAME["stop"].takes == ""  # there is nothing to write after it
+    assert "twice" in _BY_NAME["stop"].about
+    # And it names no key: the row under the editor is where the keys are said, so a line
+    # here naming the one this stands in for would be that key read twice on one screen.
+    assert "ctrl" not in _BY_NAME["stop"].about
+
+
+@pytest.mark.timeout(60)
+async def test_a_typed_stop_leaves_no_half_made_gesture_behind_it() -> None:
+    """A press made before the command and one made after it are not one gesture.
+
+    With nothing running the key is asked twice before it leaves. A `/stop` typed between the
+    two presses that left the first of them counted would make the second the one that
+    leaves -- the interface closing on one key after a line that said there was nothing to
+    stop, which is a day at the prompt ended by a command about something else.
+    """
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press("ctrl+c")
+        await driver.pause()
+        assert app._presses == 1  # the press that asks, and is then typed past
+
+        await _typed(driver, "/stop")
+        await until(lambda: "nothing to stop" in transcript(app), driver)
+        assert not app._presses  # counted from nothing, so the next press is a first press
+
+        await driver.press("ctrl+c")
+        await driver.pause()
+
+        assert app._presses == 1
+        assert "press ctrl+c again to leave" in transcript(app)
+        assert app.is_running
+
+
+@pytest.mark.timeout(90)
+async def test_the_press_after_a_typed_stop_does_not_close_the_interface(
+    workspace: Path,
+) -> None:
+    """The same, over a flow that was stopped and has finished unwinding.
+
+    Nothing is running by then and nothing is on its way out, so a press left standing by the
+    command would meet the rung that leaves -- and the run somebody stopped on purpose would
+    take the terminal with it.
+    """
+    written(workspace, "flow", FLOW)
+    app = Humanize()
+    async with app.run_test() as driver:
+        app._flow_named, app._models = "flow", [Runs("claude/m:high")]
+        await _typed(driver, "start")
+        await until(
+            lambda: bool(app._agents and any(agent.sessions for agent in app._agents)),
+            driver,
+        )
+        await driver.press("ctrl+c")
+        await driver.pause()
+        assert app._presses == 1
+
+        await _typed(driver, "/stop")
+        await until(lambda: not app._agents and not app._stopping, driver)
+
+        await driver.press("ctrl+c")
+        await driver.pause()
+
+        assert app.is_running
+        assert "press ctrl+c again to leave" in transcript(app)
+
+
+@pytest.mark.timeout(60)
+async def test_the_keys_name_what_the_press_after_a_typed_stop_does() -> None:
+    """A flow on its way out is one rung, and the row of keys has to name that one.
+
+    The row reads the count of presses first, so a `/stop` typed after a press that asked
+    would offer to leave on a key that closes the conversations still open under their turns.
+    Counting from nothing again is what keeps the row true as well as the key.
+    """
+    from hmz.coganchor.agents import ClaudeCodeAgent, ClaudeCodeAgentConfig
+
+    app = Humanize()
+    async with app.run_test() as driver:
+        await driver.press("ctrl+c")  # the press that asks, and is then typed past
+        await driver.pause()
+        assert app._presses == 1
+        app._stopping = [
+            ClaudeCodeAgent(ClaudeCodeAgentConfig(model="claude-opus-5", effort="high"))
+        ]
+
+        await _typed(driver, "/stop")
+        await until(lambda: "already stopping" in transcript(app), driver)
+
+        assert "ctrl+c close them" in app._keys()
+        assert "ctrl+c again to exit" not in app._keys()


### PR DESCRIPTION
`还要支持/stop停止flow（相当于按两次ctrl c）` — stopping a run from the prompt was a key
pressed twice and nothing else, and a key is not where somebody looks for a command.

## What this adds

One entry in the table every command is declared in: `/stop`, the line said about it in the
`/` list, and `action_stop`, which does what the second `ctrl+c` does.

**Typed once, not twice.** The key asks twice because a day's work is behind a key a finger
also lands on by mistake; nothing is typed by mistake, so writing the command out and sending
it is the deliberation the second press stands in for. The line beside it in the list says
so, and names no key — the row under the editor is where the keys are said.

**It says when there is nothing to stop.** `action_stop_flow` is deliberately silent there,
which is right for a press in the middle of a gesture; with nothing running the key is the one
that *leaves*, and what it says is about leaving. A command typed on purpose that answers with
nothing reads as one that did not work. A flow already told to stop and not yet gone is said to
be stopping rather than told again — stopping hands the agents it holds on to the ones on their
way out, and run over an empty list it would let go of the ones already there, which is the
third press losing its only way to the conversations still open under their turns.

**It leaves no half-made gesture behind it.** `/stop` is not counted as a press, and it does
not leave a press made before it standing either. `ctrl+c`, then `/stop`, then `ctrl+c`: the
second press would have met the rung that leaves once the flow had unwound — the interface
closing on one key after a line that stopped a run. The count goes back to nothing, which is
what the second press itself does, so the press after a `/stop` is the one that does not wait
while the flow is still going, and a first press once it is gone. (Found by `/code-review`,
reproduced, fixed, and three tests fail without the fix.)

The one clause for a flow that is still unwinding is now written down once and said by both
places that say it.

## Docs and spec

`specs/tui.md` carries the rules in its own MUST voice, `docs/reference/tui.md` the command,
and `docs/user/stopping.md` the fourth way to stop; the pages that enumerate the ways to stop
a run name it too.

## Verification

- `uv run pytest` — 2939 passed, 72 skipped.
- `uv run pre-commit run --all-files` — clean. (Two pre-existing ruff findings in
  `tests/tui/test_keys.py`, from the unit that landed just before this one, are fixed here
  because they block the gate.)
- Seven headless pilot tests in `tests/tui/test_stopping.py`, typing the command character by
  character as somebody at the prompt does.
- **A real run** in the interface over `claude@nvidia/azure/anthropic/claude-haiku-4-5:low`: a
  turn under way stopped on `/stop`, the epic records the run as `stopped`, a second `/stop`
  answered `no flow is running, so there is nothing to stop`, and `ctrl+c` before a `/stop` and
  `ctrl+c` after it left the interface up and asking rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
