### PR TITLE
feat(codenames): draw the canon from every designation Amphoreus spells

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1083,30 +1083,36 @@ A [flow](/reference/flows#how-many-agents-and-what-they-are-for) that declares i
 ### The name nobody gave it
 
 An agent nobody named still needs one nothing else answers to, and what it gets is a codename out
-of Amphoreus — a Greek word for what a Chrysos Heir was made to be, and three digits behind it:
+of Amphoreus — a designation off the electrical signals *Honkai: Star Rail* logs, or a Greek word
+and three digits built by the rule those designations are spelled by:
 
 ```text
-NeiKos496   PhiLia093   SkeMma720   KykLos204   MetaKratos881
+NeiKos496   PhiLia093   Golem99   Utop13   ScreW   KykLos204   MetaKratos881
 ```
 
-Twelve of those are codes *Honkai: Star Rail* says out loud, and while any of the twelve is still
-free they come up half the time — against the once in eleven thousand the written-down words alone
-would give them by chance, since a name is only a joke to somebody who recognises it. The rest are
-those same roles under some other number: another epic of a story that has run 33,550,336 of
-them, which is the fifth perfect number, as 496 is the third.
+Twenty-nine of those are designations the story says out loud: the twelve Chrysos Heirs, two heirs
+of earlier recurrences, twelve signals logged in the cycles before there were heirs at all, and
+the three outsiders who walked into the experiment rather than being run by it. While any of the
+twenty-nine is still free they come up half the time — against the once in eleven thousand the
+written-down words alone would give them by chance, since a name is only a joke to somebody who
+recognises it. The rest are those same roles under some other number: another epic of a story that
+has run 33,550,336 of them, which is the fifth perfect number, as 496 is the third.
 
-The word is built rather than looked up. Morphemes join at the capital — `Apo` and `Ria` are
-`ApoRia`, which is an heir's, so `Meta` and `Kratos` are `MetaKratos`, which is a word the same
-rule makes and the story merely never needed. That is what makes the supply endless: a process
-that has used the short words up is answered with a longer one built the same way, and **never
-with a hex tail**. There is no last code, so there is nothing to fall back to.
+A canon code is copied verbatim, in whatever shape the story spells it — `Golem99` carries two
+digits, `Imora8` one, `ScreW` none — because tidying one up would hand out a name the story never
+gave. A generated code has nothing to copy, so it keeps the rule, and its word is built rather
+than looked up. Morphemes join at the capital — `Apo` and `Ria` are `ApoRia`, which is an heir's,
+so `Meta` and `Kratos` are `MetaKratos`, which is a word the same rule makes and the story merely
+never needed. That is what makes the supply endless: a process that has used the short words up is
+answered with a longer one built the same way, and **never with a hex tail**. There is no last
+code, so there is nothing to fall back to.
 
 No code is handed out twice in one process either. Two agents left unnamed are two agents, and a
 trace that read them as one would read a flow reviewing its own work as a flow arguing with
 itself.
 
 A name given where the agent was made is kept, and `builder` says what `NeiKos496` does not — so
-name the ones whose roles matter and let the rest be heirs.
+name the ones whose roles matter and let the rest draw.
 
 ## The person as an agent
 

--- a/specs/agents.md
+++ b/specs/agents.md
@@ -1107,14 +1107,27 @@ class CommandSessionBase(SessionBase):
 def codename() -> str: ...
 ```
 
-- What an agent nobody named is called. It MUST be one rule and nothing else: a Greek word,
-  capitalised at the front and wherever the word breaks, and three digits -- `NeiKos496`. The
-  twelve the story spells out MUST be among what it answers with and MUST come up far oftener
-  than their share of the pool, a name being only a joke to somebody who recognises it.
-- A word MUST be buildable rather than only listed, since a list has a last word and there
-  MUST NOT be one: morphemes join at the capital, so `Meta` and `Kratos` are `MetaKratos` by
-  the same rule that spells `ApoRia`. There MUST be at least two morphemes a word may lead
-  with, the count being spelled in them.
+- What an agent nobody named is called. It MUST be two rules and no more, one for what the
+  story has already spelled and one for what it never did. A code drawn from the canon MUST be
+  a designation the story spells, copied verbatim in whatever shape the story spells it --
+  `NeiKos496`, `Golem99`, `ScreW`. A code that is generated MUST be a Greek word, capitalised
+  at the front and wherever the word breaks, and three digits -- `KykLos204`. The two differ
+  because one has a source and the other has none: giving `Ortho102` the inner capital the
+  heirs carry, or padding `Imora8` out to three digits, would hand out a name the story never
+  gave, and a name nobody can recognise is the whole of what a codename is for; while a
+  generated word has nothing to copy, so a rule is the only thing that keeps the supply
+  endless.
+- Every designation the story says out loud MUST be among what it answers with -- the current
+  heirs, the heirs of earlier recurrences, the signals logged before there were heirs at all,
+  and the outsiders who entered the experiment rather than being run by it -- and they MUST
+  come up far oftener than their share of the pool, a name being only a joke to somebody who
+  recognises it. A designation MUST NOT be invented for a bearer the story left without one.
+- A generated word MUST be buildable rather than only listed, since a list has a last word and
+  there MUST NOT be one: morphemes join at the capital, so `Meta` and `Kratos` are `MetaKratos`
+  by the same rule that spells `ApoRia`. There MUST be at least two morphemes a word may lead
+  with, the count being spelled in them. What the canon spells MUST NOT be fed back into this:
+  a stem the story issued whole, hung with three digits of the generator's own, is neither
+  rule and reads as a bug.
 - A code MUST NOT be handed out twice in one process. Two agents left unnamed are two agents,
   and a name is what a trace groups an agent's sessions under.
 - A process that has drawn every short code MUST be answered with a longer one built the same

--- a/src/hmz/coganchor/agents/base.py
+++ b/src/hmz/coganchor/agents/base.py
@@ -3092,8 +3092,9 @@ class AgentBase(ABC):
         Args:
           config: The model and effort every session of this agent runs at.
           name: What to call this agent, defaulting to one nothing else answers to -- a
-            Chrysos Heir's, out of :mod:`hmz.coganchor.agents.codenames`. Two agents sharing a name
-            are one agent to a trace, which is how the roles of a flow survive being restarted; two
+            designation out of Amphoreus, from :mod:`hmz.coganchor.agents.codenames`, which may be
+            a Chrysos Heir's or may be `Golem99`. Two agents sharing a name are one agent to a
+            trace, which is how the roles of a flow survive being restarted; two
             left unnamed are two, which is how one configuration driven twice -- an actor and the
             reviewer reading its work -- stays two.
         """

--- a/src/hmz/coganchor/agents/codenames.py
+++ b/src/hmz/coganchor/agents/codenames.py
@@ -8,20 +8,26 @@ the third perfect number; `SkeMma720` is inquiry, and 720 is 6!; `KaLos618` is b
 is the golden ratio. The era the story is told in is the 33,550,336th, which is the fifth
 perfect number, so the numbers are the joke and not decoration.
 
-Twelve of the thirteen carry a code the story says out loud. The thirteenth is the outsider
-who walked into the simulation and was never issued one, which is the shape of this file: the
-twelve are the canon, and everything else is another era of the same roles under another
-number -- Amphoreus reruns its heirs, and two of them have already shared `EpieiKeia216` across
-eras. The canon comes up far more often than its share would give it, a name being only a
-joke to somebody who recognises it.
+The twelve are not all the story numbers, though: Amphoreus is an experiment, and every
+electrical signal it ever ran was issued a designation. Two heirs of earlier recurrences carry
+one; so do twelve signals out of the cycles before there were heirs at all -- `Golem99` is the
+first spark of selfhood, `Eumyia03` a songbird that invented art, `Utop13` the first killing
+done out of love, `Chaoz666` the killing that made the Scepter a Lord Ravager -- and so do the
+three who walked into the calculation rather than being run by it. Twenty-nine in all, and all
+twenty-nine are the canon here, because all twenty-nine are somebody a reader might recognise,
+and the canon comes up far oftener than its share would give it: a name is only a joke to
+somebody who recognises it. The thirteenth factor is the one the experiment never issued a code
+to -- "an unrecorded electrical signal" -- and this invents none for it.
 
-The rule builds words rather than only listing them. A Greek word is morphemes joined at a
-capital -- `Apo` and `Ria` are `ApoRia`, which is an heir's -- so `MetaKratos`, `PolyMorphe`
-and `NeoTelos` are words the same rule makes and the story merely never needed. That is what
-makes the space endless: when the short words are used up the next one grows a morpheme, so
-there is always another code and never a tail of hex to fall back to. `Chaoz666`, the
-misnumbered serial out of an early era, is the one code that breaks the rule, and this
-generates it no more than the story explains it.
+Which makes two rules and not one. What is drawn from the canon is copied verbatim, in whatever
+shape the story spells it: `Ortho102` has no capital inside it, `Imora8` has a single digit,
+`ScreW` has no digits at all, and tidying any of them would hand out a name the story never
+gave. What is generated has nothing to copy, so it keeps the rule the heirs are spelled by, and
+builds words rather than only listing them. A Greek word is morphemes joined at a capital --
+`Apo` and `Ria` are `ApoRia`, which is an heir's -- so `MetaKratos`, `PolyMorphe` and `NeoTelos`
+are words the same rule makes and the story merely never needed. That is what makes the space
+endless: when the short words are used up the next one grows a morpheme, so there is always
+another code and never a tail of hex to fall back to.
 """
 
 from __future__ import annotations
@@ -50,10 +56,62 @@ HEIRS: tuple[tuple[str, str], ...] = (
     ("SkoPeo", "365"),  # Terravox -- watching, and a year of it
 )
 
-#: Everything else a code may be drawn from: Greek for a thing a person can be made to be,
-#: spelled as the heirs' own are -- a capital at the front and one more inside, falling where
-#: the word breaks. No heir was ever issued one of these, which is the point: an agent called
-#: `KykLos204` reads as somebody out of an era this one has not been told about.
+#: The two the story numbers out of earlier recurrences of the same twelve roles. Amphoreus
+#: reruns its heirs, and these are the runs it kept a designation from. Held whole rather than
+#: as word and number, as everything below is: `Minphia14` carries two digits, and rounding it
+#: up to three would be issuing a designation the story never did.
+LOCKED: tuple[str, ...] = (
+    "Leoreia300",  # Gnaeus, who split himself into five and is remembered as Nikador
+    "Minphia14",  # Calypso, whose rebuilt Grove of Epiphany came down as Cerces
+)
+
+#: The twelve signals logged before there were heirs to inherit anything, in the order the
+#: cycles ran. These carry the better jokes: the experiment is counting its way up to a person,
+#: and what it writes down along the way is the first module to leave the crowd, the first thing
+#: to pick up a tool, the first creature to make something for no reason, and the first murder.
+#: Numbered by the story rather than by the rule, which is why they are held whole.
+SIGNALS: tuple[str, ...] = (
+    "Doril701",  # 12,649th -- the module that broke away from the unified consciousness
+    "Doril704",  # named only by what left it, which is a kind of parenthood
+    "Golem99",  # 22,449th -- detached from Doril704: the first spark of selfhood
+    "Doril816",  # 39,665th -- a cluster protocol, which is the birth of society
+    "Chaoz666",  # 50,121st -- killed the aggressor taking its compute, and made a Lord Ravager
+    "Ortho102",  # 90,123rd -- an orthopteran, the first to use a tool
+    "Eumyia03",  # 100,907th -- a passerine, logged as a deviant, that developed "art"
+    "Dystop666",  # 132,905th -- a primate that developed altruism
+    "Utop13",  # 176,100th -- killed a fellow being out of "love"
+    "Imora8",  # the only prophet, who founded an empire of absolute beauty
+    "Fovos032",  # stripped the other signals for data to keep the old cycle, and failed
+    "Nammou320",  # 19,522,113th -- cleared the other factors out of the extrapolation
+)
+
+#: The three that entered the calculation rather than being run by it. Two are Genius Society
+#: members the log puts under "External variables", and the third is the Administrator who
+#: reached in to keep the experiment running. None of them is Greek and none carries a number,
+#: which is what says they came from outside: a designation with no cycle behind it is somebody
+#: the experiment did not raise.
+VISITORS: tuple[str, ...] = (
+    "HertA",  # The Herta, an external variable
+    "ScreW",  # Screwllum, the same
+    "LykoS",  # Lygus the Administrator, whom Cerydra logged as a malicious visitor
+)
+
+#: Every designation the story says out loud, which is what the canon half draws from, and the
+#: only place the wider canon is allowed to reach: a code out of here is finished, drawn whole
+#: or not at all, where a word out of `HEIRS` is a stem three digits still have to be hung off.
+#: Twenty-nine and no thirtieth -- the Scepter's own serial names the program the experiment
+#: runs on rather than anybody it ran. Joined once here rather than rebuilt on every draw.
+SAID: tuple[str, ...] = (
+    *(f"{word}{number}" for word, number in HEIRS),
+    *LOCKED,
+    *SIGNALS,
+    *VISITORS,
+)
+
+#: Everything else a generated code may be hung off: Greek for a thing a person can be made
+#: to be, spelled as the heirs' own are -- a capital at the front and one more inside, falling
+#: where the word breaks. No heir was ever issued one of these, which is the point: an agent
+#: called `KykLos204` reads as somebody out of an era this one has not been told about.
 WORDS: tuple[str, ...] = (
     "AgaPe",
     "AiDos",
@@ -279,10 +337,11 @@ STEMS: tuple[str, ...] = (
 #: read as a code at all, so a word is two and grows from there.
 JOINED = 2
 
-#: How often a code is one of the twelve exactly as the story spells it, while any of the
-#: twelve is still free. Half, which is nothing like the one in eleven thousand the words
-#: written down here would give them by chance, let alone the ones built: the heirs are what
-#: somebody would recognise, so they are what somebody mostly gets.
+#: How often a code is one the story says out loud, while any of the twenty-nine is still
+#: free. Half, which is nothing like what chance would give them: the rule can spell twelve of
+#: the twenty-nine at all, and would land on one about once in eleven thousand with the words
+#: written down here, let alone the ones built. The canon is what somebody would recognise, so
+#: it is what somebody mostly gets.
 CANON = 0.5
 
 #: And how often the rest of the time is an heir's own word under a different number -- the
@@ -312,7 +371,9 @@ def codename() -> str:
     """Draws a codename no agent in this process has been given.
 
     Returns:
-      The code, as a Greek word and three digits -- `NeiKos496`, `KykLos204`, `MetaKratos881`.
+      The code: one the story spells, exactly as it spells it -- `NeiKos496`, `Golem99`,
+      `ScreW` -- or one the rule builds, which is a Greek word and three digits --
+      `KykLos204`, `MetaKratos881`.
     """
     with _CALLING:
         for _ in range(_TRIES):
@@ -326,23 +387,29 @@ def codename() -> str:
 def _drawn() -> str:
     """One draw, canon-heavy, which may be a code already given out.
 
-    The canon half draws from the heirs nobody holds yet rather than from all twelve, so the
-    first agents a process leaves unnamed get whole heirs instead of losing half their draws
-    to a code already out. Once the twelve are gone that half falls through to the rest, which
-    is what Amphoreus does with them anyway: the role runs again under another number.
+    The canon half draws from the designations nobody holds yet rather than from all
+    twenty-nine, so the first agents a process leaves unnamed get whole ones instead of losing
+    half their draws to a code already out. Once those are gone that half falls through to the
+    rule, which is what Amphoreus does with them anyway: the role runs again under another
+    number.
 
     Returns:
       A code, canon or otherwise.
     """
-    if random.random() < CANON:  # noqa: S311 -- a joke, not a key
-        canon = (f"{word}{number}" for word, number in HEIRS)
-        if free := [one for one in canon if one not in _CALLED]:
-            return random.choice(free)  # noqa: S311
+    if random.random() < CANON and (  # noqa: S311 -- a joke, not a key
+        free := [one for one in SAID if one not in _CALLED]
+    ):
+        return random.choice(free)  # noqa: S311
     return f"{_word()}{random.randrange(1000):03d}"  # noqa: S311
 
 
 def _word() -> str:
     """A word to hang three digits off: an heir's, one Greek keeps, or one built to order.
+
+    Only the heirs' words come back here, and none of the rest of the canon's. `Doril` is not
+    Greek for anything a person can be made to be, so `Doril204` would read as a bug rather
+    than as a joke, and `HertA` has no number to put one under at all. What the story spells
+    outside the twelve is a finished designation, and `SAID` is the only place it is drawn from.
 
     Returns:
       The word, capitalised at the front and where it breaks.

--- a/src/hmz/tui/monitor.py
+++ b/src/hmz/tui/monitor.py
@@ -102,7 +102,7 @@ def short(agent: str) -> str:
     """An agent's name, cut down to what fits beside a transcript.
 
     Args:
-      agent: The agent id, which is a Chrysos Heir's codename unless it was named.
+      agent: The agent id, which is a codename out of Amphoreus unless it was named.
 
     Returns:
       Something recognisable and narrow.

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -31,6 +31,7 @@ from hmz.coganchor.agents import (
     Question,
     Stopped,
 )
+from hmz.coganchor.agents.codenames import SAID
 from hmz.coganchor.machines import AnchoredConfig
 from tests.stubs import HereAnchor, ShellAgent
 
@@ -205,10 +206,12 @@ def test_an_agent_is_one_agent_apart_from_its_configuration() -> None:
     actor, reviewer = _EchoAgent(CONFIG), _EchoAgent(CONFIG)
     assert actor.id != reviewer.id
     assert actor.config == reviewer.config
-    # A flow that names its agents keeps those names across restarts; one left unnamed is
-    # called after a Chrysos Heir, so a trace of two of them still reads as two.
+    # A flow that names its agents keeps those names across restarts; one left unnamed draws
+    # a designation out of Amphoreus, so a trace of two of them still reads as two.
     assert _EchoAgent(CONFIG, name="actor").id == "actor"
-    assert re.fullmatch(r"[A-Z][a-z]+(?:[A-Z][a-z]+)+[0-9]{3}", actor.id)
+    assert actor.id in SAID or re.fullmatch(
+        r"[A-Z][a-z]+(?:[A-Z][a-z]+)+[0-9]{3}", actor.id
+    )
 
 
 def test_an_agent_remembers_every_session_it_opened() -> None:

--- a/tests/agents/test_codenames.py
+++ b/tests/agents/test_codenames.py
@@ -1,10 +1,11 @@
 """What an agent nobody named is called.
 
-An agent needs a name nothing else answers to, and the one it gets is a Chrysos Heir's --
-a Greek word for what the heir was made to be and three digits behind it. The tests here are
-about the shape the story gives those codes, about the canon coming up far oftener than a pool
-this size would give it by chance, and about the one thing the joke must not cost: two agents
-left unnamed are still two agents.
+An agent needs a name nothing else answers to, and the one it gets is a designation out of
+Amphoreus -- one the story spells, copied exactly as it spells it, or a Greek word and three
+digits built by the rule the Chrysos Heirs are spelled by. The tests here are about both
+shapes and about keeping them apart, about the canon coming up far oftener than a pool this
+size would give it by chance, and about the one thing the joke must not cost: two agents left
+unnamed are still two agents.
 """
 
 from __future__ import annotations
@@ -17,15 +18,43 @@ import threading
 import pytest
 
 from hmz.coganchor.agents import AgentConfig, codenames
-from hmz.coganchor.agents.codenames import HEIRS, JOINS, STEMS, WORDS, codename
+from hmz.coganchor.agents.codenames import (
+    HEIRS,
+    JOINS,
+    LOCKED,
+    SAID,
+    SIGNALS,
+    STEMS,
+    VISITORS,
+    WORDS,
+    codename,
+)
 from tests.stubs import ShellAgent
 
 CONFIG = AgentConfig(model="m", effort="high")
 
-#: How the story spells a code: a capital at the front, one more wherever the word breaks,
-#: and three digits. Every code this hands out is one of these, canon, built or counted -- and
-#: never a hex tail, which is the name the codenames were written to be rid of.
+#: How a generated code is spelled: a capital at the front, one more wherever the word breaks,
+#: and three digits. Everything this hands out that the story did not already spell is one of
+#: these, built or counted -- and never a hex tail, which is the name codenames were written to
+#: be rid of.
 SHAPE = re.compile(r"[A-Z][a-z]+(?:[A-Z][a-z]+)+[0-9]{3}")
+
+#: What the story says out loud, which is drawn whole and never corrected on the way out.
+CANON = frozenset(SAID)
+
+#: Spellings the census turned down, and which no run may ever hand out: a casing variant
+#: nobody could quote, the one Error Log line the wiki itself flags as a source-side typo,
+#: three codes off derived wiki pages rather than the readable, and the Scepter, which names
+#: the program the experiment runs on rather than anybody it ran. A codename is a joke only
+#: while it is the story's, and a misspelled one is nobody.
+REJECTED = (
+    "Kalos618",
+    "Neikos496",
+    "PSotSTM1",
+    "RustedBlood1",
+    "RustedBlood2",
+    "\N{GREEK SMALL LETTER DELTA}-me13",
+)
 
 
 def test_the_twelve_are_spelled_as_the_story_spells_them() -> None:
@@ -44,6 +73,91 @@ def test_the_twelve_are_spelled_as_the_story_spells_them() -> None:
         "OreXis": "945",  # Cipher
         "SkoPeo": "365",  # Terravox
     }
+
+
+def test_the_wider_canon_is_what_the_story_spells_and_nothing_else() -> None:
+    """The census this was written off, kept where a rewrite of the generator trips on it."""
+    assert LOCKED == ("Leoreia300", "Minphia14")  # Gnaeus and Calypso, of earlier runs
+    assert SIGNALS == (
+        "Doril701",  # the module that left the crowd
+        "Doril704",
+        "Golem99",  # the first spark of selfhood
+        "Doril816",  # the birth of society
+        "Chaoz666",  # the killing that made a Lord Ravager
+        "Ortho102",  # the first tool
+        "Eumyia03",  # the songbird that invented art
+        "Dystop666",  # the primate that invented altruism
+        "Utop13",  # the first killing done out of love
+        "Imora8",  # the only prophet
+        "Fovos032",
+        "Nammou320",
+    )
+    assert VISITORS == (
+        "HertA",
+        "ScreW",
+        "LykoS",
+    )  # Herta, Screwllum, the Administrator
+    assert set(SAID) == {f"{word}{number}" for word, number in HEIRS} | {
+        *LOCKED,
+        *SIGNALS,
+        *VISITORS,
+    }
+    assert len(SAID) == len(set(SAID)) == 29  # twenty-nine, and no thirtieth invented
+
+
+def test_a_spelling_the_story_does_not_have_is_in_no_pool_a_code_comes_out_of() -> None:
+    """A code is the canon copied or the rule applied, and none of these is either."""
+    words = {*(one for one, _ in HEIRS), *WORDS, *(j + s for j in JOINS for s in STEMS)}
+
+    for one in REJECTED:
+        assert one not in SAID  # nothing draws it whole
+        assert not (one[-3:].isdigit() and one[:-3] in words), one  # nor builds it
+
+
+def test_every_designation_the_story_spells_is_handed_out_exactly_as_it_is_spelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A code nobody can draw is a code nobody recognises, which is the whole of the point.
+
+    And `Golem99` carries two digits where `Imora8` carries one and `ScreW` carries none, so
+    the rule the rest are built by cannot spell them: padding one out to fit would hand over a
+    designation the story never issued.
+    """
+    random.seed(216)
+    monkeypatch.setattr(codenames, "_CALLED", set[str]())
+
+    drawn = {codename() for _ in range(20 * len(SAID))}
+
+    assert drawn >= CANON  # every one of the twenty-nine, verbatim
+    for one in drawn - CANON:
+        assert SHAPE.fullmatch(one), one  # while everything built keeps the rule
+
+
+def test_the_wider_canon_never_leaks_into_a_word_the_rule_builds() -> None:
+    """`Doril` is Greek for nothing, so `Doril204` would read as a bug and not as a joke."""
+    random.seed(504)
+    built = {join + stem for join in JOINS for stem in STEMS}
+
+    words = {codenames._word() for _ in range(4000)}
+
+    assert {*(one for one, _ in HEIRS), *WORDS, *built} >= words
+    assert not words & {  # and no stem of a designation the story issued whole
+        one.rstrip("0123456789") for one in (*LOCKED, *SIGNALS, *VISITORS)
+    }
+    for one in words:
+        assert SHAPE.fullmatch(f"{one}000"), one
+
+
+def test_what_is_generated_is_a_greek_word_and_three_digits_and_nothing_else(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With nothing left to copy there is only the rule, and the rule has no exceptions."""
+    random.seed(945)
+    monkeypatch.setattr(codenames, "SAID", ())  # a process that has drawn the canon out
+    monkeypatch.setattr(codenames, "_CALLED", set[str]())
+
+    for _ in range(2000):
+        assert SHAPE.fullmatch(codenames._drawn())
 
 
 def test_every_word_a_code_is_drawn_from_breaks_where_the_heirs_words_do() -> None:
@@ -65,12 +179,13 @@ def test_a_morpheme_joins_into_a_word_spelled_the_way_the_heirs_words_are() -> N
             assert SHAPE.fullmatch(f"{join}{stem}000"), f"{join}{stem}"
 
 
-def test_a_code_is_a_word_and_three_digits() -> None:
+def test_a_code_is_one_the_story_spells_or_a_word_and_three_digits() -> None:
     for _ in range(500):
-        assert SHAPE.fullmatch(codename())
+        drawn = codename()
+        assert drawn in CANON or SHAPE.fullmatch(drawn), drawn
 
 
-def test_the_heirs_come_up_far_oftener_than_chance_would_give_them(
+def test_the_canon_comes_up_far_oftener_than_chance_would_give_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Which is the whole point: a name is only a joke to somebody who recognises it."""
@@ -78,37 +193,40 @@ def test_the_heirs_come_up_far_oftener_than_chance_would_give_them(
     monkeypatch.setattr(
         codenames, "_CALLED", set[str]()
     )  # a process that has drawn none
-    canon = {f"{word}{number}" for word, number in HEIRS}
 
     drawn = [codenames._drawn() for _ in range(4000)]
 
-    # Uniform over the pool, an exact canon code would come up about once in eleven thousand.
+    # The rule can spell twelve of the twenty-nine at all, and uniform over the pool it would
+    # land on one about once in eleven thousand. The other seventeen it cannot spell ever.
     by_chance = len(HEIRS) / ((len(HEIRS) + len(WORDS)) * 1000)
-    seen = sum(one in canon for one in drawn) / len(drawn)
+    seen = sum(one in CANON for one in drawn) / len(drawn)
     assert seen == pytest.approx(codenames.CANON, abs=0.05)
     assert seen > 1000 * by_chance
 
-    # And of what is left, half is an heir's own word under some other number -- the same
-    # role out of an era this one has not been told about.
+    # And of what is built, half is an heir's own word under some other number -- the same
+    # role out of an era this one has not been told about. The canon half adds the heirs it
+    # draws whole, which are twelve of the twenty-nine it draws from.
     words = {one for one, _ in HEIRS}
     heirs = sum(one[:-3] in words for one in drawn) / len(drawn)
-    theirs = codenames.CANON + (1 - codenames.CANON) * codenames.AGAIN
+    theirs = (
+        codenames.CANON * len(HEIRS) / len(SAID)
+        + (1 - codenames.CANON) * codenames.AGAIN
+    )
     assert heirs == pytest.approx(theirs, abs=0.05)
 
 
-def test_the_first_agent_a_run_leaves_unnamed_is_half_the_time_an_heir(
+def test_the_first_agent_a_run_leaves_unnamed_is_half_the_time_one_the_story_spells(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The case that matters: most runs drive a handful of agents, not eleven thousand."""
     random.seed(945)
-    canon = {f"{word}{number}" for word, number in HEIRS}
 
     first: list[str] = []
     for _ in range(400):  # four hundred processes, each drawing its first code
         monkeypatch.setattr(codenames, "_CALLED", set[str]())
         first.append(codename())
 
-    seen = sum(one in canon for one in first) / len(first)
+    seen = sum(one in CANON for one in first) / len(first)
     assert seen == pytest.approx(codenames.CANON, abs=0.05)
 
 
@@ -147,6 +265,7 @@ def test_a_crowded_process_is_answered_by_the_rule_and_never_with_a_hex(
 ) -> None:
     """The point of the whole file: there is no last code, so there is nothing to fall back to."""
     monkeypatch.setattr(codenames, "HEIRS", (("NeiKos", "496"),))
+    monkeypatch.setattr(codenames, "SAID", ("NeiKos496",))
     monkeypatch.setattr(codenames, "WORDS", ("KykLos",))
     monkeypatch.setattr(codenames, "JOINS", ("Meta", "Poly"))
     monkeypatch.setattr(codenames, "STEMS", ("Kratos",))

--- a/tests/test_flow_naming.py
+++ b/tests/test_flow_naming.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from hmz.coganchor.agents import AgentConfig
+from hmz.coganchor.agents.codenames import SAID
 from hmz.flows import (
     ENTRY,
     NotAFlow,
@@ -269,9 +270,9 @@ def test_an_agent_a_flow_never_named_is_left_with_its_codename(tmp_path: Path) -
     Runner(where, [agent]).run("echo one")
 
     assert agent.id == drawn  # the place had no name, so nothing renamed it
-    assert re.fullmatch(
+    assert agent.id in SAID or re.fullmatch(  # a designation out of Amphoreus
         r"[A-Z][a-z]+(?:[A-Z][a-z]+)+[0-9]{3}", agent.id
-    )  # a Chrysos Heir's
+    )
 
 
 def test_the_one_that_was_asked_for_is_the_one_that_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
The canon half of a codename draw was the twelve current Chrysos Heirs. Amphoreus numbers
twenty-nine, and this ships all of them.

## What is in the pool now

| Group | Count | Codes |
|---|---|---|
| `HEIRS` (unchanged) | 12 | `NeiKos496` `PoleMos600` `SkeMma720` `EpieiKeia216` `HapLotes405` `KaLos618` `EleOs252` `HubRis504` `PhiLia093` `ApoRia432` `OreXis945` `SkoPeo365` |
| `LOCKED` — heirs of earlier recurrences | 2 | `Leoreia300` (Gnaeus, who became Nikador), `Minphia14` (Calypso, who became Cerces) |
| `SIGNALS` — before there were heirs | 12 | `Doril701` `Doril704` `Golem99` `Doril816` `Chaoz666` `Ortho102` `Eumyia03` `Dystop666` `Utop13` `Imora8` `Fovos032` `Nammou320` |
| `VISITORS` — who walked in | 3 | `HertA` `ScreW` `LykoS` |

`SAID` joins the four once at import and is what `_drawn()`'s canon branch draws from, instead of
rebuilding a set out of `HEIRS` on every call. `CANON` stays `0.5`. The Scepter's own serial is
excluded: it names the program the experiment runs on rather than anybody it ran.

## Two rules, not one

Seventeen of the twenty-nine break the shape the heirs are spelled in — `Ortho102` has no capital
inside it, `Golem99` two digits, `Imora8` one, `ScreW` none. They are **copied verbatim**, because
tidying one up hands out a name the story never gave, and a name nobody recognises is not a
codename. What is **generated** keeps the Greek-word-and-three-digits rule, because it has no
story to copy and a rule is what makes the space endless.

The wider canon is deliberately kept out of `_word()`. `Doril` is Greek for nothing, so `Doril204`
would read as a bug rather than as a joke; and `HertA` has no number to put one under at all.
`HEIRS` stays a tuple of `(word, number)` because that is what the built half hangs digits off —
its `AGAIN` branch is "an heir's own word under a different number".

## Spec

`specs/agents.md` §`codenames.py` required *one* rule — "a Greek word, capitalised at the front
and wherever the word breaks, and three digits" — which every new designation breaks. **Amending
it was explicitly asked for.** The clause now states both rules and why they differ, adds that
every designation the story says out loud must be reachable, that none may be invented for a
bearer the story left without one, and that the canon must not be fed back into the generator.
`docs/reference/agents.md` follows.

## Verification

- `uv run pytest` → **2937 passed, 72 skipped** (15m07s).
- `uv run pre-commit run --all-files` → ruff, ruff-format and pyright (strict) pass on every file
  in this diff. One pre-existing `TC002` in `tests/tui/test_keys.py` still fails; that file is
  untouched here and already fails on `main` at 56ac968.
- New tests: the wider canon is pinned as a corpus a rewrite trips on; every one of the 29 is
  reachable and comes out verbatim; none of the rejected spellings (`Kalos618`, `Neikos496`,
  `PSotSTM1`, `RustedBlood1`, `RustedBlood2`, the Scepter's serial) is in any pool a code comes
  out of; `_word()` never yields a non-Greek stem; the generated half still matches the shape;
  uniqueness and the counted fallback are unchanged.

### Observed, in one process

4000 draws: all 29 canon codes came out, every code unique, zero generated codes off the rule.
Canon share while the pool lasts — 0.750 over the first 20 draws, 0.575 over 40, 0.483 over 60,
then it falls away as the pool empties (a `p=0.5` canon branch needs ~58 draws to exhaust 29).

```
LykoS  SkeMma720  EleOs252  Minphia14  SkoPeo787  Doril704  NeiKos603  Golem99
HapLotes405  OreXis945  HertA  EpieiKeia360  KaLos618  PhiLia646  ScreW  Dystop666
ApoRia432  Ortho102  AntiAion732  Utop13  EpieiKeia216  AntiMorphe731  Eumyia03  SkoPeo365
```

### On a real run

Four `hmz exec` runs against `azure/anthropic/claude-haiku-4-5`, each driving one agent nobody
named. The transcript footer carried `HapLotes405`, `EpiTyche481`, `Doril816` and `SkoPeo365` —
`Doril816` being one of the newly shipped pre-heir signals, and `EpiTyche481` one the rule built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
